### PR TITLE
add v-model functionality to EsAccordionList

### DIFF
--- a/es-design-system/pages/molecules/es-accordion.vue
+++ b/es-design-system/pages/molecules/es-accordion.vue
@@ -3,197 +3,329 @@
         <h1>
             Accordion
         </h1>
-        <p>
+        <p class="mb-450">
             Makes use of <b-link href="https://bootstrap-vue.org/docs/components/collapse">
                 bootstrap-vue collapse
             </b-link>
         </p>
 
-        <h2 class="mt-450">
-            Single expand (default)
-        </h2>
-        <p>
-            By default, accordions will only allow one item to be expanded at a time. Upon expanding a second
-            item, the open item will collapse.
-        </p>
-        <es-accordion-list initial-expanded-id="single-question-1">
-            <es-accordion id="single-question-1">
-                <template #title>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit?
-                </template>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                    labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
-                    gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
-                    Mi tempus imperdiet nulla malesuada pellentesque elit.
-                </p>
-            </es-accordion>
-            <es-accordion id="single-question-2">
-                <template #title>
-                    Faucibus purus in massa tempor nec feugiat?
-                </template>
-                <p>
-                    Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
-                    quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur vitae
-                    nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare arcu dui
-                    vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
-                </p>
-            </es-accordion>
-            <es-accordion id="single-question-3">
-                <template #title>
-                    Duis convallis convallis tellus id interdum velit laoreet id?
-                </template>
-                <p>
-                    Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
-                    id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
-                    Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
-                    vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
-                    Est velit egestas dui id ornare arcu odio ut sem.
-                </p>
-            </es-accordion>
-            <es-accordion id="single-question-4">
-                <template #title>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus?
-                </template>
-                <p>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
-                    risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
-                    enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
-                    cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi tincidunt.
-                    Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in mollis nunc sed
-                    id semper.
-                </p>
-            </es-accordion>
-        </es-accordion-list>
+        <div class="mb-450">
+            <h2>
+                Single expand (default)
+            </h2>
+            <p>
+                By default, accordions will only allow one item to be expanded at a time. Upon expanding a second
+                item, the open item will collapse.
+            </p>
+            <es-accordion-list initial-expanded-id="single-question-1">
+                <es-accordion id="single-question-1">
+                    <template #title>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit?
+                    </template>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                        labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
+                        gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
+                        Mi tempus imperdiet nulla malesuada pellentesque elit.
+                    </p>
+                </es-accordion>
+                <es-accordion id="single-question-2">
+                    <template #title>
+                        Faucibus purus in massa tempor nec feugiat?
+                    </template>
+                    <p>
+                        Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
+                        quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur
+                        vitae nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare
+                        arcu dui vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="single-question-3">
+                    <template #title>
+                        Duis convallis convallis tellus id interdum velit laoreet id?
+                    </template>
+                    <p>
+                        Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
+                        id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
+                        Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
+                        vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
+                        Est velit egestas dui id ornare arcu odio ut sem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="single-question-4">
+                    <template #title>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus?
+                    </template>
+                    <p>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
+                        risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
+                        enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
+                        cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi
+                        tincidunt. Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in
+                        mollis nunc sed id semper.
+                    </p>
+                </es-accordion>
+            </es-accordion-list>
+        </div>
 
