### PR TITLE
Add font size utility classes

### DIFF
--- a/es-bs-base/scss/_type.scss
+++ b/es-bs-base/scss/_type.scss
@@ -132,3 +132,10 @@ mark,
     content: "\2014\00A0"; // em dash, nbsp
   }
 }
+
+
+@each $size, $value in $font-sizes {
+  .font-size-#{$size} {
+    font-size: $value;
+  }
+}

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -345,16 +345,11 @@ $font-family-base:            $font-family-sans-serif !default;
 // stylelint-enable value-keyword-case
 
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-
-// fusv-disable
 $font-size-xs:                $font-size-base * 0.75;
-// fusv-enable
 $font-size-sm:                $font-size-base * 0.875 !default;
-$font-size-lg:                $font-size-base * 1.125 !default;
-// fusv-disable
-$font-size-xl:                $font-size-base * 1.375;
-$font-size-xxl:               $font-size-base * 3;
-// fusv-enable
+$font-size-lg:                $font-size-base * 1.25 !default;
+$font-size-xl:                $font-size-base * 1.35 !default;
+$font-size-xxl:               $font-size-base * 1.85 !default;
 
 // used in font-size-* utility classes
 $font-sizes: (

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -356,6 +356,16 @@ $font-size-xl:                $font-size-base * 1.375;
 $font-size-xxl:               $font-size-base * 3;
 // fusv-enable
 
+// used in font-size-* utility classes
+$font-sizes: (
+  "xxl": $font-size-xxl,
+  "xl": $font-size-xl,
+  "lg": $font-size-lg,
+  "base": $font-size-base,
+  "sm": $font-size-sm,
+  "xs": $font-size-xs,
+);
+
 // fusv-disable
 $font-weight-lightest:        lighter;
 // fusv-enable

--- a/es-bs-base/scss/variables/_type.scss
+++ b/es-bs-base/scss/variables/_type.scss
@@ -1,0 +1,14 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@import "../functions";
+@import "../mixins";
+@import "../variables";
+
+:export {
+  xxl: $font-size-xxl;
+  xl: $font-size-xl;
+  lg: $font-size-lg;
+  base: $font-size-base;
+  sm: $font-size-sm;
+  xs: $font-size-xs;
+}

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -65,7 +65,8 @@
                     Font Weight Utility Classes
                 </h2>
                 <b-table
-                    :fields="fontWeightFields"
+                    fixed
+                    :fields="fontFields"
                     :items="fontWeightItems"
                     striped>
                     <template #cell(example)="data">
@@ -74,15 +75,34 @@
                 </b-table>
             </b-col>
         </b-row>
+        <b-row class="my-5 border-top pt-5">
+            <b-col>
+                <h2>
+                    Font Size Utility Classes
+                </h2>
+                <b-table
+                    fixed
+                    :fields="fontFields"
+                    :items="fontSizeItems"
+                    striped>
+                    <template #cell(example)="data">
+                        <span :class="data.item.name">sample text at {{ data.item.size }} size</span>
+                    </template>
+                </b-table>
+            </b-col>
+        </b-row>
     </div>
 </template>
 
 <script>
+import sassType from '@energysage/es-bs-base/scss/variables/_type.scss';
+
 export default {
     name: 'AtomsTypography',
     data() {
         return {
-            fontWeightFields: [
+            sassType,
+            fontFields: [
                 'name',
                 // virtual column that can reference two fields
                 { key: 'example', label: 'Example' },
@@ -111,6 +131,32 @@ export default {
                 {
                     name: 'font-weight-bolder',
                     weight: '700',
+                },
+            ],
+            fontSizeItems: [
+                {
+                    name: 'font-size-xs',
+                    size: sassType.xs,
+                },
+                {
+                    name: 'font-size-xs',
+                    size: sassType.sm,
+                },
+                {
+                    name: 'font-size-base',
+                    size: sassType.base,
+                },
+                {
+                    name: 'font-size-lg',
+                    size: sassType.lg,
+                },
+                {
+                    name: 'font-size-xl',
+                    size: sassType.xl,
+                },
+                {
+                    name: 'font-size-xxl',
+                    size: sassType.xxl,
                 },
             ],
         };

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -139,7 +139,7 @@ export default {
                     size: sassType.xs,
                 },
                 {
-                    name: 'font-size-xs',
+                    name: 'font-size-sm',
                     size: sassType.sm,
                 },
                 {

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -142,11 +142,6 @@ export default {
     color: $danger;
 }
 
-// TODO: Move to its own utils in es-bs-base
-.font-size-sm {
-    font-size: $font-size-sm;
-}
-
 .es-form-input:disabled, .es-form-input[readonly] {
     border: 0;
 }


### PR DESCRIPTION
<!-- Add a title with the Jira ticket and purpose, e.g. "ESDS-123 Awesome new feature". -->

<!-- Uncomment this if it's relevant. -->
<!-- **TIME SENSITIVE.** Deploy by: -->

# Related Jira Tickets
<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/ESDS-123) and any other related tickets. -->

- https://www.figma.com/file/ILnQorHR2IcGAsIkme9Ctb/ESDS-1.0?node-id=59%3A538

## Changes
<!-- Describe your work in detail. -->

- Added font size utility classes to match figma definition; based largely on csm's implementation [here](https://github.com/EnergySage/es-cdgm/blob/master/frontend/assets/scss/bs4/_font.scss#L17)
	- Added a few more not in figma following a similar addition pattern

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->

- Manual Vis
