### PR TITLE
fix: internal layout of mobile radio cards custom styling example

### DIFF
--- a/es-design-system/pages/molecules/es-form-radio-cards.vue
+++ b/es-design-system/pages/molecules/es-form-radio-cards.vue
@@ -54,7 +54,7 @@
                             cols="12"
                             lg="4">
                             <es-form-radio-card
-                                class="align-items-center d-lg-flex flex-column font-size-base font-weight-normal line-height-base p-3 p-lg-4 text-lg-center"
+                                class="align-items-center d-block d-lg-flex flex-column font-size-base font-weight-normal line-height-base p-3 p-lg-4 text-lg-center"
                                 :value="option.value">
                                 <component
                                     :is="option.icon"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-110

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Radio cards documentation was initially developed before the recent EsButton changes were merged in, so the mobile layout inside the "Custom card styling" example cards was assuming a button display of `block` or `inline-block`. With the new EsButton changes, default display for buttons updated to `inline-flex`, so some of the desktop-targeted flex styles like `flex-column` began applying on mobile unintentionally. This PR explicitly sets mobile display to `block` for the intended layout.

(would display screenshots here but GitHub is currently having an issue uploading images)

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Viewed layout in Chrome responsive devtools on mobile size

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
