### PR TITLE
fix: issues with link variant of EsButton

### DIFF
--- a/es-design-system/pages/molecules/es-button.vue
+++ b/es-design-system/pages/molecules/es-button.vue
@@ -23,578 +23,678 @@
             Icons inside of small buttons should be 18px or 1.125rem.
         </p>
 
-        <h2>
-            Primary Button
-        </h2>
-        <table class="table mb-4">
-            <thead>
-                <tr>
-                    <th scope="col">
-                        State
-                    </th>
-                    <th scope="col">
-                        Examples
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td scope="row">
-                        Normal
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button>
-                                Default button
-                            </es-button>
-                            <es-button>
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-                            <es-button>
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button size="sm">
-                                Small button
-                            </es-button>
+        <div class="my-5">
+            <h2>
+                Primary Button
+            </h2>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            State
+                        </th>
+                        <th scope="col">
+                            Examples
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td scope="row">
+                            Normal
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button>
+                                    Default button
+                                </es-button>
+                                <es-button>
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+                                <es-button>
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button size="sm">
+                                    Small button
+                                </es-button>
 
-                            <es-button size="sm">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
+                                <es-button size="sm">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
 
-                            <es-button size="sm">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td scope="row">
-                        Disabled
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button disabled>
-                                Default button
-                            </es-button>
+                                <es-button size="sm">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Disabled
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button disabled>
+                                    Default button
+                                </es-button>
 
-                            <es-button disabled>
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
+                                <es-button disabled>
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
 
-                            <es-button disabled>
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                disabled
-                                size="sm">
-                                Small button
-                            </es-button>
+                                <es-button disabled>
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    disabled
+                                    size="sm">
+                                    Small button
+                                </es-button>
 
-                            <es-button
-                                disabled
-                                size="sm">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
+                                <es-button
+                                    disabled
+                                    size="sm">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
 
-                            <es-button
-                                disabled
-                                size="sm">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>
-            Secondary Button
-        </h2>
-        <table class="table mb-4">
-            <thead>
-                <tr>
-                    <th scope="col">
-                        State
-                    </th>
-                    <th scope="col">
-                        Examples
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td scope="row">
-                        Normal
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button variant="secondary">
-                                Default button
-                            </es-button>
-                            <es-button variant="secondary">
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-                            <es-button variant="secondary">
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                size="sm"
-                                variant="secondary">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td scope="row">
-                        Disabled
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button
-                                disabled
-                                variant="secondary">
-                                Default button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                variant="secondary">
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                variant="secondary">
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                disabled
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                size="sm"
-                                variant="secondary">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>
-            Outline Primary Button
-        </h2>
-        <table class="table mb-4">
-            <thead>
-                <tr>
-                    <th scope="col">
-                        State
-                    </th>
-                    <th scope="col">
-                        Examples
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td scope="row">
-                        Normal
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button outline>
-                                Default button
-                            </es-button>
-                            <es-button outline>
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-                            <es-button outline>
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                outline
-                                size="sm">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                outline
-                                size="sm">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                outline
-                                size="sm">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td scope="row">
-                        Disabled
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button
-                                disabled
-                                outline>
-                                Default button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline>
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline>
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                disabled
-                                outline
-                                size="sm">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                size="sm">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                size="sm">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>
-            Outline Secondary Button
-        </h2>
-        <table class="table mb-4">
-            <thead>
-                <tr>
-                    <th scope="col">
-                        State
-                    </th>
-                    <th scope="col">
-                        Examples
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td scope="row">
-                        Normal
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button
-                                outline
-                                variant="secondary">
-                                Default button
-                            </es-button>
-                            <es-button
-                                outline
-                                variant="secondary">
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-                            <es-button
-                                outline
-                                variant="secondary">
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td scope="row">
-                        Disabled
-                    </td>
-                    <td>
-                        <div class="mb-2">
-                            <es-button
-                                disabled
-                                outline
-                                variant="secondary">
-                                Default button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                variant="secondary">
-                                Default button
-                                <icon-chevron-right class="ml-1" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                variant="secondary">
-                                <icon-chevron-right />
-                            </es-button>
-                        </div>
-                        <div>
-                            <es-button
-                                disabled
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                Small button
-                                <icon-chevron-right
-                                    class="ml-2"
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-
-                            <es-button
-                                disabled
-                                outline
-                                size="sm"
-                                variant="secondary">
-                                <icon-chevron-right
-                                    height="1.125rem"
-                                    width="1.125rem" />
-                            </es-button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-
-        <h2>
-            Width change across breakpoints
-        </h2>
-        <p>
-            Often, designs will specify buttons to be full width on mobile and content width on desktop.
-            Below is an example of how to easily accomplish this.
-        </p>
-        <div class="mb-4">
-            <es-button class="w-100 w-lg-auto">
-                Responsive button
-            </es-button>
+                                <es-button
+                                    disabled
+                                    size="sm">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
 
