### PR TITLE
Add extra-context slot

### DIFF
--- a/es-design-system/package.json
+++ b/es-design-system/package.json
@@ -17,8 +17,8 @@
         "deploy:prod": "env-cmd -f .env.prod npm run deploy",
         "deploy": " npm --prefix aws run cdk deploy",
         "lint": "npm run lint:js && npm run lint:style",
-        "lint:js": "eslint --ext \".js,.vue,.mdx\" --ignore-path ../.gitignore .",
-        "lint:style": "stylelint \"**/*.{css,scss,sass,html,vue}\" --ignore-path ../.gitignore",
+        "lint:js": "eslint --ext \".js,.vue,.mdx\" --ignore-path .gitignore .",
+        "lint:style": "stylelint \"**/*.{css,scss,sass,html,vue}\" --ignore-path .gitignore",
         "lintfix": "npm run lint:js -- --fix && npm run lint:style -- --fix"
     },
     "prettier": "eslint-config-energysage/prettier",

--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -1,26 +1,53 @@
 <template>
-    <b-row>
-        <b-col
-            cols="12"
-            lg="6">
-            <es-form-input
-                id="myId"
-                v-model="docInput">
-                <template #label>
-                    Account Number
-                </template>
-                <template #message>
-                    Please enter your account number.
-                </template>
-                <template #errorMessage>
-                    Please enter a valid account number.
-                </template>
-                <template #successMessage>
-                    Your account number has been submitted successfully.
-                </template>
-            </es-form-input>
-        </b-col>
-    </b-row>
+    <div>
+        <b-row>
+            <b-col
+                cols="12"
+                lg="6">
+                <es-form-input
+                    id="myId"
+                    v-model="docInput">
+                    <template #label>
+                        Account Number
+                    </template>
+                    <template #message>
+                        Please enter your account number.
+                    </template>
+                    <template #errorMessage>
+                        Please enter a valid account number.
+                    </template>
+                    <template #successMessage>
+                        Your account number has been submitted successfully.
+                    </template>
+                </es-form-input>
+            </b-col>
+        </b-row>
+        <b-row class="mt-4">
+            <b-col
+                cols="12"
+                lg="6">
+                <es-form-input
+                    id="myId2"
+                    v-model="example2">
+                    <template #label>
+                        Account Number
+                    </template>
+                    <template #extraContext>
+                        Extra Context Goes Here
+                    </template>
+                    <template #message>
+                        Please enter your account number.
+                    </template>
+                    <template #errorMessage>
+                        Please enter a valid account number.
+                    </template>
+                    <template #successMessage>
+                        Your account number has been submitted successfully.
+                    </template>
+                </es-form-input>
+            </b-col>
+        </b-row>
+    </div>
 </template>
 <script>
 // TODO: Add input state/msg validation example
@@ -34,6 +61,7 @@ export default {
     data() {
         return {
             docInput: 'Example text',
+            example2: 'Example two',
         };
     },
 };

--- a/es-vue-base/package-lock.json
+++ b/es-vue-base/package-lock.json
@@ -25,7 +25,7 @@
         "autoprefixer": "^9.8.8",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^29.0.3",
-        "bootstrap-vue": "^2.23.0",
+        "bootstrap-vue": "^2.23.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.20.0",
         "eslint-config-energysage": "^2.2.2",
@@ -4929,9 +4929,9 @@
       }
     },
     "node_modules/bootstrap-vue": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.0.tgz",
-      "integrity": "sha512-cue/PixZ9p3SF7+x0necSE5jkwHWcBeDtUn8/MIWvqh0p5uxWjW3qIMep4cro6wte6ASJ7jGWhTaqHDtdMgHow==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.1.tgz",
+      "integrity": "sha512-SEWkG4LzmMuWjQdSYmAQk1G/oOKm37dtNfjB5kxq0YafnL2W6qUAmeDTcIZVbPiQd2OQlIkWOMPBRGySk/zGsg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19256,9 +19256,9 @@
       "requires": {}
     },
     "bootstrap-vue": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.0.tgz",
