### PR TITLE
fix: default bold font weight, EsSupportCard flexibility

### DIFF
--- a/es-bs-base/scss/_reboot.scss
+++ b/es-bs-base/scss/_reboot.scss
@@ -155,7 +155,7 @@ blockquote {
 
 b,
 strong {
-  font-weight: $font-weight-bolder; // Add the correct font weight in Chrome, Edge, and Safari
+  font-weight: $font-weight-bold; // Add the correct font weight in Chrome, Edge, and Safari
 }
 
 small {

--- a/es-design-system/pages/atoms/typography.vue
+++ b/es-design-system/pages/atoms/typography.vue
@@ -66,11 +66,13 @@
                         Paragraph: Mint lime taco salsa lemon lime minty tabasco
                         pepper apple vinaigrette chai tea portobello mushrooms
                         couscous eating together green bowl tahini drizzle mint
-                        crispy iceberg lettuce orange dill lentils lime Southern
-                        Italian mediterranean vegetables pasta lemon. Hummus
-                        falafel bowl red grapes plums peppermint artichoke hearts
-                        ultimate crunchy seaweed lemonade zest walnut mushroom tart
-                        macadamia nut cookies apples hearts of palm cherries Thai
+                        crispy iceberg lettuce orange dill lentils lime.
+                        <b>
+                            Southern Italian mediterranean vegetables pasta lemon.
+                        </b>
+                        Hummus falafel bowl red grapes plums peppermint artichoke hearts.
+                        Ultimate crunchy seaweed lemonade zest walnut mushroom tart
+                        macadamia nut cookies apples hearts of palm cherries. Thai
                         super chili lemon tahini dressing seeds sweet potato dragon
                         fruit smoked tofu.
                     </p>

--- a/es-design-system/pages/organisms/es-support-card.vue
+++ b/es-design-system/pages/organisms/es-support-card.vue
@@ -76,7 +76,7 @@
                             Default
                         </dt>
                         <dd>
-                            n/a
+                            <code>''</code>
                         </dd>
                     </dl>
                     <dl>
@@ -84,7 +84,8 @@
                             Description
                         </dt>
                         <dd>
-                            Required. The alternate text for the image.
+                            The alternate text for the image. Used by default unless content is supplied to the
+                            <code>image</code> slot.
                         </dd>
                     </dl>
                 </ds-responsive-table-row>
@@ -102,7 +103,7 @@
                             Default
                         </dt>
                         <dd>
-                            n/a
+                            <code>''</code>
                         </dd>
                     </dl>
                     <dl>
@@ -110,7 +111,8 @@
                             Description
                         </dt>
                         <dd>
-                            Required. The URL of the image to display.
+                            The URL of the image to display. Used by default unless content is supplied to the
+                            <code>image</code> slot.
                         </dd>
                     </dl>
                 </ds-responsive-table-row>
@@ -302,6 +304,34 @@
                         </dt>
                         <dd>
                             The content to insert into the card's heading.
+                        </dd>
+                    </dl>
+                </ds-responsive-table-row>
+                <ds-responsive-table-row>
+                    <dl>
+                        <dt>
+                            Name
+                        </dt>
+                        <dd>
+                            <code>image</code>
+                        </dd>
+                    </dl>
+                    <dl>
+                        <dt>
+                            Default
+                        </dt>
+                        <dd>
+                            <code>&lt;b-img&gt;</code>
+                        </dd>
+                    </dl>
+                    <dl>
+                        <dt>
+                            Description
+                        </dt>
+                        <dd>
+                            Optional. Replaces the default <code>&lt;b-img&gt;</code> tag that uses the
+                            <code>imageSrc</code> and <code>imageAltText</code> props. Allows full customization
+                            of the image component used, for example if a <code>&lt;nuxt-img&gt;</code> is desired.
                         </dd>
                     </dl>
                 </ds-responsive-table-row>

--- a/es-vue-base/src/lib-components/EsSupportCard.vue
+++ b/es-vue-base/src/lib-components/EsSupportCard.vue
@@ -24,7 +24,7 @@
                     component) for consuming applications to use in targeting ::v-deep styles on <p> tags to remove
                     the natural <p> bottom margin, for example.
 
-                    e.g. the Storyblok Richtext component generates a <p> tag within this that automatically
+                    e.g. a CMS rich text component may generate a <p> tag within this that automatically
                     gets a bottom margin, which throws off the vertical centering. we are intentionally leaving
                     the removal of that bottom margin up to consuming applications rather than removing it on all
                     <p> tags within this element, in case they may want two <p> tags or any other markup in here.

--- a/es-vue-base/src/lib-components/EsSupportCard.vue
+++ b/es-vue-base/src/lib-components/EsSupportCard.vue
@@ -8,15 +8,30 @@
                 <h2 class="align-items-center d-flex font-size-300 justify-content-center justify-content-lg-start mb-150 mb-lg-100 pl-lg-200">
                     <slot name="headline" />
                 </h2>
-                <b-img
-                    :alt="imageAltText"
-                    class="EsSupportCard-image bg-teal-200 mb-150 mb-lg-0 rounded-circle"
-                    height="100px"
-                    :src="imageSrc"
-                    width="100px" />
-                <p class="font-size-75 font-size-lg-100 mb-150 mb-lg-0 pl-lg-200">
+                <div class="EsSupportCard-imageContainer mb-150 mb-lg-0">
+                    <slot name="image">
+                        <b-img
+                            v-if="imageAltText && imageSrc"
+                            :alt="imageAltText"
+                            class="bg-teal-200 rounded-circle"
+                            height="100px"
+                            :src="imageSrc"
+                            width="100px" />
+                    </slot>
+                </div>
+                <!--
+                    we are giving 'EsSupportCard-description' a unique class (that we don't use directly in this
+                    component) for consuming applications to use in targeting ::v-deep styles on <p> tags to remove
+                    the natural <p> bottom margin, for example.
+
+                    e.g. the Storyblok Richtext component generates a <p> tag within this that automatically
+                    gets a bottom margin, which throws off the vertical centering. we are intentionally leaving
+                    the removal of that bottom margin up to consuming applications rather than removing it on all
+                    <p> tags within this element, in case they may want two <p> tags or any other markup in here.
+                -->
+                <div class="EsSupportCard-description font-size-75 font-size-lg-100 mb-150 mb-lg-0 pl-lg-200">
                     <slot name="description" />
-                </p>
+                </div>
             </b-col>
             <b-col
                 cols="12"
@@ -61,11 +76,11 @@ export default {
     props: {
         imageAltText: {
             type: String,
-            required: true,
+            default: '',
         },
         imageSrc: {
             type: String,
-            required: true,
+            default: '',
         },
         primaryCtaTarget: {
             type: String,
@@ -112,7 +127,7 @@ export default {
             padding-left: 115px;
         }
 
-        &-image {
+        &-imageContainer {
             /* account for 15px standard column padding */
             left: 15px;
             position: absolute;


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-484

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Lowers the font weight of `<b>` and `<strong>` tags from `700` to `600` to better match the new, lighter default font weight for body text
- Updated the Typography docs page to include a bold sentence within the paragraph example to show the treatment for bold text
- Changed the wrapper element for the `description` slot of `EsSupportCard` from `<p>` to `<div>` to allow for more flexibility in what markup can live inside it
- Provided a new `image` slot for `EsSupportCard` so consuming applications can completely replace the image component used if desired, and made the `imageAltText` and `imageSrc` props no longer required
- Updated the `EsSupportCard` docs page to describe the props and slots updates

#### New bold text within Typography paragraph
<img width="1211" alt="Screen Shot 2023-05-12 at 11 28 00 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/eb93305e-2470-47ff-a343-3479c22910d2">

#### EsSupportCard props and slots updates
<img width="1172" alt="Screen Shot 2023-05-12 at 11 27 17 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/9b657cf2-d7d0-44e5-b1e6-c9f0264b3f5d">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested in Chrome responsive devtools
- Tested the component without `imageAltText` and `imageSrc` provided and ensured it still rendered decently

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
