### PR TITLE
ESDS-69 Popover Color Schemes

### DIFF
--- a/es-design-system/pages/molecules/es-popover.vue
+++ b/es-design-system/pages/molecules/es-popover.vue
@@ -1,54 +1,122 @@
 <template>
     <div>
-        <div>
-            <!-- eslint-disable vuejs-accessibility/label-has-for -->
-            <label>
-                With Title
-                <es-button
-                    id="titleTarget"
-                    class="p-0 text-gray-700 align-text-bottom"
-                    tabindex="0"
-                    variant="link">
-                    <IconInfo
-                        width="16px"
-                        height="16px" />
-                </es-button>
-            </label>
-            <EsPopover target="titleTarget">
-                <template #title>
-                    My Title
-                </template>
-                <p class="mb-0">
-                    Install solar panels through this program and get $250 cash back.
-                    <a
-                        class="mt-2 d-block"
-                        href="https://communitysolar.energysage.com/"
-                        target="_blank">Learn more.</a>
-                </p>
-            </EsPopover>
+        <div class="mb-3">
+            <h2>
+                Dark Variant
+            </h2>
+            <div>
+                <!-- eslint-disable vuejs-accessibility/label-has-for -->
+                <label>
+                    With Title
+                    <es-button
+                        id="darkTitleTarget"
+                        class="p-0 text-gray-700 align-text-bottom"
+                        tabindex="0"
+                        variant="link">
+                        <IconInfo
+                            width="16px"
+                            height="16px" />
+                    </es-button>
+                </label>
+                <EsPopover
+                    target="darkTitleTarget"
+                    variant="dark">
+                    <template #title>
+                        My Title
+                    </template>
+                    <p class="mb-0">
+                        Install solar panels through this program and get $250 cash back.
+                        <a
+                            class="mt-2 d-block"
+                            href="https://communitysolar.energysage.com/"
+                            target="_blank">Learn More</a>
+                    </p>
+                </EsPopover>
+            </div>
+            <div>
+                <label>
+                    No Title
+                    <es-button
+                        id="darkNoTitleTarget"
+                        class="p-0 text-gray-700 align-text-bottom"
+                        tabindex="0"
+                        variant="link">
+                        <IconInfo
+                            width="16px"
+                            height="16px" />
+                    </es-button>
+                </label>
+                <EsPopover
+                    target="darkNoTitleTarget"
+                    variant="dark">
+                    <p class="mb-0">
+                        Install solar panels through this program and get $250 cash back.
+                        <a
+                            class="mt-2 d-block"
+                            href="https://communitysolar.energysage.com/"
+                            target="_blank">Learn More</a>
+                    </p>
+                </EsPopover>
+            </div>
         </div>
         <div>
-            <label>
-                No Title
-                <es-button
-                    id="noTitleTarget"
-                    class="p-0 text-gray-700 align-text-bottom"
-                    tabindex="0"
-                    variant="link">
-                    <IconInfo
-                        width="16px"
-                        height="16px" />
-                </es-button>
-            </label>
-            <EsPopover target="noTitleTarget">
-                <p class="mb-0">
-                    Install solar panels through this program and get $250 cash back.
-                    <a
-                        class="mt-2 d-block"
-                        href="https://communitysolar.energysage.com/"
-                        target="_blank">Learn more.</a>
-                </p>
-            </EsPopover>
+            <h2>
+                Light Variant
+            </h2>
+            <div>
+                <!-- eslint-disable vuejs-accessibility/label-has-for -->
+                <label>
+                    With Title
+                    <es-button
+                        id="lightTitleTarget"
+                        class="p-0 text-gray-700 align-text-bottom"
+                        tabindex="0"
+                        variant="link">
+                        <IconInfo
+                            width="16px"
+                            height="16px" />
+                    </es-button>
+                </label>
+                <EsPopover
+                    target="lightTitleTarget"
+                    variant="light">
+                    <template #title>
+                        My Title
+                    </template>
+                    <p class="mb-0">
+                        Install solar panels through this program and get $250 cash back.
+                        <a
+                            class="mt-2 d-block"
+                            href="https://communitysolar.energysage.com/"
+                            target="_blank">Learn More</a>
+                    </p>
+                </EsPopover>
+            </div>
+            <div>
+                <label>
+                    No Title
+                    <es-button
+                        id="lightNoTitleTarget"
+                        class="p-0 text-gray-700 align-text-bottom"
+                        tabindex="0"
+                        variant="link">
+                        <IconInfo
+                            width="16px"
+                            height="16px" />
+                    </es-button>
+                </label>
+                <EsPopover
+                    target="lightNoTitleTarget"
+                    variant="light">
+                    <p class="mb-0">
+                        Install solar panels through this program and get $250 cash back.
+                        <a
+                            class="mt-2 d-block"
+                            href="https://communitysolar.energysage.com/"
+                            target="_blank">Learn More</a>
+                    </p>
+                </EsPopover>
+            </div>
         </div>
     </div>
 </template>

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -4,7 +4,8 @@
         :show="show"
         :target="target"
         :placement="placement"