-        <h2>
-            Deprecated Buttons (do not use)
-        </h2>
-        <p class="mb-4">
-            It is recommended not to use these variants and to refactor your code to remove instances of them.
-            They are a legacy artifact of Bootstrap, don't match EnergySage branding, and will be removed in a future
-            version of ESDS.
-        </p>
-        <div class="mb-4">
-            <es-button variant="success">
-                Success button
-            </es-button>
-            <es-button variant="info">
-                Info button
-            </es-button>
-            <es-button variant="warning">
-                Warning button
-            </es-button>
-            <es-button variant="danger">
-                Danger button
-            </es-button>
-            <es-button variant="light">
-                Light button
-            </es-button>
-            <es-button variant="dark">
-                Dark button
-            </es-button>
-            <es-button variant="mid">
-                Mid button
-            </es-button>
-            <es-button variant="mid-dark">
-                Mid dark button
-            </es-button>
-            <es-button variant="highlight">
-                Highlight button
-            </es-button>
-            <es-button variant="highlight-dark">
-                Highlight dark button
-            </es-button>
+        <div class="my-5">
+            <h2>
+                Secondary Button
+            </h2>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            State
+                        </th>
+                        <th scope="col">
+                            Examples
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td scope="row">
+                            Normal
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button variant="secondary">
+                                    Default button
+                                </es-button>
+                                <es-button variant="secondary">
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+                                <es-button variant="secondary">
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    size="sm"
+                                    variant="secondary">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Disabled
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button
+                                    disabled
+                                    variant="secondary">
+                                    Default button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    variant="secondary">
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    variant="secondary">
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    disabled
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    size="sm"
+                                    variant="secondary">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
-        <div class="mb-2">
-            <es-button
-                outline
-                variant="success">
-                Success button
-            </es-button>
-            <es-button
-                outline
-                variant="info">
-                Info button
-            </es-button>
-            <es-button
-                outline
-                variant="warning">
-                Warning button
-            </es-button>
-            <es-button
-                outline
-                variant="danger">
-                Danger button
-            </es-button>
-            <es-button
-                outline
-                variant="light">
-                Light button
-            </es-button>
-            <es-button
-                outline
-                variant="dark">
-                Dark button
-            </es-button>
-            <es-button
-                outline
-                variant="mid">
-                Mid button
-            </es-button>
-            <es-button
-                outline
-                variant="mid-dark">
-                Mid dark button
-            </es-button>
-            <es-button
-                outline
-                variant="highlight">
-                Highlight button
-            </es-button>
-            <es-button
-                outline
-                variant="highlight-dark">
-                Highlight dark button
-            </es-button>
+
+        <div class="my-5">
+            <h2>
+                Outline Primary Button
+            </h2>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            State
+                        </th>
+                        <th scope="col">
+                            Examples
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td scope="row">
+                            Normal
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button outline>
+                                    Default button
+                                </es-button>
+                                <es-button outline>
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+                                <es-button outline>
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    outline
+                                    size="sm">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    outline
+                                    size="sm">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    outline
+                                    size="sm">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Disabled
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button
+                                    disabled
+                                    outline>
+                                    Default button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline>
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline>
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Outline Secondary Button
+            </h2>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            State
+                        </th>
+                        <th scope="col">
+                            Examples
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td scope="row">
+                            Normal
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button
+                                    outline
+                                    variant="secondary">
+                                    Default button
+                                </es-button>
+                                <es-button
+                                    outline
+                                    variant="secondary">
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+                                <es-button
+                                    outline
+                                    variant="secondary">
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Disabled
+                        </td>
+                        <td>
+                            <div class="mb-2">
+                                <es-button
+                                    disabled
+                                    outline
+                                    variant="secondary">
+                                    Default button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    variant="secondary">
+                                    Default button
+                                    <icon-chevron-right class="ml-1" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    variant="secondary">
+                                    <icon-chevron-right />
+                                </es-button>
+                            </div>
+                            <div>
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    Small button
+                                    <icon-chevron-right
+                                        class="ml-2"
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+
+                                <es-button
+                                    disabled
+                                    outline
+                                    size="sm"
+                                    variant="secondary">
+                                    <icon-chevron-right
+                                        height="1.125rem"
+                                        width="1.125rem" />
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Link button
+            </h2>
+            <p>
+                The <code>link</code> variant will render a button with the appearance of a link while
+                maintaining the default padding and size of a button. This is useful when the link button
+                will appear next to another button (e.g. within a modal), as they will remain vertically
+                aligned relative to each other.
+            </p>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            State
+                        </th>
+                        <th scope="col">
+                            Examples
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td scope="row">
+                            Default
+                        </td>
+                        <td>
+                            <div>
+                                <es-button variant="link">
+                                    Link button
+                                </es-button>
+                                <es-button>
+                                    Default button
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Small
+                        </td>
+                        <td>
+                            <div>
+                                <es-button
+                                    size="sm"
+                                    variant="link">
+                                    Link button
+                                </es-button>
+                                <es-button size="sm">
+                                    Small button
+                                </es-button>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td scope="row">
+                            Inline
+                        </td>
+                        <td>
+                            <p>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. In tellus
+                                <es-button
+                                    inline
+                                    size="sm"
+                                    variant="link">
+                                    integer feugiat scelerisque
+                                </es-button>
+                                varius. Risus in hendrerit gravida rutrum. Faucibus interdum posuere lorem ipsum
+                                dolor sit amet consectetur adipiscing. Mi tempus imperdiet nulla malesuada pellentesque
+                                elit.
+                            </p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Width change across breakpoints
+            </h2>
+            <p>
+                Often, designs will specify buttons to be full width on mobile and content width on desktop.
+                Below is an example of how to easily accomplish this.
+            </p>
+            <div class="mb-4">
+                <es-button class="w-100 w-lg-auto">
+                    Responsive button
+                </es-button>
+            </div>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                Deprecated Buttons (do not use)
+            </h2>
+            <p class="mb-4">
+                It is recommended not to use these variants and to refactor your code to remove instances of them.
+                They are a legacy artifact of Bootstrap, don't match EnergySage branding, and will be removed in a
+                future version of ESDS.
+            </p>
+            <div class="mb-4">
+                <es-button variant="success">
+                    Success button
+                </es-button>
+                <es-button variant="info">
+                    Info button
+                </es-button>
+                <es-button variant="warning">
+                    Warning button
+                </es-button>
+                <es-button variant="danger">
+                    Danger button
+                </es-button>
+                <es-button variant="light">
+                    Light button
+                </es-button>
+                <es-button variant="dark">
+                    Dark button
+                </es-button>
+                <es-button variant="mid">
+                    Mid button
+                </es-button>
+                <es-button variant="mid-dark">
+                    Mid dark button
+                </es-button>
+                <es-button variant="highlight">
+                    Highlight button
+                </es-button>
+                <es-button variant="highlight-dark">
+                    Highlight dark button
+                </es-button>
+            </div>
+            <div class="mb-2">
+                <es-button
+                    outline
+                    variant="success">
+                    Success button
+                </es-button>
+                <es-button
+                    outline
+                    variant="info">
+                    Info button
+                </es-button>
+                <es-button
+                    outline
+                    variant="warning">
+                    Warning button
+                </es-button>
+                <es-button
+                    outline
+                    variant="danger">
+                    Danger button
+                </es-button>
+                <es-button
+                    outline
+                    variant="light">
+                    Light button
+                </es-button>
+                <es-button
+                    outline
+                    variant="dark">
+                    Dark button
+                </es-button>
+                <es-button
+                    outline
+                    variant="mid">
+                    Mid button
+                </es-button>
+                <es-button
+                    outline
+                    variant="mid-dark">
+                    Mid dark button
+                </es-button>
+                <es-button
+                    outline
+                    variant="highlight">
+                    Highlight button
+                </es-button>
+                <es-button
+                    outline
+                    variant="highlight-dark">
+                    Highlight dark button
+                </es-button>
+            </div>
+        </div>
+
+        <div class="my-5">
+            <h2>
+                EsButton props
+            </h2>
+            <b-table
+                :fields="propTableColumns"
+                :items="propTableRows"
+                striped />
         </div>
 
         <ds-doc-source