-        <h2 class="mt-450">
-            Single expand, starts collapsed
-        </h2>
-        <p>
-            If no initial expanded id is provided, each item will start collapsed.
-        </p>
-        <es-accordion-list>
-            <es-accordion id="collapsed-question-1">
-                <template #title>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit?
-                </template>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                    labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
-                    gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
-                    Mi tempus imperdiet nulla malesuada pellentesque elit.
-                </p>
-            </es-accordion>
-            <es-accordion id="collapsed-question-2">
-                <template #title>
-                    Faucibus purus in massa tempor nec feugiat?
-                </template>
-                <p>
-                    Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
-                    quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur vitae
-                    nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare arcu dui
-                    vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
-                </p>
-            </es-accordion>
-            <es-accordion id="collapsed-question-3">
-                <template #title>
-                    Duis convallis convallis tellus id interdum velit laoreet id?
-                </template>
-                <p>
-                    Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
-                    id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
-                    Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
-                    vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
-                    Est velit egestas dui id ornare arcu odio ut sem.
-                </p>
-            </es-accordion>
-            <es-accordion id="collapsed-question-4">
-                <template #title>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus?
-                </template>
-                <p>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
-                    risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
-                    enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
-                    cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi tincidunt.
-                    Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in mollis nunc sed
-                    id semper.
-                </p>
-            </es-accordion>
-        </es-accordion-list>
+        <div class="mb-450">
+            <h2>
+                Single expand, starts collapsed
+            </h2>
+            <p>
+                If no initial expanded id is provided, each item will start collapsed.
+            </p>
+            <es-accordion-list>
+                <es-accordion id="collapsed-question-1">
+                    <template #title>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit?
+                    </template>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                        labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
+                        gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
+                        Mi tempus imperdiet nulla malesuada pellentesque elit.
+                    </p>
+                </es-accordion>
+                <es-accordion id="collapsed-question-2">
+                    <template #title>
+                        Faucibus purus in massa tempor nec feugiat?
+                    </template>
+                    <p>
+                        Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
+                        quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur
+                        vitae nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare
+                        arcu dui vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="collapsed-question-3">
+                    <template #title>
+                        Duis convallis convallis tellus id interdum velit laoreet id?
+                    </template>
+                    <p>
+                        Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
+                        id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
+                        Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
+                        vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
+                        Est velit egestas dui id ornare arcu odio ut sem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="collapsed-question-4">
+                    <template #title>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus?
+                    </template>
+                    <p>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
+                        risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
+                        enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
+                        cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi
+                        tincidunt. Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in
+                        mollis nunc sed id semper.
+                    </p>
+                </es-accordion>
+            </es-accordion-list>
+        </div>
 
