### PR TITLE
Remove "make install" and codify how to install es-ds from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-.PHONY: install
-install:
-	npx lerna exec -- npm install
-	npx lerna bootstrap
-	npm --prefix es-vue-base run build
-
 .PHONY: dev
 dev:
 	overmind s
@@ -23,3 +17,17 @@ publish:
 .PHONY: update
 update:
 	npx lerna bootstrap
+
+# Bootstraping Commands (not reguarly called)
+
+.PHONY: build-scss-pkg
+build-scss-pkg:
+	npm --prefix es-bs-base build
+
+.PHONY: update-peer-deps
+update-peer-deps:
+	npm --prefix es-vue-base install bootstrap-vue@^2.22.0 \
+		html-truncate@^1.2.2 \
+		vue@^2.7.8 \
+		vue-slider-component@^3.2.18 \
+		vuelidate@^0.7.7

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ origin  git@github.com:EnergySage/es-ds.git (fetch)
 origin  git@github.com:EnergySage/es-ds.git (push)
 ```
 
-Next you should run `make install`. This will kick-off installing requirements for the repo.
+### Installing Dependencies and Linking packages
+
+1. `make update` (this will run `npm install` on each package within the monorepo)
+2. `make update-peer-deps` (will update peer dependencies)
+3. `make build-scss-pkg` (will build *es-bs-base*, which must happen before building *es-vue-base* because there's lines like `@import '~@energysage/es-bs-base/scss/includes';` in *es-vue-base* that will not compile without having the *es-bs-base* package built first)
+4. `make update` (will relink packages)
+5. `make build` (will build all packages)
 
 #### Vue Component Process
 
@@ -78,7 +84,7 @@ Once tests are passing, you'll need to rebuild the _es-vue-base_ package. This c
 
 Next you'll want to move back to the root of the monorepo, and run `make update`. This will ensure the new package is _sym-linked_ to the other projects in the monorepo.
 
-### Documenting the change
+### Documenting change
 
 Once your changes have been made, you'll want to ensure they're documented somewhere in `es-design-system`. If the change is a new component, it's expected you'll create a new page to display the component.
 

--- a/es-design-system/package-lock.json
+++ b/es-design-system/package-lock.json
@@ -1157,16 +1157,6 @@
             "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
             "dev": true
         },
-        "@energysage/es-bs-base": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@energysage/es-bs-base/-/es-bs-base-0.5.1.tgz",
-            "integrity": "sha512-gfYVAqymTqzcYq1NSI22WBhq13thS8Ao/p9wGGk7POHNqGd4OfR+ErWmOLFG7A3eDWx1PRAdcBU2ADhPESZOCg=="
-        },
-        "@energysage/es-vue-base": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-0.5.1.tgz",
-            "integrity": "sha512-Lv7BSj86mAvU1bshps35XesEsLM4Fn5OvPLsLL9+5duYE2DVvBPQ+YL+ouiy4qPVpyv0sLXlLL2jL7acLrQvuQ=="
-        },
         "@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",

--- a/es-vue-base/README.md
+++ b/es-vue-base/README.md
@@ -6,6 +6,16 @@ Initial layout was set-up following <https://github.com/team-innovation/vue-sfc-
 
 - `es-bs-base` is a peer-dependency for CSS styling
 
+### Peer Dependencies
+
+```bash
+npm install bootstrap-vue@^2.22.0
+html-truncate@^1.2.2
+vue@^2.7.8
+vue-slider-component@^3.2.18
+vuelidate@^0.7.7
+```
+
 ## Contributing
 
 See [root README.md](../README.md#contributing)

--- a/es-vue-base/README.md
+++ b/es-vue-base/README.md
@@ -8,13 +8,17 @@ Initial layout was set-up following <https://github.com/team-innovation/vue-sfc-
 
 ### Peer Dependencies
 
-```bash
-npm install bootstrap-vue@^2.22.0
-html-truncate@^1.2.2
-vue@^2.7.8
-vue-slider-component@^3.2.18
-vuelidate@^0.7.7
-```
+`es-vue-base` requires the following peer-dependencies:
+
+- `vue`
+- `bootstrap-vue`
+- `html-truncate`
+- `vue-slider-component`
+- `vuelidate`
+
+These dependencies can be installed at the root of this repo via `make update-peer-deps`
+
+**NOTE** (1) When adding peer dependencies please update the list above, and update the `update-peer-deps` command in the root *Makefile*. (2) When updating a peer dependency please update the version in the `update-peer-deps` command in the root *Makefile*
 
 ## Contributing
 

--- a/es-vue-base/package-lock.json
+++ b/es-vue-base/package-lock.json
@@ -1223,12 +1223,6 @@
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
       "dev": true
     },
-    "@energysage/es-bs-base": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@energysage/es-bs-base/-/es-bs-base-0.5.1.tgz",
-      "integrity": "sha512-gfYVAqymTqzcYq1NSI22WBhq13thS8Ao/p9wGGk7POHNqGd4OfR+ErWmOLFG7A3eDWx1PRAdcBU2ADhPESZOCg==",
-      "dev": true
-    },
     "@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -3540,16 +3534,6 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "autoprefixer": {
           "version": "9.8.8",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -3564,41 +3548,6 @@
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
           }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
         },
         "picocolors": {
           "version": "0.2.1",
@@ -3629,28 +3578,6 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.8.3",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         }
       }
@@ -20490,6 +20417,75 @@
         }
       }
     },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.8.3",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "vue-property-decorator": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
@@ -20506,9 +20502,9 @@
       "dev": true
     },
     "vue-slider-component": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.18.tgz",
-      "integrity": "sha512-s5KAYR1PHrXYQkCSb0KeUJdBP59SAMfe0El8qb2R7FD66sZptri9ACpq2PrZqQ2j8OD3x+yyU/cPROHDoRRPYA==",
+      "version": "3.2.20",
+      "resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.20.tgz",
+      "integrity": "sha512-S5+4d6zdL+/ClpDQoIgImIdXRv2b+75PIy3cDGsZsakhroJD6cSFA0juY/AblGqhvIkNcBIU354eOw6T26DWbA==",
       "dev": true,
       "requires": {
         "core-js": "^3.6.5",

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -74,7 +74,7 @@
     "stylelint": "^14.9.1",
     "vue": "^2.7.8",
     "vue-jest": "^3.0.7",
-    "vue-slider-component": "^3.2.18",
+    "vue-slider-component": "^3.2.20",
     "vue-template-compiler": "^2.6.14",
     "vuelidate": "^0.7.7"
   },

--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
     "env-cmd": "^10.1.0",
     "lerna": "^5.0.0",
     "nodemon": "^2.0.19"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## Issue

- Running `npm --prefix es-vue-base run build` without building `es-bs-base` first causes an error.
- `es-vue-base` references the `es-bs-base` package via a node_modules alias (`~`), so `es-bs-base` must be built prior to building `es-vue-base`.
- Building also fails in `es-vue-base` if peer dependencies are not installed prior as well.

## Changes

- Added `build-scss-pkg` and `update-peer-deps` *Makefile* commands
- Removed *make install*
- Added documentation in around initial `es-ds` set-up in a section called "Installing Dependencies and Linking packages"
