### PR TITLE
ESDS-79 used new font-weight-semibold class for EsFormInput/Textarea

### DIFF
--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -362,6 +362,7 @@ $font-weight-lightest:        lighter;
 $font-weight-lighter:         200 !default;
 $font-weight-light:           300 !default;
 $font-weight-normal:          400 !default;
+$font-weight-semibold:        500 !default;
 $font-weight-bold:            600 !default;
 $font-weight-bolder:          800 !default;
 // fusv-disable

--- a/es-bs-base/scss/utilities/_text.scss
+++ b/es-bs-base/scss/utilities/_text.scss
@@ -33,12 +33,13 @@
 
 // Weight and italics
 
-.font-weight-light   { font-weight: $font-weight-light !important; }
-.font-weight-lighter { font-weight: $font-weight-lighter !important; }
-.font-weight-normal  { font-weight: $font-weight-normal !important; }
-.font-weight-bold    { font-weight: $font-weight-bold !important; }
-.font-weight-bolder  { font-weight: $font-weight-bolder !important; }
-.font-italic         { font-style: italic !important; }
+.font-weight-light    { font-weight: $font-weight-light !important; }
+.font-weight-lighter  { font-weight: $font-weight-lighter !important; }
+.font-weight-normal   { font-weight: $font-weight-normal !important; }
+.font-weight-semibold { font-weight: $font-weight-semibold !important; }
+.font-weight-bold     { font-weight: $font-weight-bold !important; }
+.font-weight-bolder   { font-weight: $font-weight-bolder !important; }
+.font-italic          { font-style: italic !important; }
 
 // Contextual colors
 

--- a/es-design-system/nuxt.config.js
+++ b/es-design-system/nuxt.config.js
@@ -13,7 +13,7 @@ export default {
         link: [
             {
                 rel: 'stylesheet',
-                href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800;900&display=swap',
+                href: 'https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;800;900&display=swap',
             },
         ],
     },

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -54,11 +54,61 @@
                 </b-link>
             </li>
         </ul>
+        <b-row class="my-5 border-top pt-5">
+            <b-col>
+                <h2>
+                    Font Weight Utility Classes
+                </h2>
+                <b-table
+                    :fields="fontWeightFields"
+                    :items="fontWeightItems"
+                    striped>
+                    <template #cell(example)="data">
+                        <span :class="data.item.name">sample text at {{ data.item.weight }} weight</span>
+                    </template>
+                </b-table>
+            </b-col>
+        </b-row>
     </div>
 </template>
 
 <script>
 export default {
     name: 'AtomsTypography',
+    data() {
+        return {
+            fontWeightFields: [
+                'name',
+                // virtual column that can reference two fields
+                { key: 'example', label: 'Example' },
+            ],
+            fontWeightItems: [
+                {
+                    name: 'font-weight-lighter',
+                    weight: '200',
+                },
+                {
+                    name: 'font-weight-light',
+                    weight: '300',
+                },
+                {
+                    name: 'font-weight-normal',
+                    weight: '400',
+                },
+                {
+                    name: 'font-weight-semibold',
+                    weight: '500',
+                },
+                {
+                    name: 'font-weight-bold',
+                    weight: '600',
+                },
+                {
+                    name: 'font-weight-bolder',
+                    weight: '800',
+                },
+            ],
+        };
+    },
 };
 </script>

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -5,7 +5,7 @@
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
             :for="id"
-            class="label font-weight-bold justify-content-start">
+            class="label font-weight-semibold justify-content-start">
             <slot name="label" />
             <span
                 v-if="required"

--- a/es-vue-base/src/lib-components/EsFormTextarea.vue
+++ b/es-vue-base/src/lib-components/EsFormTextarea.vue
@@ -5,7 +5,7 @@
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
             :for="id"
-            class="label font-weight-bold justify-content-start">
+            class="label font-weight-semibold justify-content-start">
             <slot name="label" />
 
             <span