-        <h2 class="mt-450">
-            Multiple expand
-        </h2>
-        <p>
-            This variant allows more than one item to be expanded at a time.
-        </p>
-        <es-accordion-list
-            allow-multiple-expand
-            initial-expanded-id="multiple-question-1">
-            <es-accordion id="multiple-question-1">
-                <template #title>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit?
-                </template>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                    labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
-                    gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
-                    Mi tempus imperdiet nulla malesuada pellentesque elit.
-                </p>
-            </es-accordion>
-            <es-accordion id="multiple-question-2">
-                <template #title>
-                    Faucibus purus in massa tempor nec feugiat?
-                </template>
-                <p>
-                    Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
-                    quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur vitae
-                    nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare arcu dui
-                    vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
-                </p>
-            </es-accordion>
-            <es-accordion id="multiple-question-3">
-                <template #title>
-                    Duis convallis convallis tellus id interdum velit laoreet id?
-                </template>
-                <p>
-                    Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
-                    id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
-                    Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
-                    vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
-                    Est velit egestas dui id ornare arcu odio ut sem.
-                </p>
-            </es-accordion>
-            <es-accordion id="multiple-question-4">
-                <template #title>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus?
-                </template>
-                <p>
-                    Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
-                    risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
-                    enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
-                    cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi tincidunt.
-                    Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in mollis nunc sed
-                    id semper.
-                </p>
-            </es-accordion>
-        </es-accordion-list>
+        <div class="mb-450">
+            <h2>
+                Single expand with v-model
+            </h2>
+            <p>
+                If you want to control the accordion programmatically or trigger a UI change elsewhere
+                when a specific item is expanded, you can use the <code>v-model</code> directive to bind the
+                active id to a data value.
+            </p>
+            <div class="mb-200">
+                <es-button
+                    class="mb-50"
+                    :disabled="programmaticExpandedId === 'programmatic-question-1'"
+                    @click="programmaticExpandedId = 'programmatic-question-1'">
+                    Expand first accordion
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    :disabled="programmaticExpandedId === 'programmatic-question-2'"
+                    @click="programmaticExpandedId = 'programmatic-question-2'">
+                    Expand second accordion
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    :disabled="programmaticExpandedId === 'programmatic-question-3'"
+                    @click="programmaticExpandedId = 'programmatic-question-3'">
+                    Expand third accordion
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    :disabled="programmaticExpandedId === 'programmatic-question-4'"
+                    @click="programmaticExpandedId = 'programmatic-question-4'">
+                    Expand fourth accordion
+                </es-button>
+            </div>
+            <b-row>
+                <b-col
+                    cols="12"
+                    lg="8">
+                    <es-accordion-list
+                        v-model="programmaticExpandedId"
+                        class="mb-4 mb-lg-0">
+                        <es-accordion id="programmatic-question-1">
+                            <template #title>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit?
+                            </template>
+                            <p>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua. In tellus integer feugiat scelerisque
+                                varius. Risus in hendrerit gravida rutrum. Faucibus interdum posuere lorem ipsum
+                                dolor sit amet consectetur adipiscing. Mi tempus imperdiet nulla malesuada pellentesque
+                                elit.
+                            </p>
+                        </es-accordion>
+                        <es-accordion id="programmatic-question-2">
+                            <template #title>
+                                Faucibus purus in massa tempor nec feugiat?
+                            </template>
+                            <p>
+                                Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis
+                                ut diam quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam.
+                                Elementum curabitur vitae nunc sed velit dignissim. Velit sed ullamcorper morbi
+                                tincidunt ornare. Sed cras ornare arcu dui vivamus arcu felis bibendum. Vel pharetra
+                                vel turpis nunc eget lorem.
+                            </p>
+                        </es-accordion>
+                        <es-accordion id="programmatic-question-3">
+                            <template #title>
+                                Duis convallis convallis tellus id interdum velit laoreet id?
+                            </template>
+                            <p>
+                                Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis
+                                pellentesque id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat
+                                sed cras ornare. Turpis egestas pretium aenean pharetra magna ac. Pellentesque
+                                dignissim enim sit amet. Placerat vestibulum lectus mauris ultrices eros. Amet nisl
+                                suscipit adipiscing bibendum est ultricies. Est velit egestas dui id ornare arcu odio
+                                ut sem.
+                            </p>
+                        </es-accordion>
+                        <es-accordion id="programmatic-question-4">
+                            <template #title>
+                                Ipsum a arcu cursus vitae congue mauris rhoncus?
+                            </template>
+                            <p>
+                                Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et
+                                tortor at risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla
+                                pellentesque dignissim enim sit amet venenatis urna. Duis convallis convallis tellus
+                                id interdum velit laoreet. A arcu cursus vitae congue mauris rhoncus aenean vel elit.
+                                In aliquam sem fringilla ut morbi tincidunt. Semper auctor neque vitae tempus quam
+                                pellentesque nec. Sit amet nisl purus in mollis nunc sed id semper.
+                            </p>
+                        </es-accordion>
+                    </es-accordion-list>
+                </b-col>
+                <b-col
+                    cols="12"
+                    lg="4">
+                    <div
+                        v-if="programmaticExpandedId === 'programmatic-question-1'"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with "Lorem ipsum dolor sit amet, consectetur adipiscing elit?"
+                    </div>
+                    <div
+                        v-if="programmaticExpandedId === 'programmatic-question-2'"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with "Faucibus purus in massa tempor nec feugiat?"
+                    </div>
+                    <div
+                        v-if="programmaticExpandedId === 'programmatic-question-3'"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with "Duis convallis convallis tellus id interdum velit laoreet id?"
+                    </div>
+                    <div
+                        v-if="programmaticExpandedId === 'programmatic-question-4'"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with "Ipsum a arcu cursus vitae congue mauris rhoncus?"
+                    </div>
+                </b-col>
+            </b-row>
+        </div>
 
