### PR TITLE
fix: moved out hardcoded footer link and content

### DIFF
--- a/es-vue-base/src/lib-components/EsFooter.vue
+++ b/es-vue-base/src/lib-components/EsFooter.vue
@@ -5,13 +5,12 @@
             <div class="container">
                 <div class="row">
                     <div class="col col-12 col-md-5 col-lg-4 font-size-300 font-weight-bolder mb-150 mb-md-0">
-                        Make an impact.
+                        {{ content.banner.headline }}
                         <br class="d-none d-md-block">
-                        It's never been easier.
+                        {{ content.banner.subHeadline }}
                     </div>
                     <div class="col col-12 col-md-7 col-lg-8">
-                        We developed our one-of-a-kind marketplace with funding from the U.S. Department of Energy
-                        to make clean home energy solutions affordable and accessible to all.
+                        {{ content.banner.body }}
                     </div>
                 </div>
             </div>
@@ -48,8 +47,10 @@
                 <div class="col col-12 col-lg-4 order-lg-0 mb-200">
                     <a
                         class="d-block mb-150"
-                        href="https://www.energysage.com/">
-                        <span class="sr-only">EnergySage</span>
+                        :href="content.home.link">
+                        <span class="sr-only">
+                            {{ content.home.name }}
+                        </span>
                         <es-logo
                             height="36px"
                             width="160px" />
@@ -71,12 +72,10 @@
             <hr class="border-top border-dark m-0">
             <!-- Trademark Info -->
             <p class="mt-150 mt-lg-200">
-                ENERGYSAGE is a registered trademark and the EnergySage logo is a trademark of EnergySage, Inc.
-                Other trademarks are the property of either EnergySage, Inc. or our licensors
-                and are used with permission.
+                {{ content.trademarkText }}
             </p>
             <p class="mb-200">
-                © Copyright 2009-{{ new Date().getFullYear() }} EnergySage, Inc. All rights reserved.
+                {{ copyrightText }}
             </p>
             <!-- Trademark Info -->
             <!-- Legal -->
@@ -96,14 +95,14 @@
             <div class="d-lg-flex align-items-end">
                 <!-- eslint-disable-next-line -->
                 <img
-                    src="https://www-static.energysage.com/static/img/doe/doe-logo-179.943fe6467b04.png"
+                    :src="content.departmentOfEnergy.logoUrl"
                     aria-hidden="true"
                     class="mr-100 mb-100 mb-lg-0"
                     width="99"
                     height="25">
                 <p class="mb-0">
-                    <a href="https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems">
-                        Learn more about our success working with the US. Department of Energy.
+                    <a :href="content.departmentOfEnergy.learnMore.link">
+                        {{ content.departmentOfEnergy.learnMore.text }}
                     </a>
                 </p>
             </div>  <!-- DOE -->
@@ -123,6 +122,11 @@ export default {
         content: {
             type: Object,
             required: true,
+        },
+    },
+    computed: {
+        copyrightText() {
+            return this.content.copyrightText.replace('{currentYear}', new Date().getFullYear());
         },
     },
 };

--- a/es-vue-base/src/lib-components/EsFooter.vue
+++ b/es-vue-base/src/lib-components/EsFooter.vue
@@ -101,7 +101,9 @@
                     width="99"
                     height="25">
                 <p class="mb-0">
-                    <a :href="content.departmentOfEnergy.learnMore.link">
+                    <a
+                        :href="content.departmentOfEnergy.learnMore.link"
+                        target="_blank">
                         {{ content.departmentOfEnergy.learnMore.text }}
                     </a>
                 </p>

