### PR TITLE
Add additional input types to the form-input component

### DIFF
--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -78,7 +78,13 @@ export default {
         type: {
             type: String,
             default: 'text',
-            validator: (val) => ['text', 'number'].includes(val),
+            validator: (val) => [
+                'text',
+                'number',
+                'email',
+                'number',
+                'password',
+            ].includes(val),
         },
         /**
          * ID


### PR DESCRIPTION
Was getting:

```
[Vue warn]: Invalid prop: custom validator check failed for prop "type".
```

When adding the form-input to the login vertical. Login form requires `input[type=password]` and `input[type=email]`

## Changes
<!-- Describe your work in detail. -->

- Add `email`, `number`, `password`

