### PR TITLE
(feat): Support SSR in es-ds and es-vue-base

### DIFF
--- a/es-design-system/nuxt.config.js
+++ b/es-design-system/nuxt.config.js
@@ -29,7 +29,6 @@ export default {
             { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#b95100' },
         ],
     },
-    ssr: false,
     server: {
         port: 8500,
     },
@@ -63,6 +62,7 @@ export default {
     // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
     plugins: [
         { src: '@/plugins/api.js' },
+        // TODO: Make SSR Compliant
         { src: '~/plugins/prism', mode: 'client' },
     ],
     // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules

--- a/es-design-system/pages/atoms/color.vue
+++ b/es-design-system/pages/atoms/color.vue
@@ -106,12 +106,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./color.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./color.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/atoms/icons.vue
+++ b/es-design-system/pages/atoms/icons.vue
@@ -76,12 +76,14 @@ export default {
         },
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./icons.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./icons.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/atoms/layout.vue
+++ b/es-design-system/pages/atoms/layout.vue
@@ -287,12 +287,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./layout.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./layout.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/atoms/spacing.vue
+++ b/es-design-system/pages/atoms/spacing.vue
@@ -76,12 +76,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./spacing.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./spacing.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -176,12 +176,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./typography.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./typography.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-accordion.vue
+++ b/es-design-system/pages/molecules/es-accordion.vue
@@ -252,16 +252,18 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-accordion.vue');
-        const compSource = await import(
-            '!raw-loader!@energysage/es-vue-base/src/lib-components/EsAccordion.vue'
-        );
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-accordion.vue');
+            const compSource = await import(
+                '!raw-loader!@energysage/es-vue-base/src/lib-components/EsAccordion.vue'
+            );
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-badge.vue
+++ b/es-design-system/pages/molecules/es-badge.vue
@@ -50,14 +50,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-badge.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBadge.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-badge.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBadge.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-breadcrumbs.vue
+++ b/es-design-system/pages/molecules/es-breadcrumbs.vue
@@ -47,14 +47,17 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-breadcrumbs.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBreadcrumbs.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-breadcrumbs.vue');
+            // eslint-disable-next-line max-len
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBreadcrumbs.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-button.vue
+++ b/es-design-system/pages/molecules/es-button.vue
@@ -213,14 +213,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-badge.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBadge.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-badge.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsBadge.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-collapse.vue
+++ b/es-design-system/pages/molecules/es-collapse.vue
@@ -51,14 +51,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-collapse.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsCollapse.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-collapse.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsCollapse.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         shownEvent() {

--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -88,14 +88,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-form-input.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormInput.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-form-input.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormInput.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-form-msg.vue
+++ b/es-design-system/pages/molecules/es-form-msg.vue
@@ -43,14 +43,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-form-msg.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormMsg.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-form-msg.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormMsg.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         fakeFormMsg(success = true) {

--- a/es-design-system/pages/molecules/es-form-textarea.vue
+++ b/es-design-system/pages/molecules/es-form-textarea.vue
@@ -62,14 +62,17 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-form-textarea.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormTextarea.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-form-textarea.vue');
+            // eslint-disable-next-line max-len
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsFormTextarea.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-horizontal-list.vue
+++ b/es-design-system/pages/molecules/es-horizontal-list.vue
@@ -53,14 +53,17 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-horizontal-list.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsHorizontalList.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-horizontal-list.vue');
+            // eslint-disable-next-line max-len
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsHorizontalList.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-modal.vue
+++ b/es-design-system/pages/molecules/es-modal.vue
@@ -71,14 +71,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-modal.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsModal.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-modal.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsModal.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-popover.vue
+++ b/es-design-system/pages/molecules/es-popover.vue
@@ -161,14 +161,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-popover.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsPopover.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-popover.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsPopover.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-progress.vue
+++ b/es-design-system/pages/molecules/es-progress.vue
@@ -82,14 +82,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-progress.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsProgress.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-progress.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsProgress.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-rating.vue
+++ b/es-design-system/pages/molecules/es-rating.vue
@@ -43,14 +43,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-rating.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsRating.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-rating.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsRating.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         changeEvent($event) {

--- a/es-design-system/pages/molecules/es-slider.vue
+++ b/es-design-system/pages/molecules/es-slider.vue
@@ -44,14 +44,16 @@ export default {
         };
     },
     async created() {
-        /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-slider.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsSlider.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+        if (this.$prism) {
+            /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-slider.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsSlider.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         changeEvent($event) {

--- a/es-design-system/pages/molecules/es-support.vue
+++ b/es-design-system/pages/molecules/es-support.vue
@@ -56,14 +56,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-support.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsSupport.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-support.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsSupport.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-tabs.vue
+++ b/es-design-system/pages/molecules/es-tabs.vue
@@ -47,14 +47,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-tabs.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsTabs.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-tabs.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsTabs.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/molecules/es-verification-code.vue
+++ b/es-design-system/pages/molecules/es-verification-code.vue
@@ -104,15 +104,17 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-verification-code.vue');
-        // eslint-disable-next-line max-len
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsVerificationCode.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-verification-code.vue');
+            // eslint-disable-next-line max-len
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsVerificationCode.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         checkValidation(valid) {

--- a/es-design-system/pages/molecules/es-view-more.vue
+++ b/es-design-system/pages/molecules/es-view-more.vue
@@ -36,14 +36,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-view-more.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsViewMore.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-view-more.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsViewMore.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
 };
 </script>

--- a/es-design-system/pages/organisms/es-form.vue
+++ b/es-design-system/pages/organisms/es-form.vue
@@ -280,12 +280,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-form.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-form.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
     validations: {
         form: {

--- a/es-design-system/pages/organisms/es-review.vue
+++ b/es-design-system/pages/organisms/es-review.vue
@@ -66,14 +66,16 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-review.vue');
-        const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsReview.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-review.vue');
+            const compSource = await import('!raw-loader!@energysage/es-vue-base/src/lib-components/EsReview.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.compCode = this.$prism.normalizeCode(compSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.compCode = this.$prism.normalizeCode(compSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         createReview() {

--- a/es-design-system/pages/organisms/es-reviews-list.vue
+++ b/es-design-system/pages/organisms/es-reviews-list.vue
@@ -126,12 +126,14 @@ export default {
         };
     },
     async created() {
+        if (this.$prism) {
         /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-        const docSource = await import('!raw-loader!./es-reviews-list.vue');
-        /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+            const docSource = await import('!raw-loader!./es-reviews-list.vue');
+            /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
-        this.docCode = this.$prism.normalizeCode(docSource.default);
-        this.$prism.highlight(this);
+            this.docCode = this.$prism.normalizeCode(docSource.default);
+            this.$prism.highlight(this);
+        }
     },
     methods: {
         createReview() {

--- a/es-vue-base/build/rollup.config.js
+++ b/es-vue-base/build/rollup.config.js
@@ -30,6 +30,12 @@ const projectRoot = path.resolve(__dirname, '..');
 
 const baseConfig = {
     input: 'src/entry.js',
+    output: {
+        name: 'EsVueBase',
+        sourcemap: true,
+        exports: 'named',
+        compact: true,
+    },
     plugins: {
         preVue: [
             alias({
@@ -83,7 +89,6 @@ const baseConfig = {
     },
 };
 
-// ESM/UMD/IIFE shared settings: externals
 // Refer to https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
 const external = [
     // list external dependencies, exactly the way it is written in the import statement.
@@ -92,7 +97,6 @@ const external = [
     'bootstrap-vue',
 ];
 
-// UMD/IIFE shared settings: output.globals
 // Refer to https://rollupjs.org/guide/en#output-globals for details
 const globals = {
     // Provide global variable names to replace your external imports
@@ -106,18 +110,14 @@ const buildFormats = [];
 if (!argv.format || argv.format === 'umd') {
     const umdConfig = {
         ...baseConfig,
-        input: 'src/entry.js',
         external,
         output: {
+            ...baseConfig.output,
             file: packageJSON.browser,
-            name: 'EsDsVue',
-            sourcemap: true,
             format: 'umd',
-            exports: 'named',
             globals,
         },
         plugins: [
-            visualizer(), // Outputs bundle info to ./stats.html
             replace(baseConfig.plugins.replace),
             ...baseConfig.plugins.preVue,
             vue(baseConfig.plugins.vue),
@@ -134,6 +134,11 @@ if (!argv.format || argv.format === 'umd') {
                     ],
                 ],
             }),
+            terser({
+                output: {
+                    ecma: 5,
+                },
+            }),
         ],
     };
     buildFormats.push(umdConfig);
@@ -144,10 +149,9 @@ if (!argv.format || argv.format === 'es') {
         input: 'src/entry.esm.js',
         external,
         output: {
-            sourcemap: true,
+            ...baseConfig.output,
             file: packageJSON.module,
             format: 'esm',
-            exports: 'named',
         },
         plugins: [
             visualizer(), // Outputs bundle info to ./stats.html
@@ -177,12 +181,9 @@ if (!argv.format || argv.format === 'cjs') {
         ...baseConfig,
         external,
         output: {
-            compact: true,
+            ...baseConfig.output,
             file: packageJSON.main,
             format: 'cjs',
-            name: 'EsVueBase',
-            exports: 'named',
-            sourcemap: true,
             globals,
         },
         plugins: [
@@ -200,35 +201,6 @@ if (!argv.format || argv.format === 'cjs') {
         ],
     };
     buildFormats.push(cjsConfig);
-}
-
-if (!argv.format || argv.format === 'iife') {
-    const unpkgConfig = {
-        ...baseConfig,
-        external,
-        output: {
-            compact: true,
-            file: packageJSON.unpkg,
-            format: 'iife',
-            name: 'EsVueBase',
-            exports: 'named',
-            sourcemap: true,
-            globals,
-        },
-        plugins: [
-            replace(baseConfig.plugins.replace),
-            ...baseConfig.plugins.preVue,
-            vue(baseConfig.plugins.vue),
-            ...baseConfig.plugins.postVue,
-            babel(baseConfig.plugins.babel),
-            terser({
-                output: {
-                    ecma: 5,
-                },
-            }),
-        ],
-    };
-    buildFormats.push(unpkgConfig);
 }
 
 // Export config

--- a/es-vue-base/build/rollup.config.js
+++ b/es-vue-base/build/rollup.config.js
@@ -34,7 +34,6 @@ const baseConfig = {
         name: 'EsVueBase',
         sourcemap: true,
         exports: 'named',
-        compact: true,
     },
     plugins: {
         preVue: [
@@ -113,7 +112,6 @@ if (!argv.format || argv.format === 'umd') {
         external,
         output: {
             ...baseConfig.output,
-            file: packageJSON.browser,
             format: 'umd',
             globals,
         },
@@ -134,14 +132,34 @@ if (!argv.format || argv.format === 'umd') {
                     ],
                 ],
             }),
+        ],
+    };
+
+    // Minified build is default
+    buildFormats.push({
+        ...umdConfig,
+        output: {
+            ...umdConfig.output,
+            compact: true,
+            file: packageJSON.browser,
+        },
+        plugins: [
+            ...umdConfig.plugins,
             terser({
                 output: {
                     ecma: 5,
                 },
             }),
         ],
-    };
-    buildFormats.push(umdConfig);
+    });
+
+    buildFormats.push({
+        ...umdConfig,
+        output: {
+            ...umdConfig.output,
+            file: packageJSON.browser.replace('min.', ''),
+        },
+    });
 }
 if (!argv.format || argv.format === 'es') {
     const esConfig = {
@@ -150,7 +168,6 @@ if (!argv.format || argv.format === 'es') {
         external,
         output: {
             ...baseConfig.output,
-            file: packageJSON.module,
             format: 'esm',
         },
         plugins: [
@@ -173,7 +190,32 @@ if (!argv.format || argv.format === 'es') {
             }),
         ],
     };
-    buildFormats.push(esConfig);
+
+    // Minified build is default
+    buildFormats.push({
+        ...esConfig,
+        output: {
+            ...esConfig.output,
+            compact: true,
+            file: packageJSON.module,
+        },
+        plugins: [
+            ...esConfig.plugins,
+            terser({
+                output: {
+                    ecma: 5,
+                },
+            }),
+        ],
+    });
+
+    buildFormats.push({
+        ...esConfig,
+        output: {
+            ...esConfig.output,
+            file: packageJSON.module.replace('min.', ''),
+        },
+    });
 }
 
 if (!argv.format || argv.format === 'cjs') {
@@ -200,7 +242,32 @@ if (!argv.format || argv.format === 'cjs') {
             babel(baseConfig.plugins.babel),
         ],
     };
-    buildFormats.push(cjsConfig);
+
+    // Minified build is default
+    buildFormats.push({
+        ...cjsConfig,
+        output: {
+            ...cjsConfig.output,
+            compact: true,
+            file: packageJSON.main,
+        },
+        plugins: [
+            ...cjsConfig.plugins,
+            terser({
+                output: {
+                    ecma: 5,
+                },
+            }),
+        ],
+    });
+
+    buildFormats.push({
+        ...cjsConfig,
+        output: {
+            ...cjsConfig.output,
+            file: packageJSON.main.replace('min.', ''),
+        },
+    });
 }
 
 // Export config

--- a/es-vue-base/build/rollup.config.js
+++ b/es-vue-base/build/rollup.config.js
@@ -13,7 +13,11 @@ import babel from '@rollup/plugin-babel';
 import { visualizer } from 'rollup-plugin-visualizer';
 import terser from '@rollup/plugin-terser';
 import minimist from 'minimist';
-import packageJSON from '../package.json';
+import {
+    main as mainFileName,
+    browser as browserFileName,
+    module as moduleFileName,
+} from '../package.json';
 
 // Get browserslist config and remove ie from es build targets
 const esbrowserslist = fs.readFileSync('./.browserslistrc')
@@ -104,7 +108,7 @@ const globals = {
     'bootstrap-vue': 'bootstrapVue',
 };
 
-// Customize configs for individual targets
+// UMD Build: https://github.com/umdjs/umd
 const buildFormats = [];
 if (!argv.format || argv.format === 'umd') {
     const umdConfig = {
@@ -141,7 +145,7 @@ if (!argv.format || argv.format === 'umd') {
         output: {
             ...umdConfig.output,
             compact: true,
-            file: packageJSON.browser,
+            file: browserFileName,
         },
         plugins: [
             ...umdConfig.plugins,
@@ -157,10 +161,12 @@ if (!argv.format || argv.format === 'umd') {
         ...umdConfig,
         output: {
             ...umdConfig.output,
-            file: packageJSON.browser.replace('min.', ''),
+            file: browserFileName.browser.replace('min.', ''),
         },
     });
 }
+
+// ESM Build: https://github.com/standard-things/esm
 if (!argv.format || argv.format === 'es') {
     const esConfig = {
         ...baseConfig,
@@ -197,7 +203,7 @@ if (!argv.format || argv.format === 'es') {
         output: {
             ...esConfig.output,
             compact: true,
-            file: packageJSON.module,
+            file: moduleFileName,
         },
         plugins: [
             ...esConfig.plugins,
@@ -213,18 +219,18 @@ if (!argv.format || argv.format === 'es') {
         ...esConfig,
         output: {
             ...esConfig.output,
-            file: packageJSON.module.replace('min.', ''),
+            file: moduleFileName.module.replace('min.', ''),
         },
     });
 }
 
+// CommonJS Build: https://requirejs.org/docs/commonjs.html
 if (!argv.format || argv.format === 'cjs') {
     const cjsConfig = {
         ...baseConfig,
         external,
         output: {
             ...baseConfig.output,
-            file: packageJSON.main,
             format: 'cjs',
             globals,
         },
@@ -249,7 +255,7 @@ if (!argv.format || argv.format === 'cjs') {
         output: {
             ...cjsConfig.output,
             compact: true,
-            file: packageJSON.main,
+            file: mainFileName,
         },
         plugins: [
             ...cjsConfig.plugins,
@@ -265,7 +271,7 @@ if (!argv.format || argv.format === 'cjs') {
         ...cjsConfig,
         output: {
             ...cjsConfig.output,
-            file: packageJSON.main.replace('min.', ''),
+            file: mainFileName.replace('min.', ''),
         },
     });
 }

--- a/es-vue-base/build/rollup.config.js
+++ b/es-vue-base/build/rollup.config.js
@@ -161,7 +161,7 @@ if (!argv.format || argv.format === 'umd') {
         ...umdConfig,
         output: {
             ...umdConfig.output,
-            file: browserFileName.browser.replace('min.', ''),
+            file: browserFileName.replace('min.', ''),
         },
     });
 }
@@ -219,7 +219,7 @@ if (!argv.format || argv.format === 'es') {
         ...esConfig,
         output: {
             ...esConfig.output,
-            file: moduleFileName.module.replace('min.', ''),
+            file: moduleFileName.replace('min.', ''),
         },
     });
 }

--- a/es-vue-base/package-lock.json
+++ b/es-vue-base/package-lock.json
@@ -19,6 +19,7 @@
         "@rollup/plugin-image": "^3.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-replace": "^5.0.0",
+        "@rollup/plugin-terser": "^0.4.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@vue/babel-preset-app": "^5.0.8",
         "@vue/test-utils": "^1.3.0",
@@ -51,7 +52,6 @@
         "prettier-eslint": "^15.0.1",
         "rimraf": "^3.0.2",
         "rollup": "^2.52.8",
-        "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-visualizer": "^5.7.1",
         "rollup-plugin-vue": "^5.1.9",
         "stylelint": "^14.16.1",
@@ -3137,6 +3137,37 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
+      "dev": true,
+      "dependencies": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x || ^3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -12674,56 +12705,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.0.tgz",
@@ -12917,15 +12898,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13036,6 +13008,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
       "dev": true
     },
     "node_modules/source-map": {
@@ -13693,9 +13671,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -17000,6 +16978,28 @@
           "dev": true,
           "requires": {
             "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+      "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
+      "dev": true,
+      "requires": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+          "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         }
       }
@@ -24305,46 +24305,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "rollup-plugin-visualizer": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.0.tgz",
@@ -24485,15 +24445,6 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
-    "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -24580,6 +24531,12 @@
           "dev": true
         }
       }
+    },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -25091,9 +25048,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -18,8 +18,8 @@
   },
   "main": "dist/es-vue-base.cjs.js",
   "module": "dist/es-vue-base.esm.js",
-  "browser": "dist/es-vue-base.umd.js",
-  "unpkg": "dist/es-vue-base.min.js",
+  "browser": "dist/es-vue-base.umd.min.js",
+  "unpkg": "dist/es-vue-base.umd.min.js",
   "files": [
     "dist",
     "src"

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -16,8 +16,8 @@
     "lint:style": "stylelint \"**/*.{scss,sass,vue}\" --ignore-path ../.gitignore",
     "lintfix": "npm run lint:js -- --fix && npm run lint:style -- --fix"
   },
-  "main": "dist/es-vue-base.cjs.js",
-  "module": "dist/es-vue-base.esm.js",
+  "main": "dist/es-vue-base.cjs.min.js",
+  "module": "dist/es-vue-base.esm.min.js",
   "browser": "dist/es-vue-base.umd.min.js",
   "unpkg": "dist/es-vue-base.umd.min.js",
   "files": [

--- a/es-vue-base/package.json
+++ b/es-vue-base/package.json
@@ -16,9 +16,9 @@
     "lint:style": "stylelint \"**/*.{scss,sass,vue}\" --ignore-path ../.gitignore",
     "lintfix": "npm run lint:js -- --fix && npm run lint:style -- --fix"
   },
-  "main": "dist/es-vue-base.ssr.js",
+  "main": "dist/es-vue-base.cjs.js",
   "module": "dist/es-vue-base.esm.js",
-  "browser": "dist/es-vue-base.esm.js",
+  "browser": "dist/es-vue-base.umd.js",
   "unpkg": "dist/es-vue-base.min.js",
   "files": [
     "dist",
@@ -36,6 +36,7 @@
     "@rollup/plugin-image": "^3.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-replace": "^5.0.0",
+    "@rollup/plugin-terser": "^0.4.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@vue/babel-preset-app": "^5.0.8",
     "@vue/test-utils": "^1.3.0",
@@ -68,7 +69,6 @@
     "prettier-eslint": "^15.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.52.8",
-    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.7.1",
     "rollup-plugin-vue": "^5.1.9",
     "stylelint": "^14.16.1",

--- a/es-vue-base/src/lib-components/EsSlider.vue
+++ b/es-vue-base/src/lib-components/EsSlider.vue
@@ -1,36 +1,38 @@
 <template>
-    <vue-slider
-        v-model="sliderValue"
-        class="es-slider"
-        :data="data"
-        :marks="marks"
-        :min="min"
-        :max="max"
-        :dot-size="28"
-        :dot-attrs="{ 'aria-label': ariaLabel }"
-        :tooltip="tooltip"
-        lazy
-        :contained="true"
-        @change="updateSliderValue">
-        <!-- Tooltip above the slider thumb -->
-        <template #tooltip="{ value, focus }">
-            <div
-                class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary"
-                :class="[{ focus }]">
-                {{ tooltipFormatter(value) }}
-            </div>
-        </template>
-        <!-- Labels below the process bar -->
-        <template #label="{ label, active }">
-            <div :class="['slider-label', 'vue-slider-mark-label', { active }]">
-                {{ label }}
-            </div>
-        </template>
-    </vue-slider>
+    <client-only>
+        <vue-slider
+            v-model="sliderValue"
+            class="es-slider"
+            :data="data"
+            :marks="marks"
+            :min="min"
+            :max="max"
+            :dot-size="28"
+            :dot-attrs="{ 'aria-label': ariaLabel }"
+            :tooltip="tooltip"
+            lazy
+            :contained="true"
+            @change="updateSliderValue">
+            <!-- Tooltip above the slider thumb -->
+            <template #tooltip="{ value, focus }">
+                <div
+                    class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary"
+                    :class="[{ focus }]">
+                    {{ tooltipFormatter(value) }}
+                </div>
+            </template>
+            <!-- Labels below the process bar -->
+            <template #label="{ label, active }">
+                <div :class="['slider-label', 'vue-slider-mark-label', { active }]">
+                    {{ label }}
+                </div>
+            </template>
+        </vue-slider>
+    </client-only>
 </template>
 
 <script lang="js">
-import vueSlider from 'vue-slider-component';
+import vueSlider from 'vue-slider-component/dist-css/vue-slider-component.common';
 
 export default {
     name: 'EsSlider',

--- a/es-vue-base/src/lib-components/EsSlider.vue
+++ b/es-vue-base/src/lib-components/EsSlider.vue
@@ -11,7 +11,9 @@
             :dot-attrs="{ 'aria-label': ariaLabel }"
             :tooltip="tooltip"
             lazy
+            v-bind="$attrs"
             :contained="true"
+            v-on="$listeners"
             @change="updateSliderValue">
             <!-- Tooltip above the slider thumb -->
             <template #tooltip="{ value, focus }">

--- a/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
@@ -7,82 +7,90 @@ exports[`EsSlider <EsSlider
             :min="100"
             :max="500"
             ariaLabel="Select a number" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="100" max="500">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks">
-      <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
-        <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
-        <div class="slider-label vue-slider-mark-label active">
-          100
+"<client-only min="100" max="500">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks">
+        <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
+          <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
+          <div class="slider-label vue-slider-mark-label active">
+            100
+          </div>
+        </div>
+        <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
+          <div class="vue-slider-mark-step"></div>
+          <div class="slider-label vue-slider-mark-label">
+            500
+          </div>
         </div>
       </div>
-      <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
-        <div class="vue-slider-mark-step"></div>
-        <div class="slider-label vue-slider-mark-label">
-          500
-        </div>
-      </div>
-    </div>
-    <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          300
+      <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            300
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>"
+</client-only>"
 `;
 
 exports[`EsSlider <EsSlider /> tooltipFormatter works 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          $50
+"<client-only min="0" max="100">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            $50
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>"
+</client-only>"
 `;
 
 exports[`EsSlider <EsSlider :startingValue="50" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          50
+"<client-only min="0" max="100">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            50
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>"
+</client-only>"
 `;
 
 exports[`EsSlider <EsSlider variant="secondary" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100" variant="secondary">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          50
+"<client-only min="0" max="100" variant="secondary">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            50
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>"
+</client-only>"
 `;

--- a/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
@@ -7,90 +7,82 @@ exports[`EsSlider <EsSlider
             :min="100"
             :max="500"
             ariaLabel="Select a number" /> 1`] = `
-"<client-only min="100" max="500">
-  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
-    <div class="vue-slider-rail">
-      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
-      <div class="vue-slider-marks">
-        <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
-          <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
-          <div class="slider-label vue-slider-mark-label active">
-            100
-          </div>
-        </div>
-        <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
-          <div class="vue-slider-mark-step"></div>
-          <div class="slider-label vue-slider-mark-label">
-            500
-          </div>
+"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="100" max="500">
+  <div class="vue-slider-rail">
+    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
+    <div class="vue-slider-marks">
+      <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
+        <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
+        <div class="slider-label vue-slider-mark-label active">
+          100
         </div>
       </div>
-      <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
-        <div class="vue-slider-dot-handle"></div>
-        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-            300
-          </div>
+      <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
+        <div class="vue-slider-mark-step"></div>
+        <div class="slider-label vue-slider-mark-label">
+          500
+        </div>
+      </div>
+    </div>
+    <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
+      <div class="vue-slider-dot-handle"></div>
+      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+          300
         </div>
       </div>
     </div>
   </div>
-</client-only>"
+</div>"
 `;
 
 exports[`EsSlider <EsSlider /> tooltipFormatter works 1`] = `
-"<client-only min="0" max="100">
-  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
-    <div class="vue-slider-rail">
-      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-      <div class="vue-slider-marks"></div>
-      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-        <div class="vue-slider-dot-handle"></div>
-        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-            $50
-          </div>
+"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
+  <div class="vue-slider-rail">
+    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+    <div class="vue-slider-marks"></div>
+    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+      <div class="vue-slider-dot-handle"></div>
+      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+          $50
         </div>
       </div>
     </div>
   </div>
-</client-only>"
+</div>"
 `;
 
 exports[`EsSlider <EsSlider :startingValue="50" /> 1`] = `
-"<client-only min="0" max="100">
-  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
-    <div class="vue-slider-rail">
-      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-      <div class="vue-slider-marks"></div>
-      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-        <div class="vue-slider-dot-handle"></div>
-        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-            50
-          </div>
+"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
+  <div class="vue-slider-rail">
+    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+    <div class="vue-slider-marks"></div>
+    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+      <div class="vue-slider-dot-handle"></div>
+      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+          50
         </div>
       </div>
     </div>
   </div>
-</client-only>"
+</div>"
 `;
 
 exports[`EsSlider <EsSlider variant="secondary" /> 1`] = `
-"<client-only min="0" max="100" variant="secondary">
-  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
-    <div class="vue-slider-rail">
-      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-      <div class="vue-slider-marks"></div>
-      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-        <div class="vue-slider-dot-handle"></div>
-        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-            50
-          </div>
+"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" variant="secondary" min="0" max="100">
+  <div class="vue-slider-rail">
+    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+    <div class="vue-slider-marks"></div>
+    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+      <div class="vue-slider-dot-handle"></div>
+      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+          50
         </div>
       </div>
     </div>
   </div>
-</client-only>"
+</div>"
 `;

--- a/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsSlider.spec.js.snap
@@ -7,28 +7,30 @@ exports[`EsSlider <EsSlider
             :min="100"
             :max="500"
             ariaLabel="Select a number" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="100" max="500">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks">
-      <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
-        <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
-        <div class="slider-label vue-slider-mark-label active">
-          100
+"<div min="100" max="500">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 50%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks">
+        <div class="vue-slider-mark vue-slider-mark-active" style="height: 100%; width: 4px; left: 0%;">
+          <div class="vue-slider-mark-step vue-slider-mark-step-active"></div>
+          <div class="slider-label vue-slider-mark-label active">
+            100
+          </div>
+        </div>
+        <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
+          <div class="vue-slider-mark-step"></div>
+          <div class="slider-label vue-slider-mark-label">
+            500
+          </div>
         </div>
       </div>
-      <div class="vue-slider-mark" style="height: 100%; width: 4px; left: 100%;">
-        <div class="vue-slider-mark-step"></div>
-        <div class="slider-label vue-slider-mark-label">
-          500
-        </div>
-      </div>
-    </div>
-    <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          300
+      <div aria-valuetext="300" class="vue-slider-dot" role="slider" aria-valuenow="300" aria-valuemin="100" aria-valuemax="500" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 50%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            300
+          </div>
         </div>
       </div>
     </div>
@@ -37,15 +39,17 @@ exports[`EsSlider <EsSlider
 `;
 
 exports[`EsSlider <EsSlider /> tooltipFormatter works 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          $50
+"<div min="0" max="100">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            $50
+          </div>
         </div>
       </div>
     </div>
@@ -54,15 +58,17 @@ exports[`EsSlider <EsSlider /> tooltipFormatter works 1`] = `
 `;
 
 exports[`EsSlider <EsSlider :startingValue="50" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" min="0" max="100">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          50
+"<div min="0" max="100">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            50
+          </div>
         </div>
       </div>
     </div>
@@ -71,15 +77,17 @@ exports[`EsSlider <EsSlider :startingValue="50" /> 1`] = `
 `;
 
 exports[`EsSlider <EsSlider variant="secondary" /> 1`] = `
-"<div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" variant="secondary" min="0" max="100">
-  <div class="vue-slider-rail">
-    <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
-    <div class="vue-slider-marks"></div>
-    <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
-      <div class="vue-slider-dot-handle"></div>
-      <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
-        <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
-          50
+"<div min="0" max="100" variant="secondary">
+  <div class="es-slider vue-slider vue-slider-ltr" style="padding: 14px 14px; width: auto; height: 4px;" variant="secondary">
+    <div class="vue-slider-rail">
+      <div class="vue-slider-process" style="height: 100%; top: 0px; left: 0%; width: 100%; transition-property: width,left; transition-duration: 0.5s;"></div>
+      <div class="vue-slider-marks"></div>
+      <div aria-valuetext="50" class="vue-slider-dot" role="slider" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" aria-orientation="horizontal" tabindex="0" aria-label="Select a number" style="width: 28px; height: 28px; transform: translate(-50%, -50%); top: 50%; left: 100%; transition: left 0.5s;">
+        <div class="vue-slider-dot-handle"></div>
+        <div class="vue-slider-dot-tooltip vue-slider-dot-tooltip-top vue-slider-dot-tooltip-show">
+          <div class="slider-tooltip d-flex h5 align-items-center text-white justify-content-center m-0 bg-primary">
+            50
+          </div>
         </div>
       </div>
     </div>

--- a/es-vue-base/tests/jest.setup.js
+++ b/es-vue-base/tests/jest.setup.js
@@ -1,4 +1,5 @@
 import * as matchers from 'jest-extended';
+import { config } from '@vue/test-utils';
 import { toHaveNoViolations } from 'jest-axe';
 import '@testing-library/jest-dom';
 
@@ -19,3 +20,7 @@ window.matchMedia = jest.fn().mockImplementation((query) => ({
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
 }));
+
+config.stubs['client-only'] = {
+    template: '<div><slot /></div>',
+};


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Update `es-design-system` to use `ssr` during development. This will help ensure components are SSR compatible
- Added conditional checks for `$prism` which is client only; ***this is most of the diff***
- Replaced `rollup-terser-plugin`; now deprecated, with `@rollup/plugin-terser`
- Moved `EsSlider` to `client-only`. `vue-slider-component` does not play well with SSR
- Updated `rollup.config.js` for `es-vue-base`
  - Switch to using minified versions by default
  - Added sourcemaps & unminified versions
  - `cjs` is now `main` and `optimizeSSR` is applied to vue components
  - Removed `iife` build in favor of `umd` only

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Manual, visual and running test builds

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [X] I have documented testing approach
