### PR TITLE
fix: made links semibold by default, adjusted font on EsSupport & EsTabs

### DIFF
--- a/es-bs-base/scss/_buttons.scss
+++ b/es-bs-base/scss/_buttons.scss
@@ -113,6 +113,7 @@ fieldset:disabled a.btn {
   font-weight: $font-weight-normal;
   color: $link-color;
   text-decoration: $link-decoration;
+  font-weight: $link-weight;
 
   @include hover() {
     color: $link-hover-color;

--- a/es-bs-base/scss/_buttons.scss
+++ b/es-bs-base/scss/_buttons.scss
@@ -110,10 +110,9 @@ fieldset:disabled a.btn {
 
 // Make a button look and behave like a link
 .btn-link {
-  font-weight: $font-weight-normal;
+  font-weight: $link-weight;
   color: $link-color;
   text-decoration: $link-decoration;
-  font-weight: $link-weight;
 
   @include hover() {
     color: $link-hover-color;

--- a/es-bs-base/scss/_reboot.scss
+++ b/es-bs-base/scss/_reboot.scss
@@ -187,6 +187,7 @@ a {
   color: $link-color;
   text-decoration: $link-decoration;
   background-color: transparent; // Remove the gray background on active links in IE 10.
+  font-weight: $link-weight;
 
   @include hover() {
     color: $link-hover-color;

--- a/es-bs-base/scss/_reboot.scss
+++ b/es-bs-base/scss/_reboot.scss
@@ -184,10 +184,10 @@ sup { top: -.5em; }
 //
 
 a {
+  font-weight: $link-weight;
   color: $link-color;
   text-decoration: $link-decoration;
   background-color: transparent; // Remove the gray background on active links in IE 10.
-  font-weight: $link-weight;
 
   @include hover() {
     color: $link-hover-color;

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -326,6 +326,48 @@ $sizes: map-merge(
   $sizes
 );
 
+// Typography base
+//
+// Foundational variables relating to typography.
+
+// stylelint-disable value-keyword-case
+$font-family-sans-serif:      "Inter", "Helvetica Neue", Roboto, "Segoe UI", -apple-system, BlinkMacSystemFont, Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
+$font-family-base:            $font-family-sans-serif !default;
+// stylelint-enable value-keyword-case
+
+$font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
+$font-size-xs:                $font-size-base * 0.75;
+$font-size-sm:                $font-size-base * 0.875 !default;
+$font-size-lg:                $font-size-base * 1.25 !default;
+$font-size-xl:                $font-size-base * 1.35 !default;
+$font-size-xxl:               $font-size-base * 1.85 !default;
+
+// used in font-size-* utility classes
+$font-sizes: (
+  "xxl": $font-size-xxl,
+  "xl": $font-size-xl,
+  "lg": $font-size-lg,
+  "base": $font-size-base,
+  "sm": $font-size-sm,
+  "xs": $font-size-xs,
+);
+
+// fusv-disable
+$font-weight-lightest:        lighter;
+// fusv-enable
+$font-weight-lighter:         200 !default;
+$font-weight-light:           300 !default;
+$font-weight-normal:          400 !default;
+$font-weight-semibold:        500 !default;
+$font-weight-bold:            600 !default;
+$font-weight-bolder:          700 !default;
+// fusv-disable
+$font-weight-boldest:         800 !default;
+// fusv-enable
+
+$font-weight-base:            $font-weight-normal !default;
+$line-height-base:            1.5 !default;
 
 // Body
 //
@@ -343,6 +385,7 @@ $link-color:                              theme-color("primary") !default;
 $link-decoration:                         none !default;
 $link-hover-color:                        darken($link-color, 15%) !default;
 $link-hover-decoration:                   underline !default;
+$link-weight:                             $font-weight-semibold !default;
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 $emphasized-link-hover-darken-percentage: 15% !default;
 
@@ -437,48 +480,9 @@ $embed-responsive-aspect-ratios: join(
   $embed-responsive-aspect-ratios
 );
 
-// Typography
+// Typography elements
 //
 // Font, line-height, and color for body text, headings, and more.
-
-// stylelint-disable value-keyword-case
-$font-family-sans-serif:      "Inter", "Helvetica Neue", Roboto, "Segoe UI", -apple-system, BlinkMacSystemFont, Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
-$font-family-monospace:       SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
-$font-family-base:            $font-family-sans-serif !default;
-// stylelint-enable value-keyword-case
-
-$font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
-$font-size-xs:                $font-size-base * 0.75;
-$font-size-sm:                $font-size-base * 0.875 !default;
-$font-size-lg:                $font-size-base * 1.25 !default;
-$font-size-xl:                $font-size-base * 1.35 !default;
-$font-size-xxl:               $font-size-base * 1.85 !default;
-
-// used in font-size-* utility classes
-$font-sizes: (
-  "xxl": $font-size-xxl,
-  "xl": $font-size-xl,
-  "lg": $font-size-lg,
-  "base": $font-size-base,
-  "sm": $font-size-sm,
-  "xs": $font-size-xs,
-);
-
-// fusv-disable
-$font-weight-lightest:        lighter;
-// fusv-enable
-$font-weight-lighter:         200 !default;
-$font-weight-light:           300 !default;
-$font-weight-normal:          400 !default;
-$font-weight-semibold:        500 !default;
-$font-weight-bold:            600 !default;
-$font-weight-bolder:          700 !default;
-// fusv-disable
-$font-weight-boldest:         800 !default;
-// fusv-enable
-
-$font-weight-base:            $font-weight-normal !default;
-$line-height-base:            1.5 !default;
 
 $h1-font-size:                $font-size-base * 1.5 !default;
 $h2-font-size:                $font-size-base * 1.25 !default;

--- a/es-vue-base/src/lib-components/EsSupport.vue
+++ b/es-vue-base/src/lib-components/EsSupport.vue
@@ -30,7 +30,7 @@
             <div class="link">
                 <a
                     target="_blank"
-                    class="supportLink"
+                    class="font-size-sm supportLink"
                     :href="link">
                     <slot
                         v-if="hasLinkCopy"

--- a/es-vue-base/src/lib-components/EsTabs.vue
+++ b/es-vue-base/src/lib-components/EsTabs.vue
@@ -2,7 +2,7 @@
     <b-tabs
         class="es-tabs"
         v-bind="$attrs"
-        :active-nav-item-class="['font-weight-bold', 'active-tab']"
+        :active-nav-item-class="['font-weight-bolder', 'active-tab']"
         :vertical="vertical"
         :style="cssProps"
         no-nav-style
@@ -59,6 +59,7 @@ export default {
 
     .nav-link {
         color: $gray-900;
+        font-weight: $font-weight-normal;
         margin: 0 2rem -2px;
         padding: 0.25rem 0 0;
 

--- a/es-vue-base/tests/__snapshots__/EsSupport.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsSupport.spec.js.snap
@@ -9,7 +9,7 @@ exports[`EsSupport <EsSupport /> 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -25,7 +25,7 @@ exports[`EsSupport <EsSupport variant="cool" /> 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -41,7 +41,7 @@ exports[`EsSupport Image exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -57,7 +57,7 @@ exports[`EsSupport Support text exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -73,7 +73,7 @@ exports[`EsSupport Support title slot exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-137
- https://energysage.atlassian.net/browse/ESDS-107

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Font weight for anchor links has changed from 400 (normal) to 500 (semibold), per the design
- This includes the `link` variant of EsButton
- Font size of the link in EsSupport has changed from 16px to 14px, per the design
    - _(this was forced by making the links semibold, as the headline text in EsSupport then had almost the same weight as the link below)_
- Font weight for active tabs has changed from 600 (bold) to 700 (bolder), per the design
    - _(had to modify tabs anyway to retain inactive tab font weight of 400 - since they're anchor tags and would otherwise get the 500 weight - and noticed the design for active tabs differed from the code)_

#### Links are now semibold everywhere
<img width="527" alt="Screen Shot 2023-03-15 at 2 53 00 PM" src="https://user-images.githubusercontent.com/1350363/225413752-04d09d9b-c12a-497a-a395-3744dc0f5657.png">

#### Link variant of EsButton is also semibold
<img width="662" alt="Screen Shot 2023-03-15 at 3 00 12 PM" src="https://user-images.githubusercontent.com/1350363/225415269-d3b6b15a-d75e-434b-b580-84848687be32.png">

#### EsSupport link font size is slightly smaller
<img width="334" alt="Screen Shot 2023-03-15 at 2 53 49 PM" src="https://user-images.githubusercontent.com/1350363/225413856-d5df7344-3ec3-4e4c-834f-0b62182dbcb3.png">

#### Active tab is slightly bolder
<img width="431" alt="Screen Shot 2023-03-15 at 2 54 10 PM" src="https://user-images.githubusercontent.com/1350363/225413932-79b1434e-5b90-406d-b0fa-0a51ed644ac6.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Viewed every page of `es-design-system` site in Chrome to check for any links that looked wrong
- Tested in Chrome, Firefox, Safari

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
