### PR TITLE
feat: added sticky nav bar

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -257,12 +257,13 @@ $nav-hover-delay: 300ms;
 
     // sticky nav bar, initially positioned out of viewport
     .nav-es-sticky {
-      left: 0;
-      right: 0;
       top: 0;
-      transform: translateY(-100%);
-      transition: $transition-base;
+      right: 0;
+      left: 0;
       z-index: 1000;
+      // stylelint-disable-next-line property-disallowed-list
+      transition: $transition-base;
+      transform: translateY(-100%);
     }
 
     // when scrolled down, animate sticky nav bar into viewport

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -153,15 +153,21 @@ $nav-hover-delay: 300ms;
   }
 }
 
-.nav-es-global {
-  // default should be size 14px according to figma
-  font-size: $font-size-75;
+.nav-es-container {
 
-  // add a background so veil goes under the nav and nav stands out against page bg
-  background-color: $white;
+  .nav-es-global,
+  .nav-es-sticky {
+    // default should be size 14px according to figma
+    font-size: $font-size-75;
+  }
 
-  // shadow for additional visual separation between nav and more plain pages
-  box-shadow: 0 4px 4px rgba(221, 221, 221, 0.25);
+  .nav-es-global {
+    // add a background so veil goes under the nav and nav stands out against page bg
+    background-color: $white;
+
+    // shadow for additional visual separation between nav and more plain pages
+    box-shadow: 0 4px 4px rgba(221, 221, 221, 0.25);
+  }
 
   // override es-ds default
   .btn-link {
@@ -180,19 +186,18 @@ $nav-hover-delay: 300ms;
   }
 
   // Adjust default nav-link styling
-  &.navbar-light {
-    .navbar-nav {
-      // stylelint-disable-next-line selector-max-class
-      .nav-item.nav-link,
-      .dropdown-item.nav-link {
-        color: $gray-900;
+  .nav-es-sticky,
+  .navbar-light .navbar-nav {
+    // stylelint-disable-next-line selector-max-class
+    .nav-item.nav-link,
+    .dropdown-item.nav-link {
+      color: $gray-900;
 
-        // stylelint-disable-next-line selector-max-class
-        &:hover {
-          font-weight: $font-weight-semibold;
-          color: $gray-900;
-          text-decoration: underline;
-        }
+      // stylelint-disable-next-line selector-max-class
+      &:hover {
+        font-weight: $font-weight-semibold;
+        color: $gray-900;
+        text-decoration: underline;
       }
     }
   }
@@ -240,12 +245,32 @@ $nav-hover-delay: 300ms;
 
   // On Desktop a hovers display the dropdowns
   @media only screen and (min-width: $desktop-min-width) {
-    // pull navbar up to avoid overlay from getting covered by other DOM elements
-    z-index: 1000;
+    .nav-es-global,
+    .nav-es-sticky {
+      // pull navbar up to avoid overlay from getting covered by other DOM elements
+      z-index: 1000;
 
-    // shadow for additional visual separation between nav and more plain pages
-    filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
-    box-shadow: none;
+      // shadow for additional visual separation between nav and more plain pages
+      filter: drop-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
+      box-shadow: none;
+    }
+
+    // sticky nav bar, initially positioned out of viewport
+    .nav-es-sticky {
+      left: 0;
+      right: 0;
+      top: 0;
+      transform: translateY(-100%);
+      transition: $transition-base;
+      z-index: 1000;
+    }
+
+    // when scrolled down, animate sticky nav bar into viewport
+    &.scrolled {
+      .nav-es-sticky {
+        transform: translateY(0%);
+      }
+    }
 
     // Allow dropdown content to take up the full width of the page
     .dropdown-full-page {
@@ -285,6 +310,8 @@ $nav-hover-delay: 300ms;
 
     // Show top headers down chevron icon
     .nav-item {
+      cursor: pointer;
+
       .top-header-icon {
         // stylelint-disable-next-line property-disallowed-list
         transition: transform 0s;
@@ -465,8 +492,10 @@ $nav-hover-delay: 300ms;
 
   // A lot of custom styles for the mobile navigation menu
   @media only screen and (max-width: $mobile-max-width) {
-    // Set collapsed navbar height
-    height: 56px;
+    .nav-es-global {
+      // Set collapsed navbar height
+      height: 56px;
+    }
 
     // Force navigation items to align to the top and avoid conflict with other components on the page
     // Ensure menus are visible above overlay

--- a/es-design-system/pages/organisms/es-nav-bar.vue
+++ b/es-design-system/pages/organisms/es-nav-bar.vue
@@ -8,6 +8,13 @@
             container. See above.
         </p>
 
+        <p
+            v-for="index in 10"
+            :key="index"
+            class="my-800">
+            Sample content to increase page length; for testing the sticky nav bar.
+        </p>
+
         <!-- print out EsNavBar's mounted() script here so the rip-the-nav utility can access it -->
         <!-- eslint-disable vue/no-v-html -->
         <pre

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -1,5 +1,7 @@
 <template>
-    <div id="nav-main">
+    <div
+        id="nav-main"
+        class="nav-es-container">
         <div class="content-overlay" />
         <nav
             class="nav-es-global navbar navbar-expand navbar-light py-0">
@@ -92,57 +94,10 @@
                             :sub-heading="topLevelMenu.subHeading"
                             :topics="topLevelMenu.topics" />
                         <!-- desktop account menu -->
-                        <div class="d-none d-lg-block">
-                            <li class="icon-dropdown">
-                                <div class="nav-item">
-                                    <div class="nav-link dropdown-toggle d-none d-lg-flex flex-nowrap py-100">
-                                        <IconPerson class="align-self-center" />
-                                        <div class="first-name align-self-center pl-50">
-                                            Sign in
-                                        </div>
-                                    </div>
-                                    <div class="menu">
-                                        <ul
-                                            class="loggedIn dropdown-menu account-menu rounded mt-0 py-100"
-                                            style="display: none">
-                                            <li
-                                                v-for="item in items.accountMenu.loggedIn.items"
-                                                :key="item.name">
-                                                <a
-                                                    class="dropdown-item nav-link"
-                                                    :href="item.link">
-                                                    <span class="mx-50"> {{ item.name }} </span>
-                                                </a>
-                                            </li>
-                                        </ul>
-                                        <ul
-                                            class="loggedOut dropdown-menu account-menu rounded mt-0"
-                                            style="display: none">
-                                            <a
-                                                class="d-flex justify-content-around text-decoration-none"
-                                                :href="items.accountMenu.loggedOut.signIn.link">
-                                                <EsButton
-                                                    :outline="true"
-                                                    variant="secondary"
-                                                    class="m-100 w-75">
-                                                    {{ items.accountMenu.loggedOut.signIn.name }}
-                                                </EsButton>
-                                            </a>
-                                            <li>
-                                                <a
-                                                    class="d-flex justify-content-around"
-                                                    :href="items.accountMenu.loggedOut.createAccount.link">
-                                                    <EsButton
-                                                        variant="link">
-                                                        {{ items.accountMenu.loggedOut.createAccount.name }}
-                                                    </EsButton>
-                                                </a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </li>
-                        </div>
+                        <es-nav-bar-account-menu
+                            :auth-items="items.accountMenu.loggedIn.items"
+                            class="d-none d-lg-block"
+                            :logged-out="items.accountMenu.loggedOut" />
                     </b-container>
                     <!-- mobile+desktop product menus -->
                     <div class="row mx-0 d-flex justify-content-lg-center">
@@ -221,11 +176,34 @@
                 </ul>
             </div>
         </nav>
+        <!-- sticky nav bar -->
+        <nav class="nav-es-sticky bg-white d-none d-lg-block position-fixed py-25">
+            <b-container class="align-items-center d-flex justify-content-between">
+                <!-- EnergySage logo -->
+                <a
+                    class="navbar-brand d-none d-lg-block"
+                    :href="items.home.link">
+                    <!-- small desktop logo -->
+                    <es-logo
+                        width="128px"
+                        height="28px" />
+                    <span class="sr-only">
+                        {{ items.home.name }}
+                    </span>
+                </a>
+                <!-- desktop account menu -->
+                <es-nav-bar-account-menu
+                    :auth-items="items.accountMenu.loggedIn.items"
+                    class="d-none d-lg-block"
+                    :logged-out="items.accountMenu.loggedOut" />
+            </b-container>
+        </nav>
     </div>
 </template>
 
 <script lang="js">
 import EsButton from './EsButton.vue';
+import EsNavBarAccountMenu from './EsNavBarAccountMenu.vue';
 import EsNavBarProductMenu from './EsNavBarProductMenu.vue';
 import EsNavBarTopLevelMenu from './EsNavBarTopLevelMenu.vue';
 import NAV_BAR_CONTENT from '../lib-data/es-nav-bar-content';
@@ -237,6 +215,7 @@ export default {
     components: {
         EsButton,
         EsLogo,
+        EsNavBarAccountMenu,
         EsNavBarProductMenu,
         EsNavBarTopLevelMenu,
     },
@@ -300,7 +279,7 @@ export default {
         // Show overlay on hovers for desktop only
         // eslint-disable-next-line max-len
         document.querySelectorAll(
-            '.nav-es-global .nav-item .dropdown-toggle, .nav-es-global .nav-item .dropdown-menu',
+            '.nav-es-container .nav-item .dropdown-toggle, .nav-es-container .nav-item .dropdown-menu',
         )
             .forEach((element) => {
                 element.addEventListener('mouseover', () => {
@@ -334,18 +313,18 @@ export default {
         const menuDisplay = ({ loggedOut }) => {
             if (loggedOut) {
                 // logged out so allow loggedOut menu and the compare buttons to be visible
-                document.querySelectorAll('.nav-es-global .loggedOut').forEach((element) => {
+                document.querySelectorAll('.nav-es-container .loggedOut').forEach((element) => {
                     // eslint-disable-next-line no-param-reassign
                     element.style.display = null;
                 });
             } else {
                 // logged in so allow logged in menu to be visible, and show name with appropriate layout
-                document.querySelectorAll('.nav-es-global .loggedIn').forEach((element) => {
+                document.querySelectorAll('.nav-es-container .loggedIn').forEach((element) => {
                     // eslint-disable-next-line no-param-reassign
                     element.style.display = null;
                 });
-                document.querySelector('.nav-es-global .icon-dropdown .dropdown-toggle').style.display = 'flex';
-                document.querySelector('.nav-es-global .icon-dropdown .dropdown-toggle .first-name')
+                document.querySelector('.nav-es-container .icon-dropdown .dropdown-toggle').style.display = 'flex';
+                document.querySelector('.nav-es-container .icon-dropdown .dropdown-toggle .first-name')
                     .style.display = 'block';
             }
         };
@@ -357,7 +336,9 @@ export default {
             .then((response) => response.json())
             .then((data) => {
                 const name = data?.first_name || null;
-                document.querySelector('.nav-es-global .icon-dropdown .dropdown-toggle .first-name').innerHTML = name;
+                document.querySelector(
+                    '.nav-es-container .icon-dropdown .dropdown-toggle .first-name',
+                ).innerHTML = name;
                 menuDisplay({ loggedOut: (name === null) });
             }).catch((e) => {
                 // eslint-disable-next-line no-console
@@ -370,6 +351,29 @@ export default {
         window.addEventListener('pageshow', () => {
             collapse_mobile_menus();
         });
+
+        // set up options for sticky nav intersection observer
+        const intersectionOptions = {
+            rootMargin: '0px',
+            threshold: 0.0,
+        };
+
+        // set up callback for sticky nav intersection observer
+        const intersectionCallback = (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.remove('scrolled');
+                } else {
+                    entry.target.classList.add('scrolled');
+                }
+            });
+        };
+
+        // initialize intersection observer to detect when nav scrolls out of viewport
+        // https://www.smashingmagazine.com/2021/07/dynamic-header-intersection-observer/
+        const observer = new IntersectionObserver(intersectionCallback, intersectionOptions);
+        const targetEl = document.querySelector('#nav-main');
+        observer.observe(targetEl);
 
         // CUSTOM GLOBAL-NAV SCRIPT ENDS
     },

--- a/es-vue-base/src/lib-components/EsNavBarAccountMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarAccountMenu.vue
@@ -1,0 +1,69 @@
+<template>
+    <div>
+        <li class="icon-dropdown">
+            <div class="nav-item">
+                <div class="nav-link dropdown-toggle d-none d-lg-flex flex-nowrap py-100">
+                    <IconPerson class="align-self-center" />
+                    <div class="first-name align-self-center pl-50">
+                        Sign in
+                    </div>
+                </div>
+                <div class="menu">
+                    <ul
+                        class="loggedIn dropdown-menu account-menu rounded mt-0 py-100"
+                        style="display: none">
+                        <li
+                            v-for="item in authItems"
+                            :key="item.name">
+                            <a
+                                class="dropdown-item nav-link"
+                                :href="item.link">
+                                <span class="mx-50"> {{ item.name }} </span>
+                            </a>
+                        </li>
+                    </ul>
+                    <ul
+                        class="loggedOut dropdown-menu account-menu rounded mt-0"
+                        style="display: none">
+                        <a
+                            class="d-flex justify-content-around text-decoration-none"
+                            :href="loggedOut.signIn.link">
+                            <EsButton
+                                :outline="true"
+                                variant="secondary"
+                                class="m-100 w-75">
+                                {{ loggedOut.signIn.name }}
+                            </EsButton>
+                        </a>
+                        <li>
+                            <a
+                                class="d-flex justify-content-around"
+                                :href="loggedOut.createAccount.link">
+                                <EsButton
+                                    variant="link">
+                                    {{ loggedOut.createAccount.name }}
+                                </EsButton>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </li>
+    </div>
+</template>
+
+<script lang="js">
+export default {
+    name: 'EsNavBarAccountMenu',
+    props: {
+        authItems: {
+            type: Array,
+            default: () => [],
+        },
+        loggedOut: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-504

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added a sticky nav bar to `EsNavBar` that animates in as soon as the user scrolls past the nav, and animates back out as soon as the nav scrolls back into view
- Utilized intersection observer for performant updating of scroll state
- Converted the desktop account menu into a reusable component so it could be used in both the regular nav and the sticky nav
- Does not appear at all on mobile

#### Sticky nav bar
<img width="1408" alt="Screen Shot 2023-05-02 at 11 34 54 AM" src="https://user-images.githubusercontent.com/1350363/235714523-31f31435-8ced-4284-9a7c-fc980ba3a49c.png">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested in Chrome responsive devtools, Firefox, Safari

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
