### PR TITLE
fix: button content is now centered by default

### DIFF
--- a/es-bs-base/scss/_buttons.scss
+++ b/es-bs-base/scss/_buttons.scss
@@ -11,6 +11,7 @@
   font-family: $btn-font-family;
   font-weight: $btn-font-weight;
   color: $body-color;
+  justify-content: center;
   text-align: center;
   text-decoration: if($link-decoration == none, null, none);
   white-space: $btn-white-space;

--- a/es-bs-base/scss/_buttons.scss
+++ b/es-bs-base/scss/_buttons.scss
@@ -7,11 +7,11 @@
 .btn {
   display: inline-flex;
   align-items: center; // aligns text and icons vertically by default
+  justify-content: center;
   height: $font-size-base * 3; // ensures consistent button height, matching the design, regardless of content
   font-family: $btn-font-family;
   font-weight: $btn-font-weight;
   color: $body-color;
-  justify-content: center;
   text-align: center;
   text-decoration: if($link-decoration == none, null, none);
   white-space: $btn-white-space;

--- a/es-design-system/pages/molecules/es-button.vue
+++ b/es-design-system/pages/molecules/es-button.vue
@@ -492,6 +492,19 @@
         </table>
 
         <h2>
+            Width change across breakpoints
+        </h2>
+        <p>
+            Often, designs will specify buttons to be full width on mobile and content width on desktop.
+            Below is an example of how to easily accomplish this.
+        </p>
+        <div class="mb-4">
+            <es-button class="w-100 w-lg-auto">
+                Responsive button
+            </es-button>
+        </div>
+
+        <h2>
             Deprecated Buttons (do not use)
         </h2>
         <p class="mb-4">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-123

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixed an issue where button content was not centered when the width is larger than the content
- Added an example to the EsButton docs page demonstrating the primary case where this occurs: when the button is full width on mobile but content width on desktop (also makes use of the new `w-lg-auto` utility class added recently)

#### Before
<img width="387" alt="Screen Shot 2023-02-22 at 2 52 27 PM" src="https://user-images.githubusercontent.com/1350363/220743597-8e3c903d-4912-4d33-8033-7cb4374e27d3.png">

#### After
<img width="387" alt="Screen Shot 2023-02-22 at 2 52 34 PM" src="https://user-images.githubusercontent.com/1350363/220743641-67b1a198-3869-4c1d-8e4f-a33820cfad2a.png">

#### Desktop view of new example
<img width="1193" alt="Screen Shot 2023-02-22 at 2 53 45 PM" src="https://user-images.githubusercontent.com/1350363/220743892-393fc9e1-079f-498a-9219-b9dff863117d.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Used Chrome responsive devtools to view full width button on mobile and content width button on desktop, tested before and after to see left-aligned content shift to center-aligned content

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
