### PR TITLE
feat: new labelSrOnly prop for EsFormInput

### DIFF
--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -247,10 +247,8 @@ export default {
     data() {
         return {
             form: {
-                docInput: 'Example text',
                 emailCorrect: 'hello@energysage.com',
                 emailWrong: 'hello@energy',
-                example2: 'Example two',
                 firstName: '',
                 password: '',
                 phoneNumber: '',

--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -116,7 +116,7 @@
                     md="6"
                     lg="4">
                     <es-form-input
-                        id="successExample"
+                        id="successMessageExample"
                         v-model="form.emailCorrect"
                         :state="true">
                         <template #label>

--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -16,53 +16,224 @@
                 Sentence case.
             </b-link>
         </p>
-        <b-row class="my-5">
-            <b-col
-                cols="12"
-                lg="6">
-                <es-form-input
-                    id="myId"
-                    v-model="docInput">
-                    <template #label>
-                        Account number
-                    </template>
-                    <template #message>
-                        Please enter your account number.
-                    </template>
-                    <template #errorMessage>
-                        Please enter a valid account number.
-                    </template>
-                    <template #successMessage>
-                        Your account number has been submitted successfully.
-                    </template>
-                </es-form-input>
-            </b-col>
-        </b-row>
-        <b-row class="mt-4">
-            <b-col
-                cols="12"
-                lg="6">
-                <es-form-input
-                    id="myId2"
-                    v-model="example2">
-                    <template #label>
-                        Account Number
-                    </template>
-                    <template #extraContext>
-                        Extra Context Goes Here
-                    </template>
-                    <template #message>
-                        Please enter your account number.
-                    </template>
-                    <template #errorMessage>
-                        Please enter a valid account number.
-                    </template>
-                    <template #successMessage>
-                        Your account number has been submitted successfully.
-                    </template>
-                </es-form-input>
-            </b-col>
-        </b-row>
+
+        <div class="my-5">
+            <h2>
+                Basic example
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="basicExample"
+                        v-model="form.firstName">
+                        <template #label>
+                            First name
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Required
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="requiredExample"
+                        v-model="form.firstName"
+                        required>
+                        <template #label>
+                            First name
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Error state
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="errorExample"
+                        v-model="form.emailWrong"
+                        :state="false">
+                        <template #label>
+                            Email address
+                        </template>
+                        <template #errorMessage>
+                            Please enter a valid email address.
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Success state
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="successExample"
+                        v-model="form.emailCorrect"
+                        :state="true">
+                        <template #label>
+                            Email address
+                        </template>
+                        <template #errorMessage>
+                            Please enter a valid email address.
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Success state with message
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="successExample"
+                        v-model="form.emailCorrect"
+                        :state="true">
+                        <template #label>
+                            Email address
+                        </template>
+                        <template #errorMessage>
+                            Please enter a valid email address.
+                        </template>
+                        <template #successMessage>
+                            Your email address has been entered successfully.
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Placeholder
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="placeholderExample"
+                        v-model="form.phoneNumber"
+                        placeholder="(XXX) XXX-XXXX">
+                        <template #label>
+                            Phone number
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Hidden label
+            </h2>
+            <p>
+                In rare cases (e.g. a call-to-action banner on a marketing page), it is desirable
+                to visually hide the input label and use the placeholder text to label the input.
+                Below is an example of how to accomplish this.
+            </p>
+            <b-row>
+                <b-col
+                    class="d-lg-flex"
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="hiddenLabelExample"
+                        v-model="form.zipCode"
+                        class="flex-grow-1"
+                        placeholder="ZIP code"
+                        label-sr-only>
+                        <template #label>
+                            ZIP code
+                        </template>
+                    </es-form-input>
+                    <es-button class="ml-lg-2 w-100 w-lg-auto">
+                        Submit
+                    </es-button>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Context message above the field
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="contextAboveExample"
+                        v-model="form.password"
+                        type="password">
+                        <template #extraContext>
+                            Your password should be hard to guess.
+                        </template>
+                        <template #label>
+                            Password
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Context message below the field
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="contextAboveExample"
+                        v-model="form.password"
+                        type="password">
+                        <template #message>
+                            Your password should be hard to guess.
+                        </template>
+                        <template #label>
+                            Password
+                        </template>
+                    </es-form-input>
+                </b-col>
+            </b-row>
+        </div>
+
         <ds-doc-source
             :comp-code="compCode"
             comp-source="es-vue-base/src/lib-components/EsFormInput.vue"
@@ -75,8 +246,16 @@ export default {
     name: 'EsFormInputDocs',
     data() {
         return {
-            docInput: 'Example text',
-            example2: 'Example two',
+            form: {
+                docInput: 'Example text',
+                emailCorrect: 'hello@energysage.com',
+                emailWrong: 'hello@energy',
+                example2: 'Example two',
+                firstName: '',
+                password: '',
+                phoneNumber: '',
+                zipCode: '',
+            },
             compCode: '',
             docCode: '',
         };

--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -220,7 +220,7 @@
                     md="6"
                     lg="4">
                     <es-form-input
-                        id="contextAboveExample"
+                        id="contextBelowExample"
                         v-model="form.password"
                         type="password">
                         <template #message>

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -5,7 +5,8 @@
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
             :for="id"
-            class="label font-weight-semibold justify-content-start">
+            class="label font-weight-semibold justify-content-start"
+            :class="{ 'sr-only': labelSrOnly }">
             <slot name="label" />
             <span
                 v-if="required"
@@ -116,6 +117,10 @@ export default {
             type: Boolean,
             default: false,
             required: false,
+        },
+        labelSrOnly: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-127

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added a `labelSrOnly` prop to EsFormInput for cases where the form consists of only an input and a submit button within a stylized marketing section like a hero or a CTA banner, and the placeholder text is used as the label for visual users.
- Simplified and broadened the number of examples on the EsFormInput page.

#### Top of EsFormInput page with new basic and required examples
<img width="633" alt="Screen Shot 2023-02-23 at 5 06 30 PM" src="https://user-images.githubusercontent.com/1350363/221041464-ee5871f0-0f9a-4126-bbbb-f7792e22e930.png">

#### New error and success state examples
<img width="670" alt="Screen Shot 2023-02-23 at 5 06 40 PM" src="https://user-images.githubusercontent.com/1350363/221041499-b83304d9-c7c4-45f3-b148-3f499d1cd529.png">

#### New placeholder and hidden label examples
<img width="1143" alt="Screen Shot 2023-02-23 at 5 06 49 PM" src="https://user-images.githubusercontent.com/1350363/221041551-b17179ba-1206-4a51-85dc-59e7bc9337fa.png">

#### Simplified context message examples
<img width="787" alt="Screen Shot 2023-02-23 at 5 06 55 PM" src="https://user-images.githubusercontent.com/1350363/221041574-38981b1d-ff79-41e6-a521-5f3bc96583a7.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested on docs page in Chrome with responsive devtools

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