-        <h2 class="mt-450">
-            EsAccordionList props
-        </h2>
-        <b-table
-            :fields="accordionListFields"
-            :items="accordionListProps"
-            striped />
+        <div class="mb-450">
+            <h2>
+                Multiple expand
+            </h2>
+            <p>
+                This variant allows more than one item to be expanded at a time. Do not use in conjunction with
+                <code>v-model</code>.
+            </p>
+            <es-accordion-list
+                allow-multiple-expand
+                initial-expanded-id="multiple-question-1">
+                <es-accordion id="multiple-question-1">
+                    <template #title>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit?
+                    </template>
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                        labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit
+                        gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing.
+                        Mi tempus imperdiet nulla malesuada pellentesque elit.
+                    </p>
+                </es-accordion>
+                <es-accordion id="multiple-question-2">
+                    <template #title>
+                        Faucibus purus in massa tempor nec feugiat?
+                    </template>
+                    <p>
+                        Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam
+                        quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur
+                        vitae nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare
+                        arcu dui vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="multiple-question-3">
+                    <template #title>
+                        Duis convallis convallis tellus id interdum velit laoreet id?
+                    </template>
+                    <p>
+                        Duis convallis convallis tellus id interdum velit laoreet id. Condimentum mattis pellentesque
+                        id nibh tortor id aliquet lectus proin. Nunc sed blandit libero volutpat sed cras ornare.
+                        Turpis egestas pretium aenean pharetra magna ac. Pellentesque dignissim enim sit amet. Placerat
+                        vestibulum lectus mauris ultrices eros. Amet nisl suscipit adipiscing bibendum est ultricies.
+                        Est velit egestas dui id ornare arcu odio ut sem.
+                    </p>
+                </es-accordion>
+                <es-accordion id="multiple-question-4">
+                    <template #title>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus?
+                    </template>
+                    <p>
+                        Ipsum a arcu cursus vitae congue mauris rhoncus. Tortor dignissim convallis aenean et tortor at
+                        risus viverra. Aliquet enim tortor at auctor urna. Placerat orci nulla pellentesque dignissim
+                        enim sit amet venenatis urna. Duis convallis convallis tellus id interdum velit laoreet. A arcu
+                        cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi
+                        tincidunt. Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in
+                        mollis nunc sed id semper.
+                    </p>
+                </es-accordion>
+            </es-accordion-list>
+        </div>
 
-        <h2 class="mt-450">
-            EsAccordion props
-        </h2>
-        <b-table
-            :fields="accordionFields"
-            :items="accordionProps" />
+        <div class="mb-450">
+            <h2>
+                EsAccordionList props
+            </h2>
+            <b-table
+                :fields="accordionListFields"
+                :items="accordionListProps"
+                striped />
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                EsAccordion props
+            </h2>
+            <b-table
+                :fields="accordionFields"
+                :items="accordionProps" />
+        </div>
 
         <ds-doc-source
             :comp-code="compCode"
@@ -231,19 +363,20 @@ export default {
                     name: 'allowMultipleExpand',
                     description: `
                         Defaults to false, which only allows one item to expand at a time. If true, allows multiple
-                        items to expand at a time.
+                        items to expand at a time. Do not use at the same time as v-model.
                     `,
                 },
                 {
                     name: 'initialExpandedId',
                     description: `
                         The id of the item that should begin expanded when the component mounts. If omitted, all
-                        items will start out collapsed.
+                        items will start out collapsed. Do not use at the same time as v-model.
                     `,
                 },
             ],
             compCode: '',
             docCode: '',
