### PR TITLE
feat: added new gray-150 color

### DIFF
--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -8,6 +8,7 @@
 // Gray Scale
 $white:    #fff !default;
 $gray-100: #fafafa !default;
+$gray-150: #f8f8f8 !default;
 $gray-200: #ececec !default;
 $gray-300: #dddddd !default;
 $gray-400: #bababa !default;
@@ -25,6 +26,7 @@ $grays: () !default;
 $grays: map-merge(
   (
     "gray-100": $gray-100,
+    "gray-150": $gray-150,
     "gray-200": $gray-200,
     "gray-300": $gray-300,
     "gray-400": $gray-400,

--- a/es-bs-base/scss/variables/_grays.scss
+++ b/es-bs-base/scss/variables/_grays.scss
@@ -7,6 +7,7 @@
 :export {
   white: $white;
   gray-100: $gray-100;
+  gray-150: $gray-150;
   gray-200: $gray-200;
   gray-300: $gray-300;
   gray-400: $gray-400;

--- a/es-design-system/pages/atoms/color.vue
+++ b/es-design-system/pages/atoms/color.vue
@@ -246,9 +246,9 @@
                     <ds-color-swatch
                         :hex="value"
                         :is-light="[
-                            'white', 'gray-100', 'gray-200', 'gray-300', 'gray-400', 'gray-500'
+                            'white', 'gray-100', 'gray-150', 'gray-200', 'gray-300', 'gray-400', 'gray-500'
                         ].includes(alias)"
-                        :show-border="['white', 'gray-100'].includes(alias)"
+                        :show-border="['white', 'gray-100', 'gray-150'].includes(alias)"
                         :token="alias" />
                 </b-col>
             </b-row>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/ESDS-150

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added new `gray-150` color of `#F8F8F8`
- Colors page shows it in the Grayscale section

#### New color in Grayscale section
<img width="1177" alt="Screen Shot 2023-04-17 at 9 49 49 AM" src="https://user-images.githubusercontent.com/1350363/232504539-58331345-b689-42e9-b951-02feb6a37833.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Ensured the `bg-gray-150` class rendered correctly on Colors docs page
- Tested `text-gray-150` using dev tools as well

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
