### PR TITLE
fix: add !important back to bg color utility classes, add breaking change note to v12 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ***BREAKING:*** `EsReview` now does not contain padding or margins; responsibility of wrapping element
+- ***BREAKING:*** `bg-white` utility class no longer has an `!important` property
 - Fixed an issue where `EsVerificationCode` emits triggered too quickly
 - Removed `EsHorizontalList` from `es-review-list` documentation in favor of row and column display
 

--- a/es-bs-base/scss/utilities/_background.scss
+++ b/es-bs-base/scss/utilities/_background.scss
@@ -12,7 +12,7 @@
 
 @mixin bg-colors($color, $value, $relative: true) {
   .bg-#{$color} {
-    background-color: $value;
+    background-color: $value !important;
   }
 }
 


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-111

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- ***BREAKING CHANGE:*** Adds the `!important` keyword back to `bg-{color}` utility classes
- Updates the CHANGELOG to indicate that the v0.12.0 release contained a breaking change that was the removal of the `!important` keyword from the `bg-white` class (see ticket for more details on the regression this introduced).

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Loaded the Colors docs page to ensure the bg colors are rendering properly and inspected the element to ensure the `!important` keyword was present.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
