### PR TITLE
feat: added prefix icon capability to EsFormInput

### DIFF
--- a/es-design-system/pages/molecules/es-form-input.vue
+++ b/es-design-system/pages/molecules/es-form-input.vue
@@ -172,9 +172,13 @@
                     <es-form-input
                         id="hiddenLabelExample"
                         v-model="form.zipCode"
+                        autocomplete="postal-code"
                         class="flex-grow-1"
-                        placeholder="ZIP code"
-                        label-sr-only>
+                        inputmode="numeric"
+                        label-sr-only
+                        maxlength="5"
+                        pattern="\d*"
+                        placeholder="ZIP code">
                         <template #label>
                             ZIP code
                         </template>
@@ -182,6 +186,35 @@
                     <es-button class="ml-lg-50 w-100 w-lg-auto">
                         Submit
                     </es-button>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-450">
+            <h2>
+                Prefix icon
+            </h2>
+            <b-row>
+                <b-col
+                    cols="12"
+                    md="6"
+                    lg="4">
+                    <es-form-input
+                        id="prefixIconExample"
+                        v-model="form.zipCode"
+                        autocomplete="postal-code"
+                        inputmode="numeric"
+                        label-sr-only
+                        maxlength="5"
+                        pattern="\d*"
+                        placeholder="ZIP code">
+                        <template #prefixIcon>
+                            <icon-location />
+                        </template>
+                        <template #label>
+                            ZIP code
+                        </template>
+                    </es-form-input>
                 </b-col>
             </b-row>
         </div>

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -24,7 +24,7 @@
             <span
                 v-if="$slots.prefixIcon"
                 aria-hidden
-                class="prefix-icon">
+                class="prefix-icon position-absolute">
                 <slot name="prefixIcon" />
             </span>
             <b-form-input
