### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,48 @@
+name: "\U0001F41E Bug report"
+description: Create a report to help us improve es-ds
+labels: ["pending triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please carefully read the contribution docs before creating a bug report
+        👉 https://energysage.atlassian.net/wiki/spaces/DSE/pages/116391995/Contribution
+
+        Please provide steps to reproduce
+        👉 [code sandbox](https://codesandbox.io/) or a link to a repo or page is helpful here
+  - type: textarea
+    id: bug-env
+    attributes:
+      label: Environment
+      description: Please provide any environment information (es-ds version, browser, operating system, ect.)
+      placeholder: Environment
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide any information for steps to reproduce. Again [code sandbox](https://codesandbox.io/) or a link to a repo or page is helpful here
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: additonal
+    attributes:
+      label: Additional context
+      description: If applicable, add any other context about the problem here
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Optional if provided reproduction. Please try not to insert an image but copy paste the log text.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: 📚 Documentation
+    url: https://energysage.atlassian.net/wiki/spaces/DSE/overview?homepageId=31588809
+    about: Check documentation for usage
+  - name: 💬 Discussions
+    url: https://energysage.atlassian.net/jira/software/projects/ESDS/boards/58
+    about: Use discussions if you have an idea for improvement and asking questions

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,36 @@
+name: "🚀 Feature request"
+description: Suggest a feature that will improve es-ds
+labels: ["pending triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request!
+
+        Please carefully read the contribution docs before suggesting a new feature
+        👉 https://energysage.atlassian.net/wiki/spaces/DSE/pages/116391995/Contribution
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what you think would be a helpful addition to es-ds, including the possible use cases and alternatives you have considered. If you have a working prototype or module that implements it, please include a link. If the feature includes EnergySage specific context, consider writing up a Jira ticket instead.
+      placeholder: Feature description
+    validations:
+      required: true
+  - type: checkboxes
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Additional information that helps us decide how to proceed.
+      options:
+        - label: Would you be willing to help implement this feature?
+  - type: checkboxes
+    id: required-info
+    attributes:
+      label: Final checks
+      description: Before submitting, please make sure you do the following
+      options:
+        - label: Read the [contribution guide](https://energysage.atlassian.net/wiki/spaces/DSE/pages/116391995/Contribution).
+          required: true
+        - label: Check existing [issues](https://github.com/EnergySage/es-ds/issues).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,44 @@
-<!-- Add a title with the Jira ticket and purpose, e.g. "ESDS-123 Awesome new feature". -->
+<!--
+    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
+-->
 
-<!-- Uncomment this if it's relevant. -->
-<!-- **TIME SENSITIVE.** Deploy by: -->
+<!---
+☝️ PR title should follow conventional commits (https://conventionalcommits.org)
 
-# Related Jira Tickets
-<!-- Link to the ticket for this work (e.g. https://energysage.atlassian.net/browse/ESDS-123) and any other related tickets. -->
+Please carefully read the contribution docs before creating a pull request
+ 👉 https://v3.nuxtjs.org/community/contribution
+-->
 
--
+### 🔗 Linked issue
 
-## Changes
-<!-- Describe your work in detail. -->
+<!-- Please ensure there is an open issue and mention its number as #123 -->
 
--
+### ❓ Type of change
 
-### Testing
-<!-- Describe tests that you have written and/or identify existing tests that cover your work. -->
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
 
--
+- [ ] 📖 Documentation (updates to the documentation or readme)
+- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
+- [ ] 👌 Enhancement (improving an existing functionality like performance)
+- [ ] ✨ New feature (a non-breaking change that adds functionality)
+- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
 
-## Feedback Requested / Focus Areas
-<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
+### 📚 Description
 
--
+<!-- Describe your changes in detail -->
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
 
-### How to run locally
-<!-- Include any instructions and/or links to docs to help reviewers see your work in their dev environments. -->
+### 🥼 Testing
 
--
+<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
 
-## Remaining TODOs
-<!-- Is there additional work to be done prior to merge/deployment, or in a subsequent PR? -->
+### 📝 Checklist
 
-- [ ]
+<!-- Put an `x` in all the boxes that apply. -->
+<!-- If your change requires a documentation PR, please link it appropriately -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have linked an issue or discussion.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have documented testing approach


### PR DESCRIPTION
I think we should depart from ES the issue template used for private ES repos, and instead more towards a more generic process. Happy to have a meeting to discuss this idea further!