-      "integrity": "sha512-cue/PixZ9p3SF7+x0necSE5jkwHWcBeDtUn8/MIWvqh0p5uxWjW3qIMep4cro6wte6ASJ7jGWhTaqHDtdMgHow==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.1.tgz",
+      "integrity": "sha512-SEWkG4LzmMuWjQdSYmAQk1G/oOKm37dtNfjB5kxq0YafnL2W6qUAmeDTcIZVbPiQd2OQlIkWOMPBRGySk/zGsg==",
       "dev": true,
       "requires": {
         "@nuxt/opencollective": "^0.3.2",

--- a/es-vue-base/package-lock.json
+++ b/es-vue-base/package-lock.json
@@ -25,7 +25,7 @@
         "autoprefixer": "^9.8.8",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^29.0.3",
-        "bootstrap-vue": "^2.22.0",
+        "bootstrap-vue": "^2.23.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.20.0",
         "eslint-config-energysage": "^2.2.2",
@@ -4929,9 +4929,9 @@
       }
     },
     "node_modules/bootstrap-vue": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.22.0.tgz",
-      "integrity": "sha512-denjR/ae0K7Jrcqud3TrZWw0p/crtyigeGUNunWQ4t+KFi+7rzJ6j6lx1W5/gpUtSSUgNbWrXcHH4lIWXzXOOQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.0.tgz",
+      "integrity": "sha512-cue/PixZ9p3SF7+x0necSE5jkwHWcBeDtUn8/MIWvqh0p5uxWjW3qIMep4cro6wte6ASJ7jGWhTaqHDtdMgHow==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19256,9 +19256,9 @@
       "requires": {}
     },
     "bootstrap-vue": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.22.0.tgz",
-      "integrity": "sha512-denjR/ae0K7Jrcqud3TrZWw0p/crtyigeGUNunWQ4t+KFi+7rzJ6j6lx1W5/gpUtSSUgNbWrXcHH4lIWXzXOOQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.23.0.tgz",
+      "integrity": "sha512-cue/PixZ9p3SF7+x0necSE5jkwHWcBeDtUn8/MIWvqh0p5uxWjW3qIMep4cro6wte6ASJ7jGWhTaqHDtdMgHow==",
       "dev": true,
       "requires": {
         "@nuxt/opencollective": "^0.3.2",

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -42,7 +42,7 @@
     "autoprefixer": "^9.8.8",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^29.0.3",
-    "bootstrap-vue": "^2.22.0",
+    "bootstrap-vue": "^2.23.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.20.0",
     "eslint-config-energysage": "^2.2.2",

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -42,7 +42,7 @@
     "autoprefixer": "^9.8.8",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^29.0.3",
-    "bootstrap-vue": "^2.23.0",
+    "bootstrap-vue": "^2.23.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.20.0",
     "eslint-config-energysage": "^2.2.2",

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -13,7 +13,11 @@
                 *
             </span>
         </label>
-
+        <p
+            v-if="hasExtraContext"
+            class="mb-1">
+            <slot name="extraContext" />
+        </p>
         <div class="input-holder">
             <b-form-input
                 :id="id"
@@ -122,6 +126,9 @@ export default {
         },
         hasError() {
             return !!this.$slots.errorMessage;
+        },
+        hasExtraContext() {
+            return !!this.$slots.extraContext;
         },
     },
 };

--- a/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`EsFormInput <EsFormInput /> 1`] = `
 "<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
+  <!---->
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <!---->
@@ -15,6 +16,7 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
 "<div required="required" class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
             *
         </span></label>
+  <!---->
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <div class="invalid-feedback">
@@ -28,6 +30,7 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
 exports[`EsFormInput <EsFormInput props /> 1`] = `
 "<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">
     <!----></label>
+  <!---->
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <!---->
@@ -40,6 +43,7 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 "<div>
   <div class="input-wrapper justify-content-end mb-2"><label for="testId" class="label font-weight-semibold justify-content-start">
       <!----></label>
+    <!---->
     <div class="input-holder"><input id="testId" type="text" class="es-form-input w-100 form-control" data-testid="testInput">
       <!---->
       <!---->
@@ -52,6 +56,7 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 exports[`EsFormInput <EsFormInput>slots</EsFormInput> 1`] = `
 "<div class="input-wrapper justify-content-end mb-2"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
+  <!---->
   <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control"> <small class="form-text text-muted">Please enter your account number.</small>
     <div class="invalid-feedback">Please enter a valid account number.</div>
     <div class="valid-feedback">Your account number has been submitted successfully.</div>


### PR DESCRIPTION
## Changes

- Add additional extra-context slot to input fields

Need to add an additional line to the login-page on `accounts.energysage` to point users without a password to the OTP flow. Similar to what's currently live on WWW:

![Screen Shot 2022-10-25 at 3 16 52 PM](https://user-images.githubusercontent.com/114260/197862301-ab8f3346-c9e6-4c07-991a-b2a447d3e7b8.png)

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->

- Manual

## Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- Ok if I merge & deploy this?