@@ -182,7 +182,6 @@ export default {
     left: $input-padding-x;
     /* allow clicks to pass through and give the input focus */
     pointer-events: none;
-    position: absolute;
     /* vertically center within the input container */
     top: calc($input-height * 0.5);
     transform: translateY(-50%);

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -19,11 +19,19 @@
             class="mb-25 font-size-75">
             <slot name="extraContext" />
         </p>
-        <div class="input-holder">
+        <div class="input-holder position-relative">
+            <!-- prefix icons are decorative only so are aria-hidden -->
+            <span
+                v-if="$slots.prefixIcon"
+                aria-hidden
+                class="prefix-icon">
+                <slot name="prefixIcon" />
+            </span>
             <b-form-input
                 :id="id"
                 :type="type"
                 class="es-form-input w-100"
+                :class="{ 'has-prefix-icon': $slots.prefixIcon }"
                 :disabled="disabled"
                 :state="state"
                 v-bind="$attrs"
@@ -162,6 +170,22 @@ export default {
     .input-holder {
         flex: 0 0 70%;
     }
+}
+
+.has-prefix-icon {
+    /* match the padding right of valid/invalid state icons */
+    padding-left: $input-height-inner !important;
+}
+
+.prefix-icon {
+    /* match the padding left of normal inputs */
+    left: $input-padding-x;
+    /* allow clicks to pass through and give the input focus */
+    pointer-events: none;
+    position: absolute;
+    /* vertically center within the input container */
+    top: calc($input-height * 0.5);
+    transform: translateY(-50%);
 }
 
 </style>

--- a/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
@@ -4,7 +4,8 @@ exports[`EsFormInput <EsFormInput /> 1`] = `
 "<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <!---->
-  <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
+  <div class="input-holder position-relative">
+    <!----> <input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <!---->
     <!---->
@@ -17,7 +18,8 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
             *
         </span></label>
   <!---->
-  <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
+  <div class="input-holder position-relative">
+    <!----> <input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <div class="invalid-feedback">
       This field is required.
@@ -31,7 +33,8 @@ exports[`EsFormInput <EsFormInput props /> 1`] = `
 "<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">
     <!----></label>
   <!---->
-  <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control">
+  <div class="input-holder position-relative">
+    <!----> <input id="myID" type="text" class="es-form-input w-100 form-control">
     <!---->
     <!---->
     <!---->
@@ -44,7 +47,8 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
   <div class="input-wrapper justify-content-end mb-50"><label for="testId" class="label font-weight-semibold justify-content-start">
       <!----></label>
     <!---->
-    <div class="input-holder"><input id="testId" type="text" class="es-form-input w-100 form-control" data-testid="testInput">
+    <div class="input-holder position-relative">
+      <!----> <input id="testId" type="text" class="es-form-input w-100 form-control" data-testid="testInput">
       <!---->
       <!---->
       <!---->
@@ -57,7 +61,8 @@ exports[`EsFormInput <EsFormInput>slots</EsFormInput> 1`] = `
 "<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <!---->
-  <div class="input-holder"><input id="myID" type="text" class="es-form-input w-100 form-control"> <small class="form-text text-muted">Please enter your account number.</small>
+  <div class="input-holder position-relative">
+    <!----> <input id="myID" type="text" class="es-form-input w-100 form-control"> <small class="form-text text-muted">Please enter your account number.</small>
     <div class="invalid-feedback">Please enter a valid account number.</div>
     <div class="valid-feedback">Your account number has been submitted successfully.</div>
   </div>

--- a/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
 "<div id="reviewsModal___BV_modal_outer_" style="position: absolute; z-index: 1040;" class="modal-lightbox" body-class="pt-0 pt-lg-200">
   <transition-stub enterclass="" leaveclass="" entertoclass="" leavetoclass="" enteractiveclass="" leaveactiveclass="">
-    <div id="reviewsModal" role="dialog" aria-labelledby="reviewsModal___BV_modal_title_" aria-describedby="reviewsModal___BV_modal_body_" class="modal fade" style="padding-right: 0px;" aria-modal="true">
+    <div id="reviewsModal" role="dialog" aria-labelledby="reviewsModal___BV_modal_title_" aria-describedby="reviewsModal___BV_modal_body_" class="modal fade" style="" aria-modal="true">
       <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable"><span tabindex="0"></span>
         <div id="reviewsModal___BV_modal_content_" tabindex="-1" class="modal-content">
           <header id="reviewsModal___BV_modal_header_" class="modal-header">

--- a/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsReviewModal.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`EsHorizontalList <EsHorizontalList /> 1`] = `
 "<div id="reviewsModal___BV_modal_outer_" style="position: absolute; z-index: 1040;" class="modal-lightbox" body-class="pt-0 pt-lg-200">
   <transition-stub enterclass="" leaveclass="" entertoclass="" leavetoclass="" enteractiveclass="" leaveactiveclass="">
-    <div id="reviewsModal" role="dialog" aria-labelledby="reviewsModal___BV_modal_title_" aria-describedby="reviewsModal___BV_modal_body_" class="modal fade" style="" aria-modal="true">
+    <div id="reviewsModal" role="dialog" aria-labelledby="reviewsModal___BV_modal_title_" aria-describedby="reviewsModal___BV_modal_body_" class="modal fade" style="padding-right: 0px;" aria-modal="true">
       <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable"><span tabindex="0"></span>
         <div id="reviewsModal___BV_modal_content_" tabindex="-1" class="modal-content">
           <header id="reviewsModal___BV_modal_header_" class="modal-header">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-133

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added a `prefixIcon` slot to EsFormInput that positions the given icon on the left side of the input
- Upgraded the two ZIP code example inputs on the EsFormInput docs page to have proper keyboard and autocomplete hinting

#### New example on EsFormInput docs page
<img width="790" alt="Screen Shot 2023-04-10 at 3 14 02 PM" src="https://user-images.githubusercontent.com/1350363/230978557-507d9fe9-ad1b-43bd-a4b2-d6295768fa17.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested in Chrome responsive devtools, Firefox, Safari
- Tested on iPhone/Android emulator with LambdaTest, confirmed numeric keyboard shows up

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
