### PR TITLE
ESDS-87 updated headings and 'bolder' to font weight 700

### DIFF
--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -364,9 +364,9 @@ $font-weight-light:           300 !default;
 $font-weight-normal:          400 !default;
 $font-weight-semibold:        500 !default;
 $font-weight-bold:            600 !default;
-$font-weight-bolder:          800 !default;
+$font-weight-bolder:          700 !default;
 // fusv-disable
-$font-weight-boldest:         700 !default;
+$font-weight-boldest:         800 !default;
 // fusv-enable
 
 $font-weight-base:            $font-weight-normal !default;
@@ -381,7 +381,7 @@ $h6-font-size:                $font-size-base !default;
 
 $headings-margin-bottom:      1rem !default;
 $headings-font-family:        $font-family-sans-serif !default;
-$headings-font-weight:        600 !default;
+$headings-font-weight:        700 !default;
 $headings-line-height:        1.2 !default;
 $headings-color:              $gray-900 !default;
 // fusv-disable

--- a/es-design-system/nuxt.config.js
+++ b/es-design-system/nuxt.config.js
@@ -13,7 +13,7 @@ export default {
         link: [
             {
                 rel: 'stylesheet',
-                href: 'https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;800;900&display=swap',
+                href: 'https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700&display=swap',
             },
         ],
     },

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -105,7 +105,7 @@ export default {
                 },
                 {
                     name: 'font-weight-bolder',
-                    weight: '800',
+                    weight: '700',
                 },
             ],
         };


### PR DESCRIPTION
<!-- Add a title with the Jira ticket and purpose, e.g. "ESDS-123 Awesome new feature". -->

<!-- Uncomment this if it's relevant. -->
<!-- **TIME SENSITIVE.** Deploy by: -->

# Related Jira Tickets
<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/ESDS-123) and any other related tickets. -->
- https://energysage.atlassian.net/browse/ESDS-87

## Changes
<!-- Describe your work in detail. -->
- Updated all headings to be font weight 700 instead of 600, per [the design](https://www.figma.com/file/ILnQorHR2IcGAsIkme9Ctb/ESDS-1.0?node-id=59%3A538)
- Swapped the font weights of `bolder` (used) and `boldest` (not used) so `bolder` is now 700
- Removed unused font weights 800 and 900 from the Google Fonts include and added 700
- Updated the utility class table on the Typography page of the design system site to reflect the new 700 weight for `bolder`

### Headers (before)
<img width="601" alt="Screen Shot 2022-11-01 at 1 07 38 PM" src="https://user-images.githubusercontent.com/1350363/199294256-eea7885d-44a5-432e-a0f1-f619d638a372.png">

### Headers (after)
<img width="558" alt="Screen Shot 2022-11-01 at 1 07 47 PM" src="https://user-images.githubusercontent.com/1350363/199294274-d47ea065-78dd-4037-887a-ead5fd9b3c24.png">

### Utility class table (before)
<img width="567" alt="Screen Shot 2022-11-01 at 1 14 14 PM" src="https://user-images.githubusercontent.com/1350363/199295150-fefc948a-6675-4f3a-a204-553411eadaea.png">

### Utility class table (after)
<img width="557" alt="Screen Shot 2022-11-01 at 1 14 20 PM" src="https://user-images.githubusercontent.com/1350363/199295187-362004c8-d5d8-4cb4-bca7-44e513cabef6.png">

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->
- Loaded design system site in Firefox, Safari, Chrome to ensure font weight rendered properly
- Searched the es-ds codebase thoroughly for all instances of font weight variable use that could be affected
- Viewed all other pages of the design system site to ensure no other components were affected unexpectedly

## Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall approach

### How to run locally
<!-- Include any instructions and/or links to docs to help reviewers see your work in their dev environments. -->
- Build es-bs-base
- Run es-design-system site
- View Typography page

## Remaining TODOs
<!-- Is there additional work to be done prior to merge/deployment, or in a subsequent PR? -->
- None