+            programmaticExpandedId: 'programmatic-question-1',
         };
     },
     async created() {

--- a/es-design-system/pages/molecules/es-tabs.vue
+++ b/es-design-system/pages/molecules/es-tabs.vue
@@ -34,59 +34,39 @@
 
         <div class="mb-450">
             <h2>
-                Selecting the active tab programmatically
+                Using v-model
             </h2>
-            <es-tabs
-                v-model="tabIndexButtons"
-                class="mb-200">
-                <es-tab title="Tab 1">
-                    <p>
-                        Content 1
-                    </p>
-                </es-tab>
-                <es-tab title="Tab 2">
-                    <p>
-                        Content 2
-                    </p>
-                </es-tab>
-                <es-tab title="Tab 3">
-                    <p>
-                        Content 3
-                    </p>
-                </es-tab>
-            </es-tabs>
+            <p>
+                If you need to select tabs programmatically or trigger a UI change elsewhere when a
+                tab is selected, you can use the <code>v-model</code> directive to bind the
+                active index to a data value.
+            </p>
             <div class="mb-100">
                 <es-button
                     class="mb-50"
-                    size="sm"
-                    @click="tabIndexButtons = 0">
+                    :disabled="tabIndexProgrammatic === 0"
+                    @click="tabIndexProgrammatic = 0">
                     Select tab 1
                 </es-button>
                 <es-button
                     class="mb-50"
-                    size="sm"
-                    @click="tabIndexButtons = 1">
+                    :disabled="tabIndexProgrammatic === 1"
+                    @click="tabIndexProgrammatic = 1">
                     Select tab 2
                 </es-button>
                 <es-button
                     class="mb-50"
-                    size="sm"
-                    @click="tabIndexButtons = 2">
+                    :disabled="tabIndexProgrammatic === 2"
+                    @click="tabIndexProgrammatic = 2">
                     Select tab 3
                 </es-button>
             </div>
-        </div>
-
-        <div class="mb-450">
-            <h2>
-                Showing separate content based on the active tab
-            </h2>
             <b-row>
                 <b-col
                     cols="12"
-                    lg="6">
+                    lg="8">
                     <es-tabs
-                        v-model="tabIndexContent"
+                        v-model="tabIndexProgrammatic"
                         class="mb-200">
                         <es-tab title="Tab 1">
                             <p>
@@ -107,19 +87,19 @@
                 </b-col>
                 <b-col
                     cols="12"
-                    lg="6">
+                    lg="4">
                     <div
-                        v-if="tabIndexContent === 0"
+                        v-if="tabIndexProgrammatic === 0"
                         class="bg-gray-300 p-200 rounded-lg text-center">
                         Content associated with tab 1
                     </div>
                     <div
-                        v-if="tabIndexContent === 1"
+                        v-if="tabIndexProgrammatic === 1"
                         class="bg-gray-300 p-200 rounded-lg text-center">
                         Content associated with tab 2
                     </div>
                     <div
-                        v-if="tabIndexContent === 2"
+                        v-if="tabIndexProgrammatic === 2"
                         class="bg-gray-300 p-200 rounded-lg text-center">
                         Content associated with tab 3
                     </div>
@@ -140,8 +120,7 @@ export default {
     name: 'EsTabsDocs',
     data() {
         return {
-            tabIndexButtons: 0,
-            tabIndexContent: 0,
+            tabIndexProgrammatic: 0,
             compCode: '',
             docCode: '',
         };

--- a/es-design-system/pages/molecules/es-tabs.vue
+++ b/es-design-system/pages/molecules/es-tabs.vue
@@ -3,28 +3,130 @@
         <h1>
             Tabs
         </h1>
-        <p>
+        <p class="mb-450">
             Extended from <b-link href="https://bootstrap-vue.org/docs/components/tabs">
                 bootstrap-vue tabs
             </b-link>
         </p>
-        <es-tabs class="my-450">
-            <es-tab title="Tab 1">
-                <p>
-                    Content 1
-                </p>
-            </es-tab>
-            <es-tab title="Tab 2">
-                <p>
-                    Content 2
-                </p>
-            </es-tab>
-            <es-tab title="Tab 3">
-                <p>
-                    Content 3
-                </p>
-            </es-tab>
-        </es-tabs>
+
+        <div class="mb-450">
+            <h2>
+                Basic example
+            </h2>
+            <es-tabs>
+                <es-tab title="Tab 1">
+                    <p>
+                        Content 1
+                    </p>
+                </es-tab>
+                <es-tab title="Tab 2">
+                    <p>
+                        Content 2
+                    </p>
+                </es-tab>
+                <es-tab title="Tab 3">
+                    <p>
+                        Content 3
+                    </p>
+                </es-tab>
+            </es-tabs>
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                Selecting the active tab programmatically
+            </h2>
+            <es-tabs
+                v-model="tabIndexButtons"
+                class="mb-200">
+                <es-tab title="Tab 1">
+                    <p>
+                        Content 1
+                    </p>
+                </es-tab>
+                <es-tab title="Tab 2">
+                    <p>
+                        Content 2
+                    </p>
+                </es-tab>
+                <es-tab title="Tab 3">
+                    <p>
+                        Content 3
+                    </p>
+                </es-tab>
+            </es-tabs>
+            <div class="mb-100">
+                <es-button
+                    class="mb-50"
+                    size="sm"
+                    @click="tabIndexButtons = 0">
+                    Select tab 1
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    size="sm"
+                    @click="tabIndexButtons = 1">
+                    Select tab 2
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    size="sm"
+                    @click="tabIndexButtons = 2">
+                    Select tab 3
+                </es-button>
+            </div>
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                Showing separate content based on the active tab
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    lg="6">
+                    <es-tabs
+                        v-model="tabIndexContent"
+                        class="mb-200">
+                        <es-tab title="Tab 1">
+                            <p>
+                                Content 1
+                            </p>
+                        </es-tab>
+                        <es-tab title="Tab 2">
+                            <p>
+                                Content 2
+                            </p>
+                        </es-tab>
+                        <es-tab title="Tab 3">
+                            <p>
+                                Content 3
+                            </p>
+                        </es-tab>
+                    </es-tabs>
+                </b-col>
+                <b-col
+                    cols="12"
+                    lg="6">
+                    <div
+                        v-if="tabIndexContent === 0"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 1
+                    </div>
+                    <div
+                        v-if="tabIndexContent === 1"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 2
+                    </div>
+                    <div
+                        v-if="tabIndexContent === 2"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 3
+                    </div>
+                </b-col>
+            </b-row>
+        </div>
+
         <ds-doc-source
             :comp-code="compCode"
             comp-source="es-vue-base/src/lib-components/EsTabs.vue"
@@ -38,6 +140,8 @@ export default {
     name: 'EsTabsDocs',
     data() {
         return {
+            tabIndexButtons: 0,
+            tabIndexContent: 0,
             compCode: '',
             docCode: '',
         };

--- a/es-vue-base/tests/EsAccordionList.spec.js
+++ b/es-vue-base/tests/EsAccordionList.spec.js
@@ -134,6 +134,104 @@ describe('EsAccordion', () => {
         expect(secondItemContent.isVisible()).toBe(false);
     });
 
+    test('EsAccordionList v-model test', async () => {
+        const accordions = [
+            {
+                id: 'accordion-id-1',
+                title: 'My Title 1',
+                content: 'My content 1.',
+            },
+            {
+                id: 'accordion-id-2',
+                title: 'My Title 2',
+                content: 'My content 2.',
+            },
+        ];
+
+        const wrapper = mount({
+            ...jestVue,
+            data() {
+                return {
+                    expandedId: accordions[0].id,
+                };
+            },
+            methods: {
+                expandFirstAccordion() {
+                    this.expandedId = accordions[0].id;
+                },
+            },
+            template: `
+                <es-accordion-list data-testid="testInput" id="testId" v-model="expandedId">
+                    <es-accordion id="${accordions[0].id}">
+                        <template #title>
+                            ${accordions[0].title}
+                        </template>
+                        <p>${accordions[0].content}</p>
+                    </es-accordion>
+                    <es-accordion id="${accordions[1].id}">
+                        <template #title>
+                            ${accordions[1].title}
+                        </template>
+                        <p>${accordions[1].content}</p>
+                    </es-accordion>
+                </es-accordion-list>
+            `,
+            components: {
+                EsAccordion,
+                EsAccordionList,
+            },
+            stubs: {
+                'es-accordion': EsAccordion,
+                'es-accordion-list': EsAccordionList,
+            },
+        });
+
+        // verify snapshot is correct
+        expect(wrapper.html()).toMatchSnapshot();
+
+        // verify the first item is expanded
+        const firstItem = wrapper.find(`#${accordions[0].id}`);
+        expect(firstItem.exists()).toBe(true);
+        const firstItemContent = firstItem.find('p');
+        expect(firstItemContent.exists()).toBe(true);
+        expect(firstItemContent.isVisible()).toBe(true);
+
+        // verify the second item is collapsed
+        const secondItem = wrapper.find(`#${accordions[1].id}`);
+        expect(secondItem.exists()).toBe(true);
+        const secondItemContent = secondItem.find('p');
+        expect(secondItemContent.exists()).toBe(true);
+        expect(secondItemContent.isVisible()).toBe(false);
+
+        // find and click the second item's button to expand it
+        const secondAccordion = wrapper.findAllComponents(EsAccordion).at(1);
+        expect(secondAccordion.exists()).toBe(true);
+        const secondButton = secondAccordion.findComponent(EsButton);
+        expect(secondButton.exists()).toBe(true);
+        await secondButton.trigger('click');
+
+        // verify the v-model data is now set to the second accordion's id
+        expect(wrapper.vm.expandedId).toBe(accordions[1].id);
+
+        // verify the first item is collapsed
+        expect(firstItemContent.isVisible()).toBe(false);
+
+        // verify the second item is expanded
+        expect(secondItemContent.isVisible()).toBe(true);
+
+        // programmatically set the v-model data to the id of the first accordion
+        await wrapper.vm.expandFirstAccordion();
+
+        // verify the data value is now set to the first accordion's id
+        expect(wrapper.vm.expandedId).toBe(accordions[0].id);
+
+        // verify the first item is expanded
+        expect(firstItemContent.isVisible()).toBe(true);
+
+        // verify the second item is collapsed
+        expect(secondItemContent.isVisible()).toBe(false);
+    });
+
     test('EsAccordionList performs multi-expand correctly', async () => {
         const accordions = [
             {

--- a/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
@@ -76,3 +76,36 @@ exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
   </div>
 </div>"
 `;
+
+exports[`EsAccordion EsAccordionList v-model test 1`] = `
+"<div role="tablist" class="rounded" data-testid="testInput" id="testId">
+  <div class="EsAccordion border-bottom border-light rounded-bottom">
+    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">
+        My Title 1
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
+        </svg></button></header>
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+      <div id="accordion-id-1" class="collapse show">
+        <div class="EsAccordion-content bg-white px-100 px-sm-200 pb-25 pt-100">
+          <p>My content 1.</p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+  <div class="EsAccordion border-bottom border-light rounded-bottom">
+    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">
+        My Title 2
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
+        </svg></button></header>
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+      <div id="accordion-id-2" class="collapse" style="display: none;">
+        <div class="EsAccordion-content bg-white px-100 px-sm-200 pb-25 pt-100">
+          <p>My content 2.</p>
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+</div>"
+`;


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-139

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- `EsAccordionList` now takes a `v-model` value for programmatic control, similar to `EsTabs`
- Added Jest tests to cover this case
- Added programmatic examples to `EsAccordionList` and `EsTabs` docs pages
- Added notes explaining that `v-model` is not to be used with `initialExpandedId` or `allowMultipleExpand` props

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested pre-existing functionality of EsAccordion (both manually and via the standard Jest test) to make sure that still works
- Tested `v-model` functionality
- Tested two cases that are not expected to work to ensure they didn't break the page:
    - Using `v-model` with `allowMultipleExpand`
    - Using `v-model` with a blank initial value
- Tested in Chrome responsive devtools, Firefox, Safari
- Tested on iPhone/Android emulator via LambdaTest
- Wrote Jest test to cover expand and collapse when using `v-model`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
