### PR TITLE
fix: add hover state to EsFormRadioCard

### DIFF
--- a/es-vue-base/src/lib-components/EsFormRadioCard.vue
+++ b/es-vue-base/src/lib-components/EsFormRadioCard.vue
@@ -64,6 +64,9 @@ export default {
     &:hover {
         /* needed to override the default background/text color switch for outline button hover state */
         background-color: $white;
+        /* match design border color on hover, override utility class */
+        border-color: $gray-400 !important;
+        /* needed to override the default background/text color switch for outline button hover state */
         color: $dark;
     }
 


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-110

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- I found a hover state built out in a design and decided to better match the interactivity of EsButton (from which EsFormRadioCard borrows styles) by implementing the hover state, vs. having none

#### Hover state shown on second card
<img width="1177" alt="Screen Shot 2023-02-07 at 4 09 53 PM" src="https://user-images.githubusercontent.com/1350363/217366205-01a15753-8b8d-4166-9fc2-42a50ce071c6.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Hovered the radio card

### 📝 Checklist
<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
