### PR TITLE
add utility classes and examples for loading button

### DIFF
--- a/es-bs-base/scss/_forms.scss
+++ b/es-bs-base/scss/_forms.scss
@@ -345,3 +345,9 @@ textarea.form-control {
     }
   }
 }
+
+// NOTE: this loading UI is subject to change
+.form-actions__button-spinner {
+  right: 0;
+  top: -1.4em;
+}

--- a/es-bs-base/scss/_forms.scss
+++ b/es-bs-base/scss/_forms.scss
@@ -345,11 +345,3 @@ textarea.form-control {
     }
   }
 }
-
-/* stylelint-disable selector-class-pattern */
-// NOTE: this loading UI is subject to change
-.form-actions__button-spinner {
-  top: -1.4em;
-  right: 0;
-}
-/* stylelint-enable */

--- a/es-bs-base/scss/_forms.scss
+++ b/es-bs-base/scss/_forms.scss
@@ -346,8 +346,10 @@ textarea.form-control {
   }
 }
 
+/* stylelint-disable selector-class-pattern */
 // NOTE: this loading UI is subject to change
 .form-actions__button-spinner {
-  right: 0;
   top: -1.4em;
+  right: 0;
 }
+/* stylelint-enable */

--- a/es-bs-base/scss/utilities/_sizing.scss
+++ b/es-bs-base/scss/utilities/_sizing.scss
@@ -33,7 +33,7 @@
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
     // Add min-width (in rem) utilities, especially useful for buttons
     @for $i from 4 through 7 {
-      .min-width#{$infix}-#{$i} { width: #{$i}em !important; }
+      .min-width#{$infix}-#{$i} { width: $i * 1em !important; }
     }
   }
 }

--- a/es-bs-base/scss/utilities/_sizing.scss
+++ b/es-bs-base/scss/utilities/_sizing.scss
@@ -33,7 +33,7 @@
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
     // Add min-width (in rem) utilities, especially useful for buttons
     @for $i from 4 through 7 {
-      .min-width#{$infix}-#{$i} { width: $i * 1em !important; }
+      .min-width#{$infix}-#{$i} { min-width: $i * 1em !important; }
     }
   }
 }

--- a/es-bs-base/scss/utilities/_sizing.scss
+++ b/es-bs-base/scss/utilities/_sizing.scss
@@ -18,3 +18,22 @@
 
 .vw-100 { width: 100vw !important; }
 .vh-100 { height: 100vh !important; }
+
+// Width Auto Utils
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    .w#{$infix}-auto { width: auto !important; }
+  }
+}
+
+// Min-width EM utils
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    // Add min-width (in rem) utilities, especially useful for buttons
+    @for $i from 4 through 7 {
+      .min-width#{$infix}-#{$i} { width: #{$i}em !important; }
+    }
+  }
+}

--- a/es-design-system/components/ds-examples-list.vue
+++ b/es-design-system/components/ds-examples-list.vue
@@ -1,8 +1,13 @@
 <template>
     <ul>
         <li>
-            <b-link :to="{ name: 'examples-form-with-validation___en' }">
-                Form with Validation
+            <b-link :to="{ name: 'examples-form-field-validation___en' }">
+                Form with Field Validation
+            </b-link>
+        </li>
+        <li>
+            <b-link :to="{ name: 'examples-form-validation___en' }">
+                Form with (form level) Validation
             </b-link>
         </li>
     </ul>

--- a/es-design-system/pages/examples/form-field-validation.vue
+++ b/es-design-system/pages/examples/form-field-validation.vue
@@ -99,7 +99,6 @@
                         <es-button
                             type="submit"
                             class="w-100 w-lg-auto"
-                            :loading="isSubmitInProgress"
                             :disabled="isSubmitInProgress">
                             <span class="position-relative d-inline-block w-100">
                                 <span

--- a/es-design-system/pages/examples/form-field-validation.vue
+++ b/es-design-system/pages/examples/form-field-validation.vue
@@ -106,7 +106,6 @@
                                     class="form-actions__button-spinner position-absolute d-inline-block h-100 w-100">
                                     <b-spinner
                                         role="status"
-                                        aria-hidden="true"
                                         label="Loading" />
                                 </span>
                                 <span

--- a/es-design-system/pages/examples/form-field-validation.vue
+++ b/es-design-system/pages/examples/form-field-validation.vue
@@ -3,7 +3,7 @@
         <b-row>
             <b-col>
                 <h1>
-                    Form with Validation
+                    Form with Field Validation
                 </h1>
                 <h2>
                     UX Guidelines
@@ -16,6 +16,13 @@
                         </li>
                         <li>
                             Validation for password fields should always trigger <em>on input-change</em>
+                        </li>
+                        <li>
+                            In practice you'll likely also want to include form-level validation,
+                            and provide feedback from a server response. In this case see the
+                            <b-link :to="{ name: 'examples-form-validation___en' }">
+                                Form with (form level) Validation
+                            </b-link> example.
                         </li>
                     </ul>
                 </p>