--- a/es-vue-base/src/lib-utils/footer-content.js
+++ b/es-vue-base/src/lib-utils/footer-content.js
@@ -5,6 +5,16 @@ export default (
     HEAT_PUMPS_DOMAIN = process.env.HEAT_PUMPS_DOMAIN || 'https://heatpumps.energysage.com',
     HELP_DOMAIN = process.env.HELP_DOMAIN || 'https://help.energysage.com',
 ) => ({
+    banner: {
+        headline: 'Make an impact.',
+        subHeadline: 'It\'s never been easier.',
+        body: `We developed our one-of-a-kind marketplace with funding from the U.S. Department of Energy to make
+            clean home energy solutions affordable and accessible to all.`,
+    },
+    home: {
+        name: 'EnergySage',
+        link: ES_DOMAIN,
+    },
     columns: [
         // TODO: remove new tab option once other verticals adopt global nav
         {
@@ -62,4 +72,14 @@ export default (
         { text: 'Mobile terms of use', url: `${ES_DOMAIN}/mobile-terms-of-use/` },
         { text: 'Non-discrimination policy', url: `${ES_DOMAIN}/nondiscrimination/` },
     ],
+    copyrightText: '© Copyright 2009-{currentYear} EnergySage, Inc. All rights reserved.',
+    trademarkText: `ENERGYSAGE is a registered trademark and the EnergySage logo is a trademark of EnergySage, Inc.
+        Other trademarks are the property of either EnergySage, Inc. or our licensors and are used with permission.`,
+    departmentOfEnergy: {
+        learnMore: {
+            link: 'https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems',
+            text: 'Learn more about our success working with the US. Department of Energy.',
+        },
+        logoUrl: 'https://www-static.energysage.com/static/img/doe/doe-logo-179.943fe6467b04.png',
+    },
 });

--- a/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
@@ -11,8 +11,8 @@ exports[`EsFooter <EsFooter /> 1`] = `
           It's never been easier.
         </div>
         <div class="col col-12 col-md-7 col-lg-8">
-          We developed our one-of-a-kind marketplace with funding from the U.S. Department of Energy
-          to make clean home energy solutions affordable and accessible to all.
+          We developed our one-of-a-kind marketplace with funding from the U.S. Department of Energy to make
+          clean home energy solutions affordable and accessible to all.
         </div>
       </div>
     </div>
@@ -114,7 +114,9 @@ exports[`EsFooter <EsFooter /> 1`] = `
           </div>
         </div>
       </div>
-      <div class="col col-12 col-lg-4 order-lg-0 mb-200"><a href="https://www.energysage.com/" class="d-block mb-150"><span class="sr-only">EnergySage</span> <svg viewBox="0 0 128 28" fill="none" xmlns="http://www.w3.org/2000/svg" style="height: 36px; width: 160px;">
+      <div class="col col-12 col-lg-4 order-lg-0 mb-200"><a href="https://www.energysage.com" class="d-block mb-150"><span class="sr-only">
+                        EnergySage
+                    </span> <svg viewBox="0 0 128 28" fill="none" xmlns="http://www.w3.org/2000/svg" style="height: 36px; width: 160px;">
             <path d="M3.14213 14.8032C3.14213 17.7722 3.93937 18.3618 5.28209 18.3618C6.45696 18.3618 7.06538 17.4143 7.12832 16.3403H9.00952C9.00952 18.6988 7.54092 19.7727 5.31705 19.7727C3.09318 19.7727 1.2959 19.0708 1.2959 14.4101C1.2959 11.2936 1.64556 8.72461 5.31705 8.72461C8.33816 8.72461 9.09344 10.3881 9.09344 13.8977V14.8032H3.14213ZM7.26819 13.4976C7.26819 10.4092 6.40801 10.0302 5.17019 10.0302C4.07924 10.0302 3.1771 10.5566 3.14913 13.4976H7.26819Z" fill="#616161"></path>
             <path d="M17.6882 19.562V12.1989C17.6882 11.0548 17.2966 10.0932 15.821 10.0932C13.9398 10.0932 13.6671 11.7778 13.6671 13.2378V19.555H11.9467V11.1391C11.9467 10.402 11.9047 9.66504 11.8418 8.92804H13.6671V10.2968H13.751C14.0014 9.77108 14.4086 9.33662 14.9161 9.05364C15.4236 8.77066 16.0063 8.65317 16.5833 8.71746C18.8421 8.71746 19.3806 10.1213 19.3806 12.227V19.562H17.6882Z" fill="#616161"></path>
             <path d="M24.1083 14.8032C24.1083 17.7722 24.9055 18.3618 26.2482 18.3618C27.4231 18.3618 28.0315 17.4143 28.0945 16.3403H29.9827C29.9827 18.6988 28.5141 19.7727 26.2902 19.7727C24.0663 19.7727 22.269 19.0708 22.269 14.4101C22.269 11.2936 22.6257 8.72461 26.2902 8.72461C29.3113 8.72461 30.0666 10.3881 30.0666 13.8977V14.8032H24.1083ZM28.2413 13.4976C28.2413 10.4092 27.3812 10.0302 26.1433 10.0302C25.0524 10.0302 24.1502 10.5566 24.1293 13.4976H28.2413Z" fill="#616161"></path>
@@ -141,8 +143,7 @@ exports[`EsFooter <EsFooter /> 1`] = `
     <hr class="border-top border-dark m-0">
     <p class="mt-150 mt-lg-200">
       ENERGYSAGE is a registered trademark and the EnergySage logo is a trademark of EnergySage, Inc.
-      Other trademarks are the property of either EnergySage, Inc. or our licensors
-      and are used with permission.
+      Other trademarks are the property of either EnergySage, Inc. or our licensors and are used with permission.
     </p>
     <p class="mb-200">
       © Copyright 2009-2023 EnergySage, Inc. All rights reserved.
@@ -162,7 +163,7 @@ exports[`EsFooter <EsFooter /> 1`] = `
         </a></div>
     </div>
     <div class="d-lg-flex align-items-end"><img src="https://www-static.energysage.com/static/img/doe/doe-logo-179.943fe6467b04.png" aria-hidden="true" width="99" height="25" class="mr-100 mb-100 mb-lg-0">
-      <p class="mb-0"><a href="https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems">
+      <p class="mb-0"><a href="https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems" target="_blank">
           Learn more about our success working with the US. Department of Energy.
         </a></p>
     </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-509

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes an issue where the EnergySage logo in the footer wasn't linking to the domain specified in the env variable
- Moves out the remaining hardcoded text and link content in EsFooter to the separate content object
- `energy.gov` link now opens in a new tab

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested passing in `https://www.google.com` as the first argument to `getEsFooterContent` and observed all the appropriate links updated their destinations, including the EnergySage logo
- Confirmed locally that all the moved-out content was still rendering properly on the page

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