@@ -611,6 +711,44 @@ export default {
     name: 'EsButtonDocs',
     data() {
         return {
+            propTableColumns: [
+                'name',
+                'type',
+                'description',
+            ],
+            propTableRows: [
+                {
+                    name: 'inline',
+                    type: 'boolean',
+                    description: `
+                        Use only for the 'link' variant. If true, removes the fixed padding and height from the
+                        button so it can be aligned with other text next to it. Defaults to false.
+                    `,
+                },
+                {
+                    name: 'outline',
+                    type: 'boolean',
+                    description: `
+                        If true, changes to the outline version of the specified variant. Defaults to false.
+                    `,
+                },
+                {
+                    name: 'size',
+                    type: 'string',
+                    description: `
+                        The size of the button: 'lg', 'md', or 'sm'. Large and medium will render exactly the
+                        same. Defaults to 'md'.
+                    `,
+                },
+                {
+                    name: 'variant',
+                    type: 'string',
+                    description: `
+                        The name of the desired button variant: 'primary', 'secondary', or 'link'.
+                        Defaults to 'primary'.
+                    `,
+                },
+            ],
             compCode: '',
             docCode: '',
         };

--- a/es-vue-base/src/lib-components/EsButton.vue
+++ b/es-vue-base/src/lib-components/EsButton.vue
@@ -1,5 +1,6 @@
 <template>
     <b-button
+        :class="{ 'inline': inline }"
         :variant="computedVariant"
         :size="size"
         v-bind="$attrs"
@@ -45,6 +46,14 @@ export default {
             validator: (val) => ['lg', 'md', 'sm'].includes(val),
             default: 'md',
         },
+        /**
+         * Only works for 'link' variant buttons.
+         * Removes the fixed height and padding so the button can fit nicely within a block of text.
+         */
+        inline: {
+            type: Boolean,
+            default: false,
+        },
     },
     computed: {
         /**
@@ -60,3 +69,15 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+.btn-link.inline {
+    /* use normal CSS here so users can override with utility classes as necessary */
+    border: none;
+    line-height: inherit;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    vertical-align: baseline;
+}
+</style>

--- a/es-vue-base/src/lib-components/EsButton.vue
+++ b/es-vue-base/src/lib-components/EsButton.vue
@@ -73,9 +73,9 @@ export default {
 <style lang="scss" scoped>
 .btn-link.inline {
     /* use normal CSS here so users can override with utility classes as necessary */
-    border: none;
-    line-height: inherit;
+    border: 0;
     height: auto;
+    line-height: inherit;
     margin: 0;
     padding: 0;
     vertical-align: baseline;

--- a/es-vue-base/src/lib-components/EsCollapse.vue
+++ b/es-vue-base/src/lib-components/EsCollapse.vue
@@ -4,6 +4,7 @@
             block
             :aria-label="id"
             class="collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body"
+            inline
             variant="link"
             @click="isExpanded = !isExpanded">
             <div>

--- a/es-vue-base/src/lib-components/EsViewMore.vue
+++ b/es-vue-base/src/lib-components/EsViewMore.vue
@@ -4,6 +4,7 @@
         <span v-html="bodyContent" />
         <EsButton
             v-if="isTruncated"
+            inline
             variant="link"
             class="p-0"
             @click="click">

--- a/es-vue-base/tests/__snapshots__/EsCollapse.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsCollapse.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsCollapse <EsCollapse /> 1`] = `
-"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block" block="">
+"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block inline" block="">
     <div>My Title</div>
     <div><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 30px; width: 30px;" class="svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
@@ -15,7 +15,7 @@ exports[`EsCollapse <EsCollapse /> 1`] = `
 `;
 
 exports[`EsCollapse EsButton exists 1`] = `
-"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block" block="">
+"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block inline" block="">
     <div>My Title</div>
     <div><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 30px; width: 30px;" class="svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
@@ -29,7 +29,7 @@ exports[`EsCollapse EsButton exists 1`] = `
 `;
 
 exports[`EsCollapse Icons switch upon button click 1`] = `
-"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block" block="">
+"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block inline" block="">
     <div>My Title</div>
     <div><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 30px; width: 30px;" class="svg collapsed">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
@@ -43,7 +43,7 @@ exports[`EsCollapse Icons switch upon button click 1`] = `
 `;
 
 exports[`EsCollapse Title and default slot exist inside EsButton 1`] = `
-"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block" block="">
+"<div><button aria-label="myId" type="button" class="btn collapse-holder pb-3 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body btn-link btn-md btn-block inline" block="">
     <div>My Title</div>
     <div><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 30px; width: 30px;" class="svg collapsed">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>

--- a/es-vue-base/tests/__snapshots__/EsViewMore.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsViewMore.spec.js.snap
@@ -1,43 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsViewMore "Show more" button emits on click 1`] = `
-"<div><span>Hello worl...</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Hello worl...</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     Show More
   </button></div>"
 `;
 
 exports[`EsViewMore "Show more" does not emit if not listening for it 1`] = `
-"<div><span>Hello world!</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Hello world!</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     Show Less
   </button></div>"
 `;
 
 exports[`EsViewMore <EsViewMore /> 1`] = `
-"<div><span>Lorem ipsum dolor am...</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Lorem ipsum dolor am...</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     Show More
   </button></div>"
 `;
 
 exports[`EsViewMore <EsViewMore clamp="testMore" 1`] = `
-"<div><span>Hello ...</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Hello ...</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     testMore
   </button></div>"
 `;
 
 exports[`EsViewMore <EsViewMore less="testLess 1`] = `
-"<div><span>Hello world!</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Hello world!</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     testLess
   </button></div>"
 `;
 
 exports[`EsViewMore character truncation breaks at correct spot 1`] = `
-"<div><span>Hello wo...</span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span>Hello wo...</span> <button type="button" class="btn p-0 btn-link btn-md inline">
     Show More
   </button></div>"
 `;
 
 exports[`EsViewMore character truncation with HTML tags only truncates text content 1`] = `
-"<div><span><h1>H...</h1></span> <button type="button" class="btn p-0 btn-link btn-md">
+"<div><span><h1>H...</h1></span> <button type="button" class="btn p-0 btn-link btn-md inline">
     Show More
   </button></div>"
 `;


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-118

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added an `inline` prop for EsButton, only for use with the `link` variant, that removes the padding, height, border, etc. to make it align perfectly with text it may be next to, so it looks like a regular link
- Added link variant examples to EsButton docs page
- Added a prop table to EsButton docs page
- Fixes a small issue with EsCollapse introduced in #501 where the expand/collapse button was slightly shorter than it should be in cases where it contained large text (it now aligns horizontally with the text content beneath it even better than it did prior to the introduction of the issue)
- Fixes an issue with EsViewMore introduced in #501 where the "Show Less" link was too tall (it now aligns with the text even better than it did prior to the introduction of the issue)

#### Link button examples on EsButton docs page
<img width="1170" alt="Screen Shot 2023-02-28 at 2 35 05 PM" src="https://user-images.githubusercontent.com/1350363/221959993-11ee9881-60f3-4ec7-87ad-13a0a96abdbb.png">

#### New props table on EsButton docs page
<img width="1176" alt="Screen Shot 2023-02-28 at 2 36 03 PM" src="https://user-images.githubusercontent.com/1350363/221960189-93caa6cc-a463-4c1b-ba1c-7849149a853a.png">

#### EsViewMore button link now aligns with text
<img width="1171" alt="Screen Shot 2023-02-28 at 2 33 41 PM" src="https://user-images.githubusercontent.com/1350363/221959720-aa7b1e16-6111-4ac3-be40-62b9ab4d3785.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested in Chrome responsive dev tools, Firefox, and Safari
- Tested in iPhone/Android emulator with LambdaTest

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