@@ -88,11 +95,6 @@
                             Notes
                         </template>
                     </es-form-textarea>
-                    <es-form-msg
-                        class="mt-3"
-                        :variant="formMsgVariant"
-                        :message="formMsg"
-                        @hidden="formMsg = ''" />
                     <div class="d-flex flex-grow-1 justify-content-end mt-3">
                         <es-button
                             type="submit"
@@ -102,13 +104,16 @@
                             <span class="position-relative d-inline-block w-100">
                                 <span
                                     v-if="isSubmitInProgress"
-                                    class="button-spinner position-absolute d-inline-block h-100 w-100">
+                                    class="form-actions__button-spinner position-absolute d-inline-block h-100 w-100">
                                     <b-spinner
                                         role="status"
                                         aria-hidden="true"
                                         label="Loading" />
                                 </span>
-                                Submit
+                                <span
+                                    :class="{'sr-only': isSubmitInProgress }">
+                                    Submit
+                                </span>
                             </span>
                         </es-button>
                     </div>
@@ -123,7 +128,6 @@ import {
     EsFormInput,
     EsFormTextarea,
     EsButton,
-    EsFormMsg,
     formMixins,
     vuelidateKeys,
     vuelidateRequired,
@@ -139,7 +143,6 @@ import {
 export default {
     name: 'EsFormDocs',
     components: {
-        EsFormMsg,
         EsFormInput,
         EsFormTextarea,
         EsButton,
@@ -182,16 +185,10 @@ export default {
         },
     },
     methods: {
-        async fakeServerRequest(isSuccess = false) {
+        async fakeServerRequest() {
             const threeSecondTimeout = async (func) => setTimeout(func, 3000);
-            await threeSecondTimeout(() => {
-                if (isSuccess) {
-                    this.showFormSuccess();
-                } else {
-                    this.showFormError();
-                }
-            });
-            this.startSubmit();
+            // eslint-disable-next-line no-console
+            await threeSecondTimeout(() => console.log('Submit Complete'));
         },
         async onSubmit() {
             this.startSubmit();

--- a/es-design-system/pages/examples/form-validation.vue
+++ b/es-design-system/pages/examples/form-validation.vue
@@ -34,9 +34,6 @@
             <b-col
                 cols="12"
                 lg="8">
-                <pre>
-                    isSubmitInProgress: {{ isSubmitInProgress }}
-                </pre>
                 <b-form
                     @submit.stop.prevent="onSubmit">
                     <es-form-msg

--- a/es-design-system/pages/examples/form-validation.vue
+++ b/es-design-system/pages/examples/form-validation.vue
@@ -54,7 +54,6 @@
                         <es-button
                             type="submit"
                             class="w-100 w-lg-auto"
-                            :loading="isSubmitInProgress"
                             :disabled="isSubmitInProgress">
                             <span class="w-100 min-width-6">
                                 <span

--- a/es-design-system/pages/examples/form-validation.vue
+++ b/es-design-system/pages/examples/form-validation.vue
@@ -1,0 +1,128 @@
+<template>
+    <b-container>
+        <b-row>
+            <b-col>
+                <h1>
+                    Form with (form level) Validation
+                </h1>
+                <p>
+                    See
+                    <b-link
+                        :to="{ name: 'examples-form-field-validation___en' }">
+                        Form Field Validation
+                    </b-link> for field level validation example
+                </p>
+                <h2>
+                    UX Guidelines
+                </h2>
+                <p>
+                    <ul>
+                        <li>
+                            Show loading spinner on button during server request
+                        </li>
+                        <li>
+                            Use <b-link :to="{ name: 'molecules-es-form-msg___en' }">
+                                EsFormMsg
+                            </b-link>
+                            for displaying of server-side form-level errors
+                        </li>
+                    </ul>
+                </p>
+            </b-col>
+        </b-row>
+        <b-row class="border-top pt-4 my-2">
+            <b-col
+                cols="12"
+                lg="8">
+                <pre>
+                    isSubmitInProgress: {{ isSubmitInProgress }}
+                </pre>
+                <b-form
+                    @submit.stop.prevent="onSubmit">
+                    <es-form-msg
+                        class="mt-3"
+                        :variant="formMsgVariant"
+                        :message="formMsg"
+                        @hidden="formMsg = ''" />
+                    <es-form-input
+                        id="form-input-name"
+                        v-model="form.name"
+                        :disabled="isSubmitInProgress"
+                        required>
+                        <template #label>
+                            Name
+                        </template>
+                    </es-form-input>
+                    <div class="d-flex flex-grow-1 justify-content-end mt-3">
+                        <es-button
+                            type="submit"
+                            class="w-100 w-lg-auto"
+                            :loading="isSubmitInProgress"
+                            :disabled="isSubmitInProgress">
+                            <span class="position-relative d-inline-block w-100 min-width-6">
+                                <span
+                                    v-if="isSubmitInProgress"
+                                    class="form-actions__button-spinner position-absolute d-inline-block h-100 w-100">
+                                    <b-spinner
+                                        role="status"
+                                        aria-hidden="true"
+                                        label="Loading" />
+                                </span>
+                                <span
+                                    :class="{'sr-only': isSubmitInProgress }">
+                                    Submit
+                                </span>
+                            </span>
+                        </es-button>
+                    </div>
+                </b-form>
+            </b-col>
+        </b-row>
+    </b-container>
+</template>
+
+<script>
+import {
+    EsFormInput,
+    EsButton,
+    EsFormMsg,
+    formMixins,
+} from '@energysage/es-vue-base';
+
+export default {
+    name: 'EsFormDocs',
+    components: {
+        EsFormMsg,
+        EsFormInput,
+        EsButton,
+    },
+    mixins: [formMixins],
+    data() {
+        return {
+            form: {
+                name: '',
+            },
+        };
+    },
+    methods: {
+        async asyncTimeout(seconds = 3) {
+            const millisecondTimeout = seconds * 1000;
+            return new Promise((resolve) => {
+                setTimeout(resolve, millisecondTimeout);
+            });
+        },
+        /**
+        * Simulate a request to a server
+        */
+        async fakeServerRequest() {
+            await this.asyncTimeout();
+            this.showFormError(); // This method via formMixins
+        },
+        async onSubmit() {
+            this.startSubmit(); // This method via formMixins, will set this.submitInProgress to true
+            await this.fakeServerRequest();
+            this.stopSubmit(); // This method via formMixins, will set this.submitInProgress to false
+        },
+    },
+};
+</script>

--- a/es-design-system/pages/examples/form-validation.vue
+++ b/es-design-system/pages/examples/form-validation.vue
@@ -56,10 +56,9 @@
                             class="w-100 w-lg-auto"
                             :loading="isSubmitInProgress"
                             :disabled="isSubmitInProgress">
-                            <span class="position-relative d-inline-block w-100 min-width-6">
+                            <span class="w-100 min-width-6">
                                 <span
-                                    v-if="isSubmitInProgress"
-                                    class="form-actions__button-spinner position-absolute d-inline-block h-100 w-100">
+                                    v-if="isSubmitInProgress">
                                     <b-spinner
                                         role="status"
                                         aria-hidden="true"

--- a/es-design-system/pages/examples/form-validation.vue
+++ b/es-design-system/pages/examples/form-validation.vue
@@ -60,7 +60,6 @@
                                     v-if="isSubmitInProgress">
                                     <b-spinner
                                         role="status"
-                                        aria-hidden="true"
                                         label="Loading" />
                                 </span>
                                 <span

--- a/es-design-system/pages/organisms/es-form.vue
+++ b/es-design-system/pages/organisms/es-form.vue
@@ -91,7 +91,6 @@
                                     class="button-spinner position-absolute d-inline-block h-100 w-100">
                                     <b-spinner
                                         role="status"
-                                        aria-hidden="true"
                                         label="Loading" />
                                 </span>
                                 Submit

--- a/es-design-system/pages/organisms/es-form.vue
+++ b/es-design-system/pages/organisms/es-form.vue
@@ -84,7 +84,6 @@
                         <es-button
                             type="submit"
                             class="w-100 w-lg-auto"
-                            :loading="isSubmitInProgress"
                             :disabled="isSubmitInProgress">
                             <span class="position-relative d-inline-block w-100">
                                 <span

--- a/es-vue-base/src/lib-mixins/forms.js
+++ b/es-vue-base/src/lib-mixins/forms.js
@@ -53,10 +53,19 @@ export default {
         * }
         */
         formErrors() {
-            if (!Object.prototype.hasOwnProperty.call(this.$v, 'form')) {
+            let hasFormAttribute = false;
+            try {
+                hasFormAttribute = Object.prototype.hasOwnProperty.call(this.$v, 'form');
+            } catch (e) {
+                return {};
+            }
+            if (!hasFormAttribute) {
                 return {};
             }
             const formFields = this.getFields(this.$v.form);
+            if (!formFields.length) {
+                return {};
+            }
             const formFieldErrors = formFields.reduce((formObj, item) => {
                 // eslint-disable-next-line no-param-reassign
                 formObj[item.name] = this.getFields(item.obj, 'isValid')
@@ -130,7 +139,13 @@ export default {
             this.submitInProgress = false;
         },
         getFields(obj, valueKey = 'obj') {
-            return Object.keys(obj)
+            let objKeys = null;
+            try {
+                objKeys = Object.keys(obj);
+            } catch (e) {
+                return [];
+            }
+            return objKeys
                 .filter((name) => !name.startsWith('$'))
                 .map((name) => ({ name, [valueKey]: obj[name] }));
         },


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->
*More details in inline-comments*

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/wiki/spaces/DS/pages/198311937/2023-01-31+Loading+UI+User+feedback+for+long-running+requests+Upcoming

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added min-width `em` based utility classes (the spinner can go beyond the width of a button if it's width is auto)
- Added width-auto utility classes (previously this was scoped style in a component example)
- Split form validation into two pages, so each are more focused on a particular feature

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- manual (in chrome)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have documented testing approach
