### PR TITLE
docs: added responsive breakpoints table to Layout page

### DIFF
--- a/es-bs-base/scss/variables/_breakpoints.scss
+++ b/es-bs-base/scss/variables/_breakpoints.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
 @import "../functions";
 @import "../mixins";
 @import "../variables";

--- a/es-bs-base/scss/variables/_breakpoints.scss
+++ b/es-bs-base/scss/variables/_breakpoints.scss
@@ -1,0 +1,12 @@
+@import "../functions";
+@import "../mixins";
+@import "../variables";
+
+:export {
+  xxl: map-get($grid-breakpoints, xxl);
+  xl: map-get($grid-breakpoints, xl);
+  lg: map-get($grid-breakpoints, lg);
+  md: map-get($grid-breakpoints, md);
+  sm: map-get($grid-breakpoints, sm);
+  xs: map-get($grid-breakpoints, xs);
+}

--- a/es-bs-base/scss/variables/_max-widths.scss
+++ b/es-bs-base/scss/variables/_max-widths.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
 @import "../functions";
 @import "../mixins";
 @import "../variables";

--- a/es-bs-base/scss/variables/_max-widths.scss
+++ b/es-bs-base/scss/variables/_max-widths.scss
@@ -1,0 +1,11 @@
+@import "../functions";
+@import "../mixins";
+@import "../variables";
+
+:export {
+  xxl: map-get($container-max-widths, xxl);
+  xl: map-get($container-max-widths, xl);
+  lg: map-get($container-max-widths, lg);
+  md: map-get($container-max-widths, md);
+  sm: map-get($container-max-widths, sm);
+}

--- a/es-design-system/pages/atoms/layout.vue
+++ b/es-design-system/pages/atoms/layout.vue
@@ -8,6 +8,24 @@
                 bootstrap-vue layout
             </b-link>
         </p>
+        <h2 class="mt-4">
+            Responsive Breakpoints
+        </h2>
+        <p>
+            At each breakpoint above extra small (xs), the content is constrained to the max width listed below.
+        </p>
+        <b-table
+            fixed
+            :fields="breakpointTableFields"
+            :items="breakpointTableItems"
+            striped>
+            <template #cell(label)="data">
+                <strong>{{ data.item.label }}</strong>
+            </template>
+        </b-table>
+        <h2 class="mt-4">
+            Grid Overview
+        </h2>
         <b-container>
             <b-row>
                 <b-col
@@ -229,12 +247,43 @@
 </template>
 
 <script>
+import sassBreakpoints from '@energysage/es-bs-base/scss/variables/_breakpoints.scss';
+import sassMaxWidths from '@energysage/es-bs-base/scss/variables/_max-widths.scss';
 
 export default {
     name: 'AtomsLayout',
     data() {
         return {
             docCode: '',
+            breakpointTableFields: [
+                { key: 'label', label: '' },
+                { key: 'xs', label: 'Extra small (xs)' },
+                { key: 'sm', label: 'Small (sm)' },
+                { key: 'md', label: 'Medium (md)' },
+                { key: 'lg', label: 'Large (lg)' },
+                { key: 'xl', label: 'Extra large (xl)' },
+                { key: 'xxl', label: 'Extra extra large (xxl)' },
+            ],
+            breakpointTableItems: [
+                {
+                    label: 'Breakpoint',
+                    xs: `< ${sassBreakpoints.sm}`,
+                    sm: `≥ ${sassBreakpoints.sm}`,
+                    md: `≥ ${sassBreakpoints.md}`,
+                    lg: `≥ ${sassBreakpoints.lg}`,
+                    xl: `≥ ${sassBreakpoints.xl}`,
+                    xxl: `≥ ${sassBreakpoints.xxl}`,
+                },
+                {
+                    label: 'Max container width',
+                    xs: 'None',
+                    sm: sassMaxWidths.sm,
+                    md: sassMaxWidths.md,
+                    lg: sassMaxWidths.lg,
+                    xl: sassMaxWidths.xl,
+                    xxl: sassMaxWidths.xxl,
+                },
+            ],
         };
     },
     async created() {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/ESDS-106

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Since our breakpoints and max widths differ slightly from the [Bootstrap](https://getbootstrap.com/docs/4.0/layout/grid/#grid-options) and [Bootstrap Vue](https://bootstrap-vue.org/docs/components/layout#grid-options) documentation - namely, in that we use an extra `xxl` breakpoint - I've added a Responsive Breakpoints table to the Layout page explaining this. It uses the Sass variables directly, so it will update if we ever change a breakpoint or max width pixel value. This should be useful for both engineers and designers to reference.

<img width="1381" alt="Screen Shot 2023-01-05 at 4 47 16 PM" src="https://user-images.githubusercontent.com/1350363/210886293-b425ddc0-078b-4a2d-8f73-2159dfbc8710.png">

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Loaded the Layout page in Chrome, Firefox, and Safari.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
