### PR TITLE
Check if form field doesn't have a related validations def

### DIFF
--- a/es-design-system/pages/organisms/es-form.vue
+++ b/es-design-system/pages/organisms/es-form.vue
@@ -23,7 +23,7 @@
                     <es-form-input
                         id="email"
                         v-model="$v.form.email.$model"
-                        :state="validateState('email')"
+                        :state="validateState('form.email')"
                         :disabled="isSubmitInProgress"
                         required>
                         <template #label>
@@ -36,7 +36,7 @@
                     <es-form-input
                         id="password"
                         v-model="$v.form.password.$model"
-                        :state="validateState('password')"
+                        :state="validateState('form.password')"
                         :disabled="isSubmitInProgress"
                         required
                         type="tel">
@@ -54,7 +54,7 @@
                     <es-form-input
                         id="phone"
                         v-model="$v.form.phone.$model"
-                        :state="validateState('phone')"
+                        :state="validateState('form.phone')"
                         :disabled="isSubmitInProgress"
                         required
                         type="tel">
@@ -69,7 +69,7 @@
                         id="notes"
                         v-model="$v.form.notes.$model"
                         :disabled="isSubmitInProgress"
-                        :state="validateState('notes')"
+                        :state="validateState('form.notes')"
                         required>
                         <template #label>
                             Notes
@@ -282,7 +282,7 @@ export default {
                 [vuelidateKeys.PHONE]: vuelidatePhone,
             },
             email: {
-                required: vuelidateRequired,
+                [vuelidateKeys.REQUIRED]: vuelidateRequired,
                 [vuelidateKeys.EMAIL]: vuelidateEmail,
             },
             notes: {

--- a/es-vue-base/src/lib-mixins/forms.js
+++ b/es-vue-base/src/lib-mixins/forms.js
@@ -66,6 +66,10 @@ export default {
     },
     methods: {
         validateState(name) {
+            // Check that given field has key in validators object
+            if (!this.$v.form[name]) {
+                return null;
+            }
             const { $dirty, $error } = this.$v.form[name];
             return $dirty ? !$error : null;
         },

--- a/es-vue-base/src/lib-mixins/forms.js
+++ b/es-vue-base/src/lib-mixins/forms.js
@@ -67,7 +67,8 @@ export default {
     methods: {
         validateState(name) {
             // Check that given field has key in validators object
-            if (!this.$v.form[name]) {
+            const fieldHasValidators = this.$v.form && this.$v.form[name];
+            if (!fieldHasValidators) {
                 return null;
             }
             const { $dirty, $error } = this.$v.form[name];

--- a/es-vue-base/src/lib-mixins/forms.js
+++ b/es-vue-base/src/lib-mixins/forms.js
@@ -53,6 +53,9 @@ export default {
         * }
         */
         formErrors() {
+            if (!Object.hasOwn(this.$v, 'form')) {
+                return {};
+            }
             const formFields = this.getFields(this.$v.form);
             const formFieldErrors = formFields.reduce((formObj, item) => {
                 // eslint-disable-next-line no-param-reassign
@@ -65,13 +68,23 @@ export default {
         },
     },
     methods: {
-        validateState(name) {
-            // Check that given field has key in validators object
-            const fieldHasValidators = this.$v.form && this.$v.form[name];
-            if (!fieldHasValidators) {
+        /**
+        * @param { string } dataPath
+        * @returns { Boolean | null } `true` if field is valid, `false` if field isn't valid, `null` if not "touched"
+        */
+        validateState(dataPath) {
+            const validatorField = dataPath.split('.').reduce((acc, field) => {
+                // eslint-disable-next-line no-param-reassign
+                acc = acc[field];
+                return acc;
+            }, this.$v);
+            if (!validatorField) {
                 return null;
             }
-            const { $dirty, $error } = this.$v.form[name];
+            if (!['$dirty', '$error'].map((key) => Object.hasOwn(validatorField, key))) {
+                return null;
+            }
+            const { $dirty, $error } = validatorField;
             return $dirty ? !$error : null;
         },
         // eslint-disable-next-line max-len

--- a/es-vue-base/tests/mixins/forms.spec.js
+++ b/es-vue-base/tests/mixins/forms.spec.js
@@ -1,0 +1,22 @@
+import { shallowMount } from '@vue/test-utils';
+import { formMixins } from '../../src/lib-mixins';
+
+test('validateState doesn\'t throw error', () => {
+    const Component = {
+        data() {
+            return {
+                form: {
+                    firstName: '',
+                },
+            };
+        },
+        render() {},
+        mixins: [formMixins],
+        validations: {},
+        mounted() {
+            this.validateState('firstName');
+        },
+    };
+    const wrapper = shallowMount(Component);
+    expect(wrapper).toBeTruthy();
+});


### PR DESCRIPTION


## Changes
<!-- Describe your work in detail. -->

- Add check to `validateState` in the event a form field doesn't include a `validations` definition.

### Testing
<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->

- Manual tested in browser & automated test
- To validate the fix, add a form field without related `validations` definitions. Without the check, the page will fail to render throwing an exception.

