### PR TITLE
fix: mobile nav indentation and layout fixes

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -539,7 +539,7 @@ $nav-hover-delay: 300ms;
       width: 100%;
       border-style: none;
 
-      .nav-item {
+      .nav-item:not(.nav-link) {
         margin: 0;
       }
     }

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -149,7 +149,7 @@
                         <a
                             class="dropdown-item nav-item nav-item-border-mobile nav-link align-items-center d-flex px-lg-100 py-lg-50"
                             :href="item.link">
-                            <span class="mx-50"> {{ item.name }} </span>
+                            {{ item.name }}
                         </a>
                     </li>
                 </ul>

--- a/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
@@ -79,7 +79,7 @@
             </ul>
             <div
                 v-if="topics && topics.length"
-                class="product-menu-flyout product-menu-flyout--large dropdown-menu row border-0 mt-0 p-lg-100">
+                class="product-menu-flyout product-menu-flyout--large dropdown-menu border-0 flex-wrap mt-0 p-lg-100">
                 <!-- mobile subnav header -->
                 <p
                     class="nav-item nav-item-border-mobile nav-link align-items-center d-flex d-lg-none font-weight-bold justify-content-between mb-0 text-decoration-none w-100">
@@ -92,18 +92,18 @@
                 </p>
                 <b-row
                     tag="ul"
-                    class="list-unstyled">
+                    class="d-block d-lg-flex list-unstyled">
                     <es-nav-bar-topic-menu
                         v-for="topic in topics"
                         :key="topic.name"
-                        class="col-lg-4"
+                        class="col-lg-4 d-block"
                         :items="topic.subtopics"
                         :link="topic.link"
                         :new-tab="topic.newTab"
                         :name="topic.name"
                         :show-items-on-mobile="topic.showItemsOnMobile"
                         :sub-heading="topic.subHeading" />
-                    <li class="col-lg-4 m-100 m-lg-0">
+                    <li class="col-lg-4 d-block m-100 m-lg-0">
                         <es-nav-bar-featured-article
                             :eyebrow="featuredArticle.eyebrow"
                             :link="featuredArticle.link"

--- a/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
@@ -103,7 +103,7 @@
                         :name="topic.name"
                         :show-items-on-mobile="topic.showItemsOnMobile"
                         :sub-heading="topic.subHeading" />
-                    <li class="col-lg-4 d-block m-100 m-lg-0">
+                    <li class="nav-item col-lg-4 d-block h-100 my-100 my-lg-0">
                         <es-nav-bar-featured-article
                             :eyebrow="featuredArticle.eyebrow"
                             :link="featuredArticle.link"

--- a/es-vue-base/src/lib-components/EsNavBarTopicMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopicMenu.vue
@@ -92,15 +92,18 @@
                     </a>
                     <div
                         v-else
-                        class="nav-item nav-item-border-mobile nav-link text-decoration-none font-weight-bold d-flex w-100 align-items-center">
-                        {{ name }}
+                        class="nav-item col-12">
+                        <span
+                            class="nav-link align-items-center border-bottom d-flex font-weight-bold h-100 text-decoration-none w-100">
+                            {{ name }}
+                        </span>
                     </div>
                 </li>
                 <li
                     v-for="item in items"
                     :key="item.name">
                     <a
-                        class="dropdown-item nav-item nav-item-border-mobile nav-link d-flex align-items-center ml-50 ml-lg-0 px-lg-0 py-lg-50"
+                        class="dropdown-item nav-item nav-item-border-mobile nav-link d-flex align-items-center ml-lg-0 px-lg-0 py-lg-50"
                         :class="{ 'font-weight-bold': item.emphasize }"
                         :href="item.link"
                         :target="newTab ? '_blank' : null">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-514
- https://energysage.atlassian.net/browse/CED-515

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixed issue where Home Solar mobile nav had a horizontal scrollbar
- Fixed issue where Home Solar mobile nav link border was not full width
- Fixed issue where third-level mobile nav title was not properly indented

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested in Chrome responsive devtools at iPhone SE and iPhone 12 Pro widths
- Tested desktop menu in Chrome, Firefox, Safari to ensure no layout regressions were introduced

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
