### PR TITLE
feat: responsive font size utility classes

### DIFF
--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -337,6 +337,20 @@ $font-family-base:            $font-family-sans-serif !default;
 // stylelint-enable value-keyword-case
 
 $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
+
+$font-size-50:                $font-size-base * 0.75 !default;
+$font-size-75:                $font-size-base * 0.875 !default;
+$font-size-100:               $font-size-base !default;
+$font-size-200:               $font-size-base * 1.125 !default;
+$font-size-300:               $font-size-base * 1.25 !default;
+$font-size-400:               $font-size-base * 1.5 !default;
+$font-size-500:               $font-size-base * 1.875 !default;
+$font-size-600:               $font-size-base * 2.375 !default;
+$font-size-700:               $font-size-base * 3 !default;
+$font-size-800:               $font-size-base * 3.375 !default;
+$font-size-900:               $font-size-base * 3.875 !default;
+
+// deprecated
 $font-size-xs:                $font-size-base * 0.75;
 $font-size-sm:                $font-size-base * 0.875 !default;
 $font-size-lg:                $font-size-base * 1.25 !default;
@@ -345,6 +359,19 @@ $font-size-xxl:               $font-size-base * 1.85 !default;
 
 // used in font-size-* utility classes
 $font-sizes: (
+  "50": $font-size-50,
+  "75": $font-size-75,
+  "100": $font-size-100,
+  "200": $font-size-200,
+  "300": $font-size-300,
+  "400": $font-size-400,
+  "500": $font-size-500,
+  "600": $font-size-600,
+  "700": $font-size-700,
+  "800": $font-size-800,
+  "900": $font-size-900,
+
+  // deprecated
   "xxl": $font-size-xxl,
   "xl": $font-size-xl,
   "lg": $font-size-lg,

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -370,7 +370,6 @@ $font-sizes: (
   "700": $font-size-700,
   "800": $font-size-800,
   "900": $font-size-900,
-
   // deprecated
   "xxl": $font-size-xxl,
   "xl": $font-size-xl,

--- a/es-bs-base/scss/utilities/_text.scss
+++ b/es-bs-base/scss/utilities/_text.scss
@@ -35,9 +35,16 @@
 
 // Responsive size
 
-// TODO: Align the design system guild on font sizing, responsive font sizing,
-// and the sm/md/lg/xl/xxl font sizes. Perhaps normalize font size token names
-// to numbers (e.g. 100, 200) like Adobe.
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    @each $size, $value in $font-sizes {
+      .font-size#{$infix}-#{$size} {
+        font-size: $value !important;
+      }
+    }
+  }
+}
 
 .font-size-h1 { @include font-size($h1-font-size, true); }
 .font-size-h2 { @include font-size($h2-font-size, true); }

--- a/es-bs-base/scss/variables/_type.scss
+++ b/es-bs-base/scss/variables/_type.scss
@@ -5,10 +5,24 @@
 @import "../variables";
 
 :export {
+  base: $font-size-base;
+
+  s50: $font-size-50;
+  s75: $font-size-75;
+  s100: $font-size-100;
+  s200: $font-size-200;
+  s300: $font-size-300;
+  s400: $font-size-400;
+  s500: $font-size-500;
+  s600: $font-size-600;
+  s700: $font-size-700;
+  s800: $font-size-800;
+  s900: $font-size-900;
+
+  // deprecated
   xxl: $font-size-xxl;
   xl: $font-size-xl;
   lg: $font-size-lg;
-  base: $font-size-base;
   sm: $font-size-sm;
   xs: $font-size-xs;
 }