-        :triggers="triggers">
+        :triggers="triggers"
+        :custom-class="customClass">
         <template
             v-if="hasTitle"
             #title>
@@ -15,7 +16,7 @@
             <slot name="title" />
             <EsButton
                 variant="link"
-                class="p-0 text-white float-right"
+                class="p-0 float-right"
                 @click="onClose">
                 <XIcon
                     height="20px"
@@ -32,7 +33,7 @@
                 <div v-if="!hasTitle">
                     <EsButton
                         variant="link"
-                        class="p-0 text-white"
+                        class="p-0 float-right"
                         @click="onClose">
                         <XIcon
                             height="20px"
@@ -72,7 +73,7 @@ export default {
         triggers: {
             type: [String, Object],
             required: false,
-            default: 'focus',
+            default: 'click',
         },
         /**
          * Placement
@@ -94,6 +95,15 @@ export default {
             required: false,
             default: false,
         },
+        /**
+         * Variant
+         */
+        customClass: {
+            type: String,
+            required: false,
+            default: 'es-popover-light',
+            validator: (val) => ['es-popover-light', 'es-popover-dark'].includes(val),
+        },
     },
     computed: {
         hasTitle() {
@@ -107,3 +117,90 @@ export default {
     },
 };
 </script>
+
+<style lang="scss">
+@import '~@energysage/es-bs-base/scss/includes';
+
+.es-popover-light {
+    &.popover {
+        background-color: $white !important;
+        border: 1px solid !important;
+        border-color: $primary;
+    }
+    .arrow::after {
+        border-bottom-color: $white !important;
+    }
+    .popover-header {
+        color: $black;
+        background-color: $white;
+        border-bottom-color: $white;
+        &::before {
+            border-bottom-color: $white;
+        }
+        .btn, .btn:hover, .btn:active {
+            color: $black;
+        }
+    }
+    .popover-body {
+        // background-color: white;
+
+        color: $black;
+        .btn, .btn:hover, .btn:active {
+            color: $black;
+        }
+    }
+}
+
+    // .bs-popover-top {
+    //     > .arrow {
+    //         &::before {
+    //             border-top-color: $pink;
+    //         }
+    //         &::after {
+    //             border-top-color: $pink;
+    //         }
+    //     }
+    // }
+    // .bs-popover-left {
+    //     > .arrow {
+    //         &::before {
+    //             border-left-color: $pink;
+    //         }
+    //         &::after {
+    //             border-left-color: $pink;
+    //         }
+    //     }
+    // }
+    // .bs-popover-right {
+    //     > .arrow {
+    //         &::before {
+    //             border-right-color: $pink;
+    //         }
+    //         &::after {
+    //             border-right-color: $pink;
+    //         }
+    //     }
+    // }
+.es-popover-dark {
+    &.popover {
+        background-color: $gray-900 !important;
+    }
+    .popover-header {
+        color: $white;
+        background-color: $gray-900;
+        border-bottom-color: $gray-900;
+        &::before {
+            border-bottom-color: $gray-900;
+        }
+        .btn, .btn:hover, .btn:active {
+            color: $white;
+        }
+    }
+    .popover-body {
+        color: $white;
+        .btn, .btn:hover, .btn:active {
+            color: $white;
+        }
+    }
+}
+</style>

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -84,7 +84,7 @@ export default {
             required: false,
             // eslint-disable-next-line max-len
             validator: (val) => ['auto', 'top', 'bottom', 'right', 'left', 'topleft', 'topright', 'bottomleft', 'bottomright', 'lefttop', 'leftbottom', 'righttop', 'rightbottom'].includes(val),
-            default: 'auto',
+            default: 'topleft',
         },
         /**
          * Show
@@ -123,12 +123,53 @@ export default {
 
 .es-popover-light {
     &.popover {
-        background-color: $white !important;
-        border: 1px solid !important;
-        border-color: $primary;
+        background-color: $white;
+        border: 1px solid $primary;
     }
-    .arrow::after {
-        border-bottom-color: $white !important;
+    // styling for all arrow backgrounds
+    &.bs-popover-bottom, &.bs-popover-auto[x-placement^=bottom] {
+        > .arrow {
+            &::before {
+                border-bottom-color: $primary;
+            }
+            &::after {
+                top: 1px;
+                border-bottom-color: $white;
+            }
+        }
+    }
+    &.bs-popover-top, &.bs-popover-auto[x-placement^=top] {
+        > .arrow {
+            &::before {
+                border-top-color: $primary;
+            }
+            &::after {
+                bottom: 1px;
+                border-top-color: $white;
+            }
+        }
+    }
+    &.bs-popover-right, &.bs-popover-auto[x-placement^=right] {
+        > .arrow {
+            &::before {
+                border-right-color: $primary;
+            }
+            &::after {
+                left: 1px;
+                border-right-color: $white;
+            }
+        }
+    }
+    &.bs-popover-left, &.bs-popover-auto[x-placement^=left] {
+        > .arrow {
+            &::before {
+                border-left-color: $primary;
+            }
+            &::after {
+                right: 1px;
+                border-left-color: $white;
+            }
+        }
     }
     .popover-header {
         color: $black;
@@ -142,8 +183,6 @@ export default {
         }
     }
     .popover-body {
-        // background-color: white;
-
         color: $black;
         .btn, .btn:hover, .btn:active {
             color: $black;
@@ -151,40 +190,11 @@ export default {
     }
 }
 
-    // .bs-popover-top {
-    //     > .arrow {
-    //         &::before {
-    //             border-top-color: $pink;
-    //         }
-    //         &::after {
-    //             border-top-color: $pink;
-    //         }
-    //     }
-    // }
-    // .bs-popover-left {
-    //     > .arrow {
-    //         &::before {
-    //             border-left-color: $pink;
-    //         }
-    //         &::after {
-    //             border-left-color: $pink;
-    //         }
-    //     }
-    // }
-    // .bs-popover-right {
-    //     > .arrow {
-    //         &::before {
-    //             border-right-color: $pink;
-    //         }
-    //         &::after {
-    //             border-right-color: $pink;
-    //         }
-    //     }
-    // }
 .es-popover-dark {
     &.popover {
         background-color: $gray-900 !important;
     }
+    // styling for all arrow backgrounds will need to be added if $popover-bg is changed from $gray-900
     .popover-header {
         color: $white;
         background-color: $gray-900;

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -5,7 +5,7 @@
         :target="target"
         :placement="placement"
         :triggers="triggers"
-        :custom-class="customClass">
+        :custom-class="`es-popover-${variant}`">
         <template
             v-if="hasTitle"
             #title>
@@ -98,11 +98,11 @@ export default {
         /**
          * Variant
          */
-        customClass: {
+        variant: {
             type: String,
             required: false,
-            default: 'es-popover-dark',
-            validator: (val) => ['es-popover-light', 'es-popover-dark'].includes(val),
+            default: 'dark',
+            validator: (val) => ['light', 'dark'].includes(val),
         },
     },
     computed: {
@@ -201,12 +201,10 @@ export default {
         .btn, .btn:hover, .btn:active {
             color: $white;
         }
-    }
-}
-.popover-content-wrapper {
-    a {
-        color: #e0eff5;
+        a {
+        color: #99CBDF;
         font-weight: $font-weight-bold;
+    }
     }
 }
 </style>

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -73,7 +73,7 @@ export default {
         triggers: {
             type: [String, Object],
             required: false,
-            default: 'click',
+            default: 'focus',
         },
         /**
          * Placement

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -101,7 +101,7 @@ export default {
         customClass: {
             type: String,
             required: false,
-            default: 'es-popover-light',
+            default: 'es-popover-dark',
             validator: (val) => ['es-popover-light', 'es-popover-dark'].includes(val),
         },
     },
@@ -191,23 +191,13 @@ export default {
 }
 
 .es-popover-dark {
-    &.popover {
-        background-color: $gray-900 !important;
-    }
-    // styling for all arrow backgrounds will need to be added if $popover-bg is changed from $gray-900
+    // styling for this color scheme will need to be added as default values for popovers are updated
     .popover-header {
-        color: $white;
-        background-color: $gray-900;
-        border-bottom-color: $gray-900;
-        &::before {
-            border-bottom-color: $gray-900;
-        }
         .btn, .btn:hover, .btn:active {
             color: $white;
         }
     }
     .popover-body {
-        color: $white;
         .btn, .btn:hover, .btn:active {
             color: $white;
         }

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -33,7 +33,7 @@
                 <div v-if="!hasTitle">
                     <EsButton
                         variant="link"
-                        class="p-0 float-right"
+                        class="p-0"
                         @click="onClose">
                         <XIcon
                             height="20px"
@@ -84,7 +84,7 @@ export default {
             required: false,
             // eslint-disable-next-line max-len
             validator: (val) => ['auto', 'top', 'bottom', 'right', 'left', 'topleft', 'topright', 'bottomleft', 'bottomright', 'lefttop', 'leftbottom', 'righttop', 'rightbottom'].includes(val),
-            default: 'topleft',
+            default: 'auto',
         },
         /**
          * Show

--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -28,7 +28,7 @@
         @binding {string} text or html of the popover content
         -->
         <template #default>
-            <div class="d-flex popover-content-wrapper">
+            <div class="d-flex">
                 <slot />
                 <div v-if="!hasTitle">
                     <EsButton

--- a/es-vue-base/tests/EsPopover.spec.js
+++ b/es-vue-base/tests/EsPopover.spec.js
@@ -13,7 +13,7 @@ const App = {
         'triggers',
         'show',
         'target',
-        'customClass',
+        'variant',
         'titleAttr',
         'btnDisabled',
     ],
@@ -41,7 +41,7 @@ const App = {
                         target: 'triggerButton',
                         triggers: this.triggers,
                         show: this.show,
-                        customClass: this.customClass,
+                        variant: this.variant,
                     },
                 },
                 [h('template', { slot: 'title' }, this.$slots.title), this.$slots.default || ''],
@@ -93,7 +93,7 @@ describe('EsPopover', () => {
             attachTo: document.body,
             propsData: {
                 triggers: 'click',
-                customClass: 'es-popover-light',
+                variant: 'light',
             },
             slots: {
                 title: 'title',
@@ -121,9 +121,9 @@ describe('EsPopover', () => {
         expect($popover.selector.props.show.default).toBe(false);
         expect($popover.selector.props.placement.default).toBe('auto');
         expect($popover.selector.props.triggers.default).toBe('focus');
-        expect($popover.selector.props.customClass.default).toBe('es-popover-dark');
+        expect($popover.selector.props.variant.default).toBe('dark');
         expect($popover.props().target).toBe('triggerButton');
-        expect($popover.props().customClass).toBe('es-popover-light');
+        expect($popover.props().variant).toBe('light');
 
         // Close button on popover
         const $closeButton = $popover.findComponent(EsButton);

--- a/es-vue-base/tests/EsPopover.spec.js
+++ b/es-vue-base/tests/EsPopover.spec.js
@@ -13,6 +13,7 @@ const App = {
         'triggers',
         'show',
         'target',
+        'customClass',
         'titleAttr',
         'btnDisabled',
     ],
@@ -40,6 +41,7 @@ const App = {
                         target: 'triggerButton',
                         triggers: this.triggers,
                         show: this.show,
+                        customClass: this.customClass,
                     },
                 },
                 [h('template', { slot: 'title' }, this.$slots.title), this.$slots.default || ''],
@@ -91,6 +93,7 @@ describe('EsPopover', () => {
             attachTo: document.body,
             propsData: {
                 triggers: 'click',
+                customClass: 'es-popover-light',
             },
             slots: {
                 title: 'title',
@@ -118,7 +121,9 @@ describe('EsPopover', () => {
         expect($popover.selector.props.show.default).toBe(false);
         expect($popover.selector.props.placement.default).toBe('auto');
         expect($popover.selector.props.triggers.default).toBe('focus');
+        expect($popover.selector.props.customClass.default).toBe('es-popover-dark');
         expect($popover.props().target).toBe('triggerButton');
+        expect($popover.props().customClass).toBe('es-popover-light');
 
         // Close button on popover
         const $closeButton = $popover.findComponent(EsButton);


### PR DESCRIPTION
<!-- Add a title with the Jira ticket and purpose, e.g. "ESDS-123 Awesome new feature". -->
ESDS-69 Popover Color Schemes
<!-- Uncomment this if it's relevant. -->
<!-- **TIME SENSITIVE.** Deploy by: -->

# Related Jira Tickets
<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/ESDS-123) and any other related tickets. -->

- https://energysage.atlassian.net/browse/ESDS-69

## Changes
<!-- Describe your work in detail. -->

- Added `customClass` prop to `EsPopover`
- Created custom classes for each color scheme (`es-popover-light` and `es-popover-dark`)

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->

- Visual

## Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- The design for the "light" popover in Figma had a gradient as the border color. From what I've read, it's not possible to set a gradient for anything other than `background` in css. I've used `$primary` instead for now. Is there a workaround to use the gradient, or should I ask for approval of a solid color from design?

### How to run locally
<!-- Include any instructions and/or links to docs to help reviewers see your work in their dev environments. -->

- Change the default value of `customClass` in `EsPopover` to view the different color schemes. 
- Change the default value of `placement` to make sure there are no regressions with the arrow/arrow border

## Remaining TODOs
<!-- Is there additional work to be done prior to merge/deployment, or in a subsequent PR? -->

- [x] Add tests for the new prop `EsPopover.spec.js` after ESDS-53 changes are merged in