--- a/es-vue-base/tests/__snapshots__/EsFormTextarea.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsFormTextarea.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsFormTextarea <EsFormTextarea /> 1`] = `
-"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start">Notes
+"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Notes
     <!----></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
     <!---->
@@ -12,7 +12,7 @@ exports[`EsFormTextarea <EsFormTextarea /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea <label /> /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
@@ -26,7 +26,7 @@ exports[`EsFormTextarea <EsFormTextarea <label /> /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea props /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
@@ -41,7 +41,7 @@ exports[`EsFormTextarea <EsFormTextarea props /> 1`] = `
 
 exports[`EsFormTextarea <EsFormTextarea v-model /> 1`] = `
 "<div>
-  <div class="input-wrapper justify-content-end mb-2"><label for="testId" class="label font-weight-bold justify-content-start">
+  <div class="input-wrapper justify-content-end mb-2"><label for="testId" class="label font-weight-semibold justify-content-start">
       <!----></label>
     <div class="input-holder"><textarea id="testId" rows="2" wrap="soft" class="es-form-textarea w-100 form-control" data-testid="testTextarea"></textarea>
       <!---->
@@ -53,7 +53,7 @@ exports[`EsFormTextarea <EsFormTextarea v-model /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea>slots</EsFormTextarea> 1`] = `
-"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start">Notes
+"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Notes
     <!----></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
     <!---->

--- a/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsFormInput <EsFormInput /> 1`] = `
-"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
@@ -12,7 +12,7 @@ exports[`EsFormInput <EsFormInput /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
@@ -26,7 +26,7 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput props /> 1`] = `
-"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start">
+"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">
     <!----></label>
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
@@ -38,7 +38,7 @@ exports[`EsFormInput <EsFormInput props /> 1`] = `
 
 exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 "<div>
-  <div class="input-wrapper justify-content-end mb-2"><label for="testId" class="label font-weight-bold justify-content-start">
+  <div class="input-wrapper justify-content-end mb-2"><label for="testId" class="label font-weight-semibold justify-content-start">
       <!----></label>
     <div class="input-holder"><input id="testId" type="text" class="es-form-input w-100 form-control" data-testid="testInput">
       <!---->
@@ -50,7 +50,7 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput>slots</EsFormInput> 1`] = `
-"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-bold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control"> <small class="form-text text-muted">Please enter your account number.</small>
     <div class="invalid-feedback">Please enter a valid account number.</div>


### PR DESCRIPTION
<!-- Add a title with the Jira ticket and purpose, e.g. "ESDS-123 Awesome new feature". -->

<!-- Uncomment this if it's relevant. -->
<!-- **TIME SENSITIVE.** Deploy by: -->

# Related Jira Tickets
<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/ESDS-123) and any other related tickets. -->
- https://energysage.atlassian.net/browse/ESDS-79

## Changes
<!-- Describe your work in detail. -->
- Added `$font-weight-semibold` variable
- Added `font-weight-semibold` utility class
- Switched EsFormInput and EsFormTextarea to use the `font-weight-semibold` utility class on their `<label>` components
- Updated Jest snapshots for EsFormInput and EsFormTextarea
- Added 200 and 300 font weights to the Google Fonts call for the Inter font, since we already have utility classes trying to use those weights
- Added "Font Weight Utility Classes" documentation to the Typography page

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->
- Clicked through the `es-design-system` site in desktop Chrome, Firefox, and Safari

## Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall approach, anything I missed

### How to run locally
<!-- Include any instructions and/or links to docs to help reviewers see your work in their dev environments. -->
- `make build` to build `es-bs-base` (where the SCSS changes are) and `es-vue-base` (where the component changes are)
- `make symlink` should hook up those builds to the `es-design-system` Nuxt app
- `npm run dev` in `es-design-system` to run the Nuxt app and see the changes, font weight on the labels should now be 500

## Remaining TODOs
<!-- Is there additional work to be done prior to merge/deployment, or in a subsequent PR? -->
- none
