### PR TITLE
fix: outline buttons now have white background

### DIFF
--- a/es-bs-base/scss/mixins/_buttons.scss
+++ b/es-bs-base/scss/mixins/_buttons.scss
@@ -88,6 +88,7 @@
   $focus-border: map-get($button-focus-border-colors, $variant);
 
   color: $color;
+  background: $white;
   border-color: $color;
 
   @include hover() {

--- a/es-design-system/pages/molecules/es-button.vue
+++ b/es-design-system/pages/molecules/es-button.vue
@@ -27,7 +27,7 @@
             <h2>
                 Primary Button
             </h2>
-            <table class="table mb-200">
+            <table class="table button-table mb-200">
                 <thead>
                     <tr>
                         <th scope="col">
@@ -131,7 +131,7 @@
             <h2>
                 Secondary Button
             </h2>
-            <table class="table mb-200">
+            <table class="table button-table mb-200">
                 <thead>
                     <tr>
                         <th scope="col">
@@ -250,7 +250,7 @@
             <h2>
                 Outline Primary Button
             </h2>
-            <table class="table mb-200">
+            <table class="table button-table mb-200">
                 <thead>
                     <tr>
                         <th scope="col">
@@ -369,7 +369,7 @@
             <h2>
                 Outline Secondary Button
             </h2>
-            <table class="table mb-200">
+            <table class="table button-table mb-200">
                 <thead>
                     <tr>
                         <th scope="col">
@@ -501,6 +501,33 @@
 
         <div class="my-450">
             <h2>
+                Dark Background
+            </h2>
+            <div class="bg-gray pb-100 px-200 pt-200 rounded-lg">
+                <es-button class="mb-100 mr-50">
+                    Primary button
+                </es-button>
+                <es-button
+                    class="mb-100 mr-50"
+                    variant="secondary">
+                    Secondary button
+                </es-button>
+                <es-button
+                    class="mb-100 mr-50"
+                    outline>
+                    Outline primary button
+                </es-button>
+                <es-button
+                    class="mb-100 mr-50"
+                    outline
+                    variant="secondary">
+                    Outline secondary button
+                </es-button>
+            </div>
+        </div>
+
+        <div class="my-450">
+            <h2>
                 Link button
             </h2>
             <p>
@@ -509,7 +536,7 @@
                 will appear next to another button (e.g. within a modal), as they will remain vertically
                 aligned relative to each other.
             </p>
-            <table class="table mb-200">
+            <table class="table button-table mb-200">
                 <thead>
                     <tr>
                         <th scope="col">
@@ -601,7 +628,7 @@
                 They are a legacy artifact of Bootstrap, don't match EnergySage branding, and will be removed in a
                 future version of ESDS.
             </p>
-            <div class="mb-200">
+            <div class="button-table mb-200">
                 <es-button variant="success">
                     Success button
                 </es-button>
@@ -633,7 +660,7 @@
                     Highlight dark button
                 </es-button>
             </div>
-            <div class="mb-50">
+            <div class="button-table mb-50">
                 <es-button
                     outline
                     variant="success">
@@ -776,11 +803,13 @@ export default {
  * for the purposes of this documentation page while keeping the
  * example code patterns simple and easy to copy out.
  *
- * normally, one would want to use "mb-2" or "mr-2" utility classes
+ * normally, one would want to use "mb-50" or "mr-50" utility classes
  * on the buttons to accomplish this spacing.
  */
-button {
-    margin-bottom: $spacer * 0.5;
-    margin-right: $spacer * 0.5;
+.button-table {
+    button {
+        margin-bottom: $spacer * 0.5;
+        margin-right: $spacer * 0.5;
+    }
 }
 </style>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-147

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Outline buttons now have a white background instead of a transparent background, matching the ESDS Figma and allowing them to be used in containers with a dark background (like the new nav CTA bar)
- Added a section to the EsButton docs page showing the four primary variants against a commonly-used dark background color

#### New docs section
<img width="1170" alt="Screen Shot 2023-04-13 at 8 35 32 AM" src="https://user-images.githubusercontent.com/1350363/231760128-67374012-6e43-41ac-9149-b16a33fbfc96.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Loaded docs page and observed new white background

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