--- a/es-design-system/components/ds-color-swatch.vue
+++ b/es-design-system/components/ds-color-swatch.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="font-size-sm px-50 py-200 rounded text-center"
+        class="font-size-75 px-50 py-200 rounded text-center"
         :class="{
             [`bg-${token}`]: true,
             'border': showBorder,

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -403,6 +403,7 @@ export default {
 
 /* pilot implementation of a responsive table */
 /* TODO: extract this to a reusable component within es-design-system docs site */
+
 .responsive-table {
     border-top: $border-width solid $border-color;
 
@@ -414,6 +415,7 @@ export default {
             background-color: $gray-200;
         }
     }
+
     dl {
         display: flex;
         margin: 0;
@@ -421,11 +423,13 @@ export default {
         dt {
             width: 30%;
         }
+
         dd {
             width: 70%;
         }
     }
 }
+
 .responsive-table-font-size {
     dl {
         dd {
@@ -434,28 +438,40 @@ export default {
         }
     }
 }
+
 @include media-breakpoint-up(sm) {
     .responsive-table {
         dl {
             dt {
                 width: 24%;
             }
+
             dd {
                 width: 76%;
             }
         }
     }
 }
+
 @include media-breakpoint-up(md) {
     .responsive-table {
+        /* undo mobile styles */
+        border-top-style: none;
+
         dl,
         dt,
         dd {
             margin: 0;
             padding: 0;
         }
+
+        /* ensure background is full height of row */
+        dd {
+            height: 100%;
+            padding: 0.5rem 0;
+        }
+
         /* undo mobile styles */
-        border-top-style: none;
         dl {
             display: block;
 
@@ -464,41 +480,26 @@ export default {
                 width: auto;
             }
         }
-        /* side padding on left-most cells */
-        dl:first-child {
-            dd,
-            dt {
-                padding-left: 0.5rem;
-            }
-        }
-        /* side padding on right-most cells */
-        dl:last-child {
-            dd,
-            dt {
-                padding-right: 0.5rem;
-            }
-        }
+
         /* column widths */
         dl:nth-child(1) {
             width: 26%;
         }
+
         dl:nth-child(2) {
             width: 12%;
         }
+
         dl:nth-child(3) {
             width: 62%;
         }
-        /* ensure background is full height of row */
-        dd {
-            height: 100%;
-            padding: 0.5rem 0;
-        }
-        &-row {
-            display: flex;
 
+        &-row {
             /* undo mobile styles */
             border-bottom-style: none;
+            display: flex;
             padding: 0;
+
             &:nth-child(even) {
                 background-color: transparent;
             }
@@ -509,10 +510,12 @@ export default {
                     border-top: $border-width solid $border-color;
                     padding: 0.5rem 0;
                 }
+
                 dd {
                     height: auto;
                 }
             }
+
             /* visually hide table columns within all rows except the first */
             &:not(:first-child) {
                 dt {
@@ -521,6 +524,7 @@ export default {
                     position: absolute;
                 }
             }
+
             /* zebra-stripe every odd row */
             &:nth-child(odd) {
                 dd {
@@ -528,21 +532,26 @@ export default {
                 }
             }
         }
+
+        /* side padding on left-most cells */
+        dl:first-child {
+            dd,
+            dt {
+                padding-left: 0.5rem;
+            }
+        }
+
+        /* side padding on right-most cells */
+        dl:last-child {
+            dd,
+            dt {
+                padding-right: 0.5rem;
+            }
+        }
     }
 }
+
 @include media-breakpoint-up(xl) {
-    .responsive-table {
-        /* column widths */
-        dl:nth-child(1) {
-            width: 20%;
-        }
-        dl:nth-child(2) {
-            width: 10%;
-        }
-        dl:nth-child(3) {
-            width: 70%;
-        }
-    }
     .responsive-table-font-size {
         dl {
             dd {
@@ -551,16 +560,34 @@ export default {
             }
         }
     }
+
+    .responsive-table {
+        /* column widths */
+        dl:nth-child(1) {
+            width: 20%;
+        }
+
+        dl:nth-child(2) {
+            width: 10%;
+        }
+
+        dl:nth-child(3) {
+            width: 70%;
+        }
+    }
 }
+
 @include media-breakpoint-up(xxl) {
     .responsive-table {
         /* column widths */
         dl:nth-child(1) {
             width: 16%;
         }
+
         dl:nth-child(2) {
             width: 10%;
         }
+
         dl:nth-child(3) {
             width: 74%;
         }

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -404,6 +404,8 @@ export default {
 /* pilot implementation of a responsive table */
 /* TODO: extract this to a reusable component within es-design-system docs site */
 
+/* stylelint-disable order/order */
+
 .responsive-table {
     border-top: $border-width solid $border-color;
 
@@ -593,4 +595,6 @@ export default {
         }
     }
 }
+
+/* stylelint-enable order/order */
 </style>

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -118,7 +118,7 @@
             </p>
             <div class="border pb-lg-100 px-100 px-lg-200 pt-100 pt-lg-200 rounded">
                 <figure>
-                    <blockquote class="font-size-lg">
+                    <blockquote class="font-size-300">
                         “Working with this company was a breeze. They were so friendly and helpful.”
                     </blockquote>
                     <figcaption>
@@ -136,34 +136,130 @@
         <b-row class="my-450">
             <b-col>
                 <h2>
-                    Font weight utility classes
+                    Font weight
                 </h2>
-                <b-table
-                    fixed
-                    :fields="fontFields"
-                    :items="fontWeightItems"
-                    striped>
-                    <template #cell(example)="data">
-                        <span :class="data.item.name">sample text at {{ data.item.weight }} weight</span>
-                    </template>
-                </b-table>
+                <p>
+                    These utility classes will apply the associated font weight to text.
+                </p>
+                <div class="responsive-table">
+                    <div
+                        v-for="data in fontWeightItems"
+                        :key="data.name"
+                        class="responsive-table-row">
+                        <dl>
+                            <dt>
+                                Name
+                            </dt>
+                            <dd>
+                                {{ data.name }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Weight
+                            </dt>
+                            <dd>
+                                {{ data.weight }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Example
+                            </dt>
+                            <dd>
+                                <span :class="data.name">The quick brown fox jumps over the lazy dog.</span>
+                            </dd>
+                        </dl>
+                    </div>
+                </div>
             </b-col>
         </b-row>
 
         <b-row class="my-450">
             <b-col>
                 <h2>
-                    Font size utility classes
+                    Font size
                 </h2>
-                <b-table
-                    fixed
-                    :fields="fontFields"
-                    :items="fontSizeItems"
-                    striped>
-                    <template #cell(example)="data">
-                        <span :class="data.item.name">sample text at {{ data.item.size }} size</span>
-                    </template>
-                </b-table>
+                <p>
+                    These utility classes will apply the associated font size to text. Responsive versions for
+                    each breakpoint are also available (e.g. <code>font-size-sm-400</code>,
+                    <code>font-size-md-400</code>, <code>font-size-lg-400</code>, <code>font-size-xl-400</code>,
+                    <code>font-size-xxl-400</code>).
+                </p>
+                <div class="responsive-table responsive-table-font-size">
+                    <div
+                        v-for="data in fontSizeItems"
+                        :key="data.name"
+                        class="responsive-table-row">
+                        <dl>
+                            <dt>
+                                Name
+                            </dt>
+                            <dd>
+                                {{ data.name }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Size
+                            </dt>
+                            <dd>
+                                {{ calculateActualFontSize(data.size) }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Example
+                            </dt>
+                            <dd>
+                                <span :class="data.name">The quick brown fox jumps over the lazy dog.</span>
+                            </dd>
+                        </dl>
+                    </div>
+                </div>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-450">
+            <b-col>
+                <h2>
+                    Font size (deprecated)
+                </h2>
+                <p>
+                    These utility classes are deprecated. Avoid using them and refactor your code to remove instances
+                    of them. They will be removed in a future version of ESDS.
+                </p>
+                <div class="responsive-table responsive-table-font-size">
+                    <div
+                        v-for="data in deprecatedFontSizeItems"
+                        :key="data.name"
+                        class="responsive-table-row">
+                        <dl>
+                            <dt>
+                                Name
+                            </dt>
+                            <dd>
+                                {{ data.name }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Size
+                            </dt>
+                            <dd>
+                                {{ calculateActualFontSize(data.size) }}
+                            </dd>
+                        </dl>
+                        <dl>
+                            <dt>
+                                Example
+                            </dt>
+                            <dd>
+                                <span :class="data.name">The quick brown fox jumps over the lazy dog.</span>
+                            </dd>
+                        </dl>
+                    </div>
+                </div>
             </b-col>
         </b-row>
 
@@ -181,10 +277,77 @@ export default {
     data() {
         return {
             sassType,
-            fontFields: [
-                'name',
-                // virtual column that can reference two fields
-                { key: 'example', label: 'Example' },
+            deprecatedFontSizeItems: [
+                {
+                    name: 'font-size-xs',
+                    size: sassType.xs,
+                },
+                {
+                    name: 'font-size-sm',
+                    size: sassType.sm,
+                },
+                {
+                    name: 'font-size-base',
+                    size: sassType.base,
+                },
+                {
+                    name: 'font-size-lg',
+                    size: sassType.lg,
+                },
+                {
+                    name: 'font-size-xl',
+                    size: sassType.xl,
+                },
+                {
+                    name: 'font-size-xxl',
+                    size: sassType.xxl,
+                },
+            ],
+            fontSizeItems: [
+                {
+                    name: 'font-size-50',
+                    size: sassType.s50,
+                },
+                {
+                    name: 'font-size-75',
+                    size: sassType.s75,
+                },
+                {
+                    name: 'font-size-100',
+                    size: sassType.s100,
+                },
+                {
+                    name: 'font-size-200',
+                    size: sassType.s200,
+                },
+                {
+                    name: 'font-size-300',
+                    size: sassType.s300,
+                },
+                {
+                    name: 'font-size-400',
+                    size: sassType.s400,
+                },
+                {
+                    name: 'font-size-500',
+                    size: sassType.s500,
+                },
+                {
+                    name: 'font-size-600',
+                    size: sassType.s600,
+                },
+                {
+                    name: 'font-size-700',
+                    size: sassType.s700,
+                },
+                {
+                    name: 'font-size-800',
+                    size: sassType.s800,
+                },
+                {
+                    name: 'font-size-900',
+                    size: sassType.s900,
+                },
             ],
             fontWeightItems: [
                 {
@@ -212,32 +375,6 @@ export default {
                     weight: '700',
                 },
             ],
-            fontSizeItems: [
-                {
-                    name: 'font-size-xs',
-                    size: sassType.xs,
-                },
-                {
-                    name: 'font-size-sm',
-                    size: sassType.sm,
-                },
-                {
-                    name: 'font-size-base',
-                    size: sassType.base,
-                },
-                {
-                    name: 'font-size-lg',
-                    size: sassType.lg,
-                },
-                {
-                    name: 'font-size-xl',
-                    size: sassType.xl,
-                },
-                {
-                    name: 'font-size-xxl',
-                    size: sassType.xxl,
-                },
-            ],
             docCode: '',
         };
     },
@@ -251,5 +388,182 @@ export default {
             this.$prism.highlight(this);
         }
     },
+    methods: {
+        calculateActualFontSize(remStr) {
+            const multiplier = parseFloat(remStr.replace('rem', ''));
+            return `${multiplier * 16}px`;
+        },
+    },
 };
 </script>
+
+<style lang="scss" scoped>
+@import '~@energysage/es-bs-base/scss/bootstrap';
+@import "~@energysage/es-bs-base/scss/variables";
+
+/* pilot implementation of a responsive table */
+/* TODO: extract this to a reusable component within es-design-system docs site */
+.responsive-table {
+    border-top: $border-width solid $border-color;
+
+    &-row {
+        border-bottom: $border-width solid $border-color;
+        padding: 0.5rem 0.5rem 0;
+
+        &:nth-child(even) {
+            background-color: $gray-200;
+        }
+    }
+    dl {
+        display: flex;
+        margin: 0;
+
+        dt {
+            width: 30%;
+        }
+        dd {
+            width: 70%;
+        }
+    }
+}
+.responsive-table-font-size {
+    dl {
+        dd {
+            max-height: 180px;
+            overflow: hidden;
+        }
+    }
+}
+@include media-breakpoint-up(sm) {
+    .responsive-table {
+        dl {
+            dt {
+                width: 24%;
+            }
+            dd {
+                width: 76%;
+            }
+        }
+    }
+}
+@include media-breakpoint-up(md) {
+    .responsive-table {
+        dl,
+        dt,
+        dd {
+            margin: 0;
+            padding: 0;
+        }
+        /* undo mobile styles */
+        border-top-style: none;
+        dl {
+            display: block;
+
+            dt,
+            dd {
+                width: auto;
+            }
+        }
+        /* side padding on left-most cells */
+        dl:first-child {
+            dd,
+            dt {
+                padding-left: 0.5rem;
+            }
+        }
+        /* side padding on right-most cells */
+        dl:last-child {
+            dd,
+            dt {
+                padding-right: 0.5rem;
+            }
+        }
+        /* column widths */
+        dl:nth-child(1) {
+            width: 26%;
+        }
+        dl:nth-child(2) {
+            width: 12%;
+        }
+        dl:nth-child(3) {
+            width: 62%;
+        }
+        /* ensure background is full height of row */
+        dd {
+            height: 100%;
+            padding: 0.5rem 0;
+        }
+        &-row {
+            display: flex;
+
+            /* undo mobile styles */
+            border-bottom-style: none;
+            padding: 0;
+            &:nth-child(even) {
+                background-color: transparent;
+            }
+
+            &:first-child {
+                dt {
+                    border-bottom: $border-width solid $border-color;
+                    border-top: $border-width solid $border-color;
+                    padding: 0.5rem 0;
+                }
+                dd {
+                    height: auto;
+                }
+            }
+            /* visually hide table columns within all rows except the first */
+            &:not(:first-child) {
+                dt {
+                    /* don't use display none because then screen readers won't read out the label */
+                    left: -9999em;
+                    position: absolute;
+                }
+            }
+            /* zebra-stripe every odd row */
+            &:nth-child(odd) {
+                dd {
+                    background-color: $gray-200;
+                }
+            }
+        }
+    }
+}
+@include media-breakpoint-up(xl) {
+    .responsive-table {
+        /* column widths */
+        dl:nth-child(1) {
+            width: 20%;
+        }
+        dl:nth-child(2) {
+            width: 10%;
+        }
+        dl:nth-child(3) {
+            width: 70%;
+        }
+    }
+    .responsive-table-font-size {
+        dl {
+            dd {
+                max-height: none;
+                overflow: visible;
+            }
+        }
+    }
+}
+@include media-breakpoint-up(xxl) {
+    .responsive-table {
+        /* column widths */
+        dl:nth-child(1) {
+            width: 16%;
+        }
+        dl:nth-child(2) {
+            width: 10%;
+        }
+        dl:nth-child(3) {
+            width: 74%;
+        }
+    }
+}
+</style>

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -16,7 +16,7 @@
         </label>
         <p
             v-if="hasExtraContext"
-            class="mb-25 font-size-sm">
+            class="mb-25 font-size-75">
             <slot name="extraContext" />
         </p>
         <div class="input-holder">

--- a/es-vue-base/src/lib-components/EsReview.vue
+++ b/es-vue-base/src/lib-components/EsReview.vue
@@ -42,7 +42,7 @@
                 </div>
                 <div
                     v-if="certified && !commentLimit"
-                    class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+                    class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
                     <div class="mr-50">
                         Verified
                     </div>
@@ -73,7 +73,7 @@
                         {{ updatedComment }}
                         <div
                             v-if="modified"
-                            class="font-size-sm text-gray-700 mt-50">
+                            class="font-size-75 text-gray-700 mt-50">
                             <span class="d-none d-lg-inline-block">Updated on </span>
                             {{ localeDate(modified) }}
                         </div>
@@ -102,7 +102,7 @@
             </small>
             <div
                 v-if="certified && !response && commentLimit"
-                class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+                class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
                 <div class="mr-50">
                     Verified
                 </div>
@@ -114,7 +114,7 @@
         </div>
         <div
             v-if="certified"
-            class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-sm">
+            class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-75">
             <IconVerified
                 class="text-gray-900 mr-50"
                 width="16px"
@@ -123,7 +123,7 @@
         </div>
         <div
             v-if="response && commentLimit"
-            class="d-flex flex-nowrap align-items-center font-size-sm mt-50 mt-lg-100">
+            class="d-flex flex-nowrap align-items-center font-size-75 mt-50 mt-lg-100">
             <b-link
                 data-testid="view-response"
                 @click="$emit('showMore')">
@@ -181,7 +181,7 @@
                         Response from {{ developerName }}
                     </p>
                     {{ response }}
-                    <p class="font-size-sm text-gray-700 m-0 mt-50 mt-lg-100">
+                    <p class="font-size-75 text-gray-700 m-0 mt-50 mt-lg-100">
                         Responded on {{ localeDate(responseDate) }}
                     </p>
                 </b-col>

--- a/es-vue-base/src/lib-components/EsSupport.vue
+++ b/es-vue-base/src/lib-components/EsSupport.vue
@@ -30,7 +30,7 @@
             <div class="link">
                 <a
                     target="_blank"
-                    class="font-size-sm supportLink"
+                    class="font-size-75 supportLink"
                     :href="link">
                     <slot
                         v-if="hasLinkCopy"

--- a/es-vue-base/tests/__snapshots__/EsReview.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsReview.spec.js.snap
@@ -77,7 +77,7 @@ exports[`EsReview Imported components exist 1`] = `
   <div class="d-flex flex-nowrap"><small class="d-flex align-items-center text-gray-700 text-nowrap details-holder"><span data-testid="subtext-test" class="name-holder d-inline-block text-truncate pr-25"><span class="d-none d-lg-inline-block">Posted by </span>
       My Name
       </span> <span class="date-holder">on 3/2/2022</span></small>
-    <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+    <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
       <div class="mr-50">
         Verified
       </div> <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900">
@@ -85,7 +85,7 @@ exports[`EsReview Imported components exist 1`] = `
       </svg>
     </div>
   </div>
-  <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-sm"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
+  <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-75"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
       <path d="M21.231 11.156v.85a9.231 9.231 0 1 1-5.474-8.438m5.474 1.053-9.23 9.24-2.77-2.77" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
     </svg>
     Verified Shopper
@@ -122,7 +122,7 @@ exports[`EsReview Shows a review has a response 1`] = `
     <!---->
   </div>
   <!---->
-  <div class="d-flex flex-nowrap align-items-center font-size-sm mt-50 mt-lg-100"><a data-testid="view-response" href="#" target="_self" class="">
+  <div class="d-flex flex-nowrap align-items-center font-size-75 mt-50 mt-lg-100"><a data-testid="view-response" href="#" target="_self" class="">
       View provider response
     </a>
     <!---->
@@ -184,7 +184,7 @@ exports[`EsReview Shows both comments and response when modal is open 1`] = `
     </h4>
     <div data-testid="both-comments"><span class="d-inline-block font-weight-bolder">Updated review: </span>
       Very very nice proj
-      <div class="font-size-sm text-gray-700 mt-50"><span class="d-none d-lg-inline-block">Updated on </span>
+      <div class="font-size-75 text-gray-700 mt-50"><span class="d-none d-lg-inline-block">Updated on </span>
         6/16/2022
       </div>
       <div class="mt-50"><span class="d-inline-block font-weight-bolder">Previous review: </span>
@@ -214,7 +214,7 @@ exports[`EsReview Shows both comments and response when modal is open 1`] = `
           Response from Test Dev
         </p>
         Thanks, Bob!
-        <p class="font-size-sm text-gray-700 m-0 mt-50 mt-lg-100">
+        <p class="font-size-75 text-gray-700 m-0 mt-50 mt-lg-100">
           Responded on 10/23/2022
         </p>
       </div>

--- a/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
@@ -47,7 +47,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         <!---->
                         <!---->
                         <!---->
-                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
                           <div class="mr-50">
                             Verified
                           </div> <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900">
@@ -74,7 +74,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         </span> <span class="date-holder">on 6/3/2022</span></small>
                       <!---->
                     </div>
-                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-sm"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
+                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-75"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
                         <path d="M21.231 11.156v.85a9.231 9.231 0 1 1-5.474-8.438m5.474 1.053-9.23 9.24-2.77-2.77" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                       </svg>
                       Verified Shopper
@@ -88,7 +88,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         <!---->
                         <!---->
                         <!---->
-                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
                           <div class="mr-50">
                             Verified
                           </div> <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900">
@@ -121,7 +121,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         </span> <span class="date-holder">on 6/3/2022</span></small>
                       <!---->
                     </div>
-                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-sm"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
+                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-75"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
                         <path d="M21.231 11.156v.85a9.231 9.231 0 1 1-5.474-8.438m5.474 1.053-9.23 9.24-2.77-2.77" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                       </svg>
                       Verified Shopper
@@ -145,7 +145,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                           ridiculus mus mauris vitae ultricies leo integer malesuada nunc vel risus commodo viverra maecenas
                           accumsan lacus vel facilisis volutpat est velit egestas dui id ornare arcu odio ut sem nulla
                           diam sit amet nisl suscipit adipiscing bibendum est ultricies integer quis
-                          <p class="font-size-sm text-gray-700 m-0 mt-50 mt-lg-100">
+                          <p class="font-size-75 text-gray-700 m-0 mt-50 mt-lg-100">
                             Responded on 6/10/2022
                           </p>
                         </div>
@@ -158,7 +158,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         <!---->
                         <!---->
                         <!---->
-                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-sm">
+                        <div class="d-lg-none d-flex flex-nowrap align-items-center ml-auto font-size-75">
                           <div class="mr-50">
                             Verified
                           </div> <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900">
@@ -178,7 +178,7 @@ exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
                         </span> <span class="date-holder">on 6/3/2022</span></small>
                       <!---->
                     </div>
-                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-sm"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
+                    <div class="d-none d-lg-flex text-gray-800 mt-50 align-items-center font-size-75"><svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="height: 16px; width: 16px;" class="text-gray-900 mr-50">
                         <path d="M21.231 11.156v.85a9.231 9.231 0 1 1-5.474-8.438m5.474 1.053-9.23 9.24-2.77-2.77" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                       </svg>
                       Verified Shopper

--- a/es-vue-base/tests/__snapshots__/EsSupport.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsSupport.spec.js.snap
@@ -9,7 +9,7 @@ exports[`EsSupport <EsSupport /> 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-75 supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -25,7 +25,7 @@ exports[`EsSupport <EsSupport variant="cool" /> 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-75 supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -41,7 +41,7 @@ exports[`EsSupport Image exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-75 supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -57,7 +57,7 @@ exports[`EsSupport Support text exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-75 supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>
@@ -73,7 +73,7 @@ exports[`EsSupport Support title slot exists 1`] = `
         Need help signing up?
       </div>
     </div>
-    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-sm supportLink">
+    <div class="link"><a target="_blank" href="https://www.google.com/" class="font-size-75 supportLink">
         Schedule a free call with your EnergySage Advisor.
       </a></div>
   </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-142

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added new static font size utility classes based on a numbered naming scheme (e.g. 50, 75, 100, 200, etc.)
- Added new responsive font size utility classes based on the same numbered naming scheme (e.g. `font-size-lg-400`)
- Upgraded the tables on the Typography docs page to be responsive (for both font size and font weight)
- Deprecated the old font size utility classes (e.g. `font-size-sm`)
- Updated all usages within ESDS of the deprecated classes with the new ones

#### New font size table on desktop
<img width="1205" alt="Screen Shot 2023-03-22 at 4 27 35 PM" src="https://user-images.githubusercontent.com/1350363/227030041-28bb01bc-442e-413d-9e10-439f3f2b7a7a.png">

#### New font size table on mobile
<img width="323" alt="Screen Shot 2023-03-22 at 4 26 37 PM" src="https://user-images.githubusercontent.com/1350363/227029842-84236363-f377-41e0-a7c0-4cd245d0230b.png">

#### Deprecated font size table on desktop
<img width="1170" alt="Screen Shot 2023-03-22 at 4 28 20 PM" src="https://user-images.githubusercontent.com/1350363/227030155-830891e9-38e1-4963-b780-692999ecbd48.png">

#### Deprecated font size table on mobile
<img width="322" alt="Screen Shot 2023-03-22 at 4 28 48 PM" src="https://user-images.githubusercontent.com/1350363/227030265-dfccf6fa-ef74-45db-9a53-8a2dc3afce01.png">

#### Updated font weight table on desktop
<img width="1170" alt="Screen Shot 2023-03-22 at 4 29 16 PM" src="https://user-images.githubusercontent.com/1350363/227030391-9b1ae045-a7b1-494f-ad8c-845c50c3535c.png">

#### Updated font weight table on mobile
<img width="323" alt="Screen Shot 2023-03-22 at 4 29 27 PM" src="https://user-images.githubusercontent.com/1350363/227030435-f967e3c3-420d-425d-807d-3c94f447fc45.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested Typography docs page in Chrome responsive devtools, Firefox, and Safari
- Tested a `<p>` tag using a different responsive font size utility class at every breakpoint to verify correct generation of utility classes

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
