### PR TITLE
feat: EsFooter and EsNavBar links are now SPA-compatible

### DIFF
--- a/es-vue-base/src/lib-components/EsFooter.vue
+++ b/es-vue-base/src/lib-components/EsFooter.vue
@@ -32,12 +32,12 @@
                                     v-for="link in column.links"
                                     :key="link.text"
                                     class="mt-25 mb-50">
-                                    <a
+                                    <es-nav-bar-link
                                         :href="link.url"
                                         :target="link.newTab ? '_blank' : null"
                                         class="text-reset">
                                         {{ link.text }}
-                                    </a>
+                                    </es-nav-bar-link>
                                 </li>
                             </ul>
                         </div>
@@ -45,7 +45,7 @@
                 </div>  <!-- Link columns -->
                 <!-- Logo and Social-->
                 <div class="col col-12 col-lg-4 order-lg-0 mb-200">
-                    <a
+                    <es-nav-bar-link
                         class="d-block mb-150"
                         :href="content.home.link">
                         <span class="sr-only">
@@ -54,10 +54,10 @@
                         <es-logo
                             height="36px"
                             width="160px" />
-                    </a>
+                    </es-nav-bar-link>
                     <!-- Social icons -->
                     <div class="d-flex text-gray-700">
-                        <a
+                        <es-nav-bar-link
                             v-for="iconLink in content.socialLinks"
                             :key="iconLink.text"
                             class="text-reset pr-150"
@@ -65,7 +65,7 @@
                             target="_blank">
                             <span class="sr-only">{{ iconLink.text }}</span>
                             <component :is="iconLink.icon" />
-                        </a>
+                        </es-nav-bar-link>
                     </div>  <!-- Social icons -->
                 </div>  <!-- Logo and Social -->
             </div>
@@ -84,11 +84,11 @@
                     v-for="link in content.legalLinks"
                     :key="link.text"
                     class="col col-6 col-lg font-size-50 mt-25 mb-50">
-                    <a
+                    <es-nav-bar-link
                         :href="link.url"
                         class="text-reset font-weight-normal">
                         {{ link.text }}
-                    </a>
+                    </es-nav-bar-link>
                 </div>
             </div>  <!-- Legal -->
             <!-- DOE -->
@@ -101,11 +101,11 @@
                     width="99"
                     height="25">
                 <p class="mb-0">
-                    <a
+                    <es-nav-bar-link
                         :href="content.departmentOfEnergy.learnMore.link"
                         target="_blank">
                         {{ content.departmentOfEnergy.learnMore.text }}
-                    </a>
+                    </es-nav-bar-link>
                 </p>
             </div>  <!-- DOE -->
         </div>
@@ -113,12 +113,14 @@
 </template>
 
 <script lang="js">
+import EsNavBarLink from './EsNavBarLink.vue';
 import EsLogo from '../lib-assets/es-logo.vue';
 
 export default {
     name: 'EsFooter',
     components: {
         EsLogo,
+        EsNavBarLink,
     },
     props: {
         content: {

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -18,7 +18,7 @@
                 </label>
             </div>
             <!-- mobile logo -->
-            <a
+            <es-nav-bar-link
                 class="d-flex d-lg-none col-8 align-self-center justify-content-center px-0"
                 :href="globalContent.home.link">
                 <es-logo
@@ -27,7 +27,7 @@
                 <span class="sr-only">
                     {{ globalContent.home.name }}
                 </span>
-            </a>
+            </es-nav-bar-link>
             <!-- mobile account menu trigger -->
             <div class="d-flex d-lg-none justify-content-end col-2 px-0">
                 <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
@@ -72,7 +72,7 @@
                 <ul class="navbar-nav d-flex flex-column w-100">
                     <!-- top-level items on mobile, full top bar on desktop -->
                     <b-container class="align-items-center d-flex flex-lg-nowrap justify-content-between">
-                        <a
+                        <es-nav-bar-link
                             class="navbar-brand d-none d-lg-block"
                             :href="globalContent.home.link">
                             <!-- small desktop logo -->
@@ -88,7 +88,7 @@
                             <span class="sr-only">
                                 {{ globalContent.home.name }}
                             </span>
-                        </a>
+                        </es-nav-bar-link>
                         <!-- top level menus -->
                         <es-nav-bar-top-level-menu
                             v-for="topLevelMenu in globalContent.topLevelMenus"
@@ -159,11 +159,11 @@
                     <li
                         v-for="item in accountContent.loggedIn.items"
                         :key="item.name">
-                        <a
+                        <es-nav-bar-link
                             class="dropdown-item nav-item nav-item-border-mobile nav-link align-items-center d-flex px-lg-100 py-lg-50"
                             :href="item.link">
                             {{ item.name }}
-                        </a>
+                        </es-nav-bar-link>
                     </li>
                 </ul>
                 <!-- logged out menu -->
@@ -193,7 +193,7 @@
         <nav class="nav-es-sticky bg-white d-none d-lg-block position-fixed py-25">
             <b-container class="align-items-center d-flex justify-content-between">
                 <!-- EnergySage logo -->
-                <a
+                <es-nav-bar-link
                     class="navbar-brand d-none d-lg-block"
                     :href="globalContent.home.link">
                     <!-- small desktop logo -->
@@ -203,7 +203,7 @@
                     <span class="sr-only">
                         {{ globalContent.home.name }}
                     </span>
-                </a>
+                </es-nav-bar-link>
                 <!-- desktop account menu -->
                 <es-nav-bar-account-menu
                     :auth-items="accountContent.loggedIn.items"

--- a/es-vue-base/src/lib-components/EsNavBarAccountMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarAccountMenu.vue
@@ -15,19 +15,19 @@
                         <li
                             v-for="item in authItems"
                             :key="item.name">
-                            <a
+                            <es-nav-bar-link
                                 class="dropdown-item nav-link"
                                 :href="item.link">
                                 <span class="mx-50">
                                     {{ item.name }}
                                 </span>
-                            </a>
+                            </es-nav-bar-link>
                         </li>
                     </ul>
                     <ul
                         class="loggedOut dropdown-menu account-menu rounded mt-0"
                         style="display: none">
-                        <a
+                        <es-nav-bar-link
                             class="d-flex justify-content-around text-decoration-none"
                             :href="loggedOut.signIn.link">
                             <EsButton
@@ -36,16 +36,16 @@
                                 class="m-100 w-75">
                                 {{ loggedOut.signIn.name }}
                             </EsButton>
-                        </a>
+                        </es-nav-bar-link>
                         <li>
-                            <a
+                            <es-nav-bar-link
                                 class="d-flex justify-content-around"
                                 :href="loggedOut.createAccount.link">
                                 <EsButton
                                     variant="link">
                                     {{ loggedOut.createAccount.name }}
                                 </EsButton>
-                            </a>
+                            </es-nav-bar-link>
                         </li>
                     </ul>
                 </div>
@@ -55,8 +55,13 @@
 </template>
 
 <script lang="js">
+import EsNavBarLink from './EsNavBarLink.vue';
+
 export default {
     name: 'EsNavBarAccountMenu',
+    components: {
+        EsNavBarLink,
+    },
     props: {
         authItems: {
             type: Array,

--- a/es-vue-base/src/lib-components/EsNavBarFeaturedArticle.vue
+++ b/es-vue-base/src/lib-components/EsNavBarFeaturedArticle.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="dropdown-cta-right">
         <div class="font-size-50">
-            <a
+            <es-nav-bar-link
                 class="d-block cta-link"
                 :href="link"
                 :target="newTab ? '_blank' : null"
@@ -19,15 +19,19 @@
                 <p class="font-weight-bold">
                     {{ name }}
                 </p>
-            </a>
+            </es-nav-bar-link>
         </div>
     </div>
 </template>
 
 <script lang="js">
+import EsNavBarLink from './EsNavBarLink.vue';
 
 export default {
     name: 'EsNavBarFeaturedArticle',
+    components: {
+        EsNavBarLink,
+    },
     props: {
         eyebrow: {
             type: String,

--- a/es-vue-base/src/lib-components/EsNavBarLink.vue
+++ b/es-vue-base/src/lib-components/EsNavBarLink.vue
@@ -1,0 +1,31 @@
+<template>
+    <component
+        :is="tag"
+        :href="isRootRelative ? '' : href"
+        :to="isRootRelative ? href : ''"
+        v-bind="$attrs"
+        v-on="$listeners">
+        <slot />
+    </component>
+</template>
+
+<script lang="js">
+export default {
+    name: 'EsNavBarLink',
+    props: {
+        href: {
+            type: String,
+            default: '',
+        },
+        tag: {
+            type: String,
+            default: 'b-link',
+        },
+    },
+    computed: {
+        isRootRelative() {
+            return this.href.startsWith('/');
+        },
+    },
+};
+</script>

--- a/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
@@ -1,7 +1,7 @@
 <template>
     <li class="dropdown nav-item nav-item-border-mobile">
         <!-- desktop product link / hover menu trigger -->
-        <a
+        <es-nav-bar-link
             class="product-menu-header-link dropdown-toggle d-none d-lg-block px-lg-100 px-xl-200 py-lg-0 text-decoration-none text-gray"
             :href="link"
             :target="newTab ? '_blank' : null"
@@ -11,7 +11,7 @@
             <span class="product-menu-header-text d-block position-relative py-lg-50">
                 {{ name }}
             </span>
-        </a>
+        </es-nav-bar-link>
         <!-- mobile flyout menu trigger -->
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
@@ -60,23 +60,23 @@
                 <li
                     class="nav-item nav-item-border-mobile nav-link align-items-center d-flex d-lg-none font-weight-bold justify-content-between text-decoration-none w-100">
                     {{ name }}
-                    <a
+                    <es-nav-bar-link
                         class="product-menu-flyout-see-all font-size-50 font-weight-bolder text-uppercase"
                         :href="link">
                         {{ seeAllText }}
-                    </a>
+                    </es-nav-bar-link>
                 </li>
                 <!-- subnav items -->
                 <li
                     v-for="item in items"
                     :key="item.name">
-                    <a
+                    <es-nav-bar-link
                         class="dropdown-item nav-item nav-item-border-mobile nav-link align-items-center d-flex px-lg-100 py-lg-50"
                         :class="{ 'font-weight-bold': item.emphasize }"
                         :href="item.link"
                         :target="item.newTab ? '_blank' : null">
                         {{ item.name }}
-                    </a>
+                    </es-nav-bar-link>
                 </li>
             </ul>
             <div
@@ -86,11 +86,11 @@
                 <p
                     class="nav-item nav-item-border-mobile nav-link align-items-center d-flex d-lg-none font-weight-bold justify-content-between mb-0 text-decoration-none w-100">
                     {{ name }}
-                    <a
+                    <es-nav-bar-link
                         class="product-menu-flyout-see-all font-size-50 font-weight-bolder text-uppercase"
                         :href="link">
                         {{ seeAllText }}
-                    </a>
+                    </es-nav-bar-link>
                 </p>
                 <b-row
                     tag="ul"
@@ -121,12 +121,14 @@
 
 <script lang="js">
 import EsNavBarFeaturedArticle from './EsNavBarFeaturedArticle.vue';
+import EsNavBarLink from './EsNavBarLink.vue';
 import EsNavBarTopicMenu from './EsNavBarTopicMenu.vue';
 
 export default {
     name: 'EsNavBarProductMenu',
     components: {
         EsNavBarFeaturedArticle,
+        EsNavBarLink,
         EsNavBarTopicMenu,
     },
     props: {

--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -1,7 +1,7 @@
 <template>
     <li class="nav-item nav-item-border-mobile top-header mx-0">
         <!-- desktop fly-out menu trigger -->
-        <a
+        <es-nav-bar-link
             v-if="!link"
             class="nav-link dropdown-toggle d-none d-lg-block py-150"
             href="#"
@@ -19,9 +19,9 @@
             <div class="font-weight-light font-size-xs pl-150">
                 {{ subHeading }}
             </div>
-        </a>
+        </es-nav-bar-link>
         <!-- mobile+desktop top-level link -->
-        <a
+        <es-nav-bar-link
             v-else
             class="nav-link d-flex align-items-center w-100 h-100 px-0 py-lg-150 px-lg-50"
             :href="link"
@@ -38,7 +38,7 @@
                     {{ subHeading }}
                 </div>
             </div>
-        </a>
+        </es-nav-bar-link>
         <!-- mobile fly-out menu trigger -->
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
@@ -135,6 +135,7 @@
 
 <script lang="js">
 import EsNavBarFeaturedArticle from './EsNavBarFeaturedArticle.vue';
+import EsNavBarLink from './EsNavBarLink.vue';
 import EsNavBarTopicMenu from './EsNavBarTopicMenu.vue';
 import { NAV_BAR_ICONS } from '../lib-utils/nav-bar-constants';
 
@@ -142,6 +143,7 @@ export default {
     name: 'EsNavBarTopLevelMenu',
     components: {
         EsNavBarFeaturedArticle,
+        EsNavBarLink,
         EsNavBarTopicMenu,
     },
     props: {

--- a/es-vue-base/src/lib-components/EsNavBarTopicMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopicMenu.vue
@@ -3,7 +3,7 @@
         class="topic-group border-0 mb-lg-200"
         :class="{ 'nav-item': showItemsOnMobile }">
         <!-- desktop header, if it's a link -->
-        <a
+        <es-nav-bar-link
             v-if="link"
             class="dropdown-item nav-link topic-menu-header d-none d-lg-block font-size-50 mb-lg-50 position-relative px-lg-0 py-lg-50 text-gray"
             :href="link"
@@ -20,7 +20,7 @@
                 class="d-block font-italic">
                 {{ subHeading }}
             </span>
-        </a>
+        </es-nav-bar-link>
         <!-- desktop header, if it's not a link -->
         <p
             v-else
@@ -85,13 +85,13 @@
                 class="visible-lg"
                 style="list-style: none; padding-left: 0; top: 0;">
                 <li class="d-lg-none">
-                    <a
+                    <es-nav-bar-link
                         v-if="link"
                         class="nav-item nav-item-border-mobile nav-link font-weight-bold d-flex w-100 align-items-center ml-50"
                         :href="link"
                         :target="newTab ? '_blank' : null">
                         {{ name }}
-                    </a>
+                    </es-nav-bar-link>
                     <div
                         v-else
                         class="nav-item col-12">
@@ -104,18 +104,18 @@
                 <li
                     v-for="item in items"
                     :key="item.name">
-                    <a
+                    <es-nav-bar-link
                         class="dropdown-item nav-item nav-item-border-mobile nav-link d-flex align-items-center ml-lg-0 px-lg-0 py-lg-50"
                         :class="{ 'font-weight-bold': item.emphasize }"
                         :href="item.link"
                         :target="item.newTab ? '_blank' : null">
                         {{ item.name }}
-                    </a>
+                    </es-nav-bar-link>
                 </li>
             </ul>
         </div>
         <!-- mobile link, shown only if we have a link and don't want to show child items on mobile -->
-        <a
+        <es-nav-bar-link
             v-if="link"
             class="nav-item nav-item-border-mobile nav-link d-lg-none w-100"
             :class="{
@@ -132,13 +132,18 @@
                 class="d-block font-italic">
                 {{ subHeading }}
             </span>
-        </a>
+        </es-nav-bar-link>
     </li>
 </template>
 
 <script lang="js">
+import EsNavBarLink from './EsNavBarLink.vue';
+
 export default {
     name: 'EsNavBarTopicMenu',
+    components: {
+        EsNavBarLink,
+    },
     props: {
         closeButtonText: {
             type: String,

--- a/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsFooter.spec.js.snap
@@ -29,10 +29,10 @@ exports[`EsFooter <EsFooter /> 1`] = `
               <li class="mt-25 mb-50"><a href="https://www.energysage.com/market-intro/" class="text-reset">
                   Home solar
                 </a></li>
-              <li class="mt-25 mb-50"><a href="https://communitysolar.energysage.com" target="_blank" class="text-reset">
+              <li class="mt-25 mb-50"><a href="https://communitysolar.energysage.com" rel="noopener" target="_blank" class="text-reset">
                   Community solar
                 </a></li>
-              <li class="mt-25 mb-50"><a href="https://heatpumps.energysage.com" target="_blank" class="text-reset">
+              <li class="mt-25 mb-50"><a href="https://heatpumps.energysage.com" rel="noopener" target="_blank" class="text-reset">
                   Heating &amp; cooling
                 </a></li>
               <li class="mt-25 mb-50"><a href="https://www.energysage.com/energy-storage/" class="text-reset">
@@ -60,10 +60,10 @@ exports[`EsFooter <EsFooter /> 1`] = `
               <li class="mt-25 mb-50"><a href="https://www.energysage.com/market/equipment-rebates/" class="text-reset">
                   Solar rebates
                 </a></li>
-              <li class="mt-25 mb-50"><a href="https://news.energysage.com" target="_blank" class="text-reset">
+              <li class="mt-25 mb-50"><a href="https://news.energysage.com" rel="noopener" target="_blank" class="text-reset">
                   News
                 </a></li>
-              <li class="mt-25 mb-50"><a href="https://help.energysage.com" target="_blank" class="text-reset">
+              <li class="mt-25 mb-50"><a href="https://help.energysage.com" rel="noopener" target="_blank" class="text-reset">
                   Help center
                 </a></li>
               <li class="mt-25 mb-50"><a href="https://www.energysage.com/market-intro/" class="text-reset">
@@ -114,7 +114,7 @@ exports[`EsFooter <EsFooter /> 1`] = `
           </div>
         </div>
       </div>
-      <div class="col col-12 col-lg-4 order-lg-0 mb-200"><a href="https://www.energysage.com" class="d-block mb-150"><span class="sr-only">
+      <div class="col col-12 col-lg-4 order-lg-0 mb-200"><a href="https://www.energysage.com" target="_self" class="d-block mb-150"><span class="sr-only">
                         EnergySage
                     </span> <svg viewBox="0 0 128 28" fill="none" xmlns="http://www.w3.org/2000/svg" style="height: 36px; width: 160px;">
             <path d="M3.14213 14.8032C3.14213 17.7722 3.93937 18.3618 5.28209 18.3618C6.45696 18.3618 7.06538 17.4143 7.12832 16.3403H9.00952C9.00952 18.6988 7.54092 19.7727 5.31705 19.7727C3.09318 19.7727 1.2959 19.0708 1.2959 14.4101C1.2959 11.2936 1.64556 8.72461 5.31705 8.72461C8.33816 8.72461 9.09344 10.3881 9.09344 13.8977V14.8032H3.14213ZM7.26819 13.4976C7.26819 10.4092 6.40801 10.0302 5.17019 10.0302C4.07924 10.0302 3.1771 10.5566 3.14913 13.4976H7.26819Z" fill="#616161"></path>
@@ -132,11 +132,11 @@ exports[`EsFooter <EsFooter /> 1`] = `
             <path d="M126.427 17.5333C126.278 17.5314 126.13 17.5595 125.992 17.616C125.853 17.6725 125.728 17.7562 125.622 17.8621C125.517 17.9681 125.433 18.0942 125.377 18.233C125.321 18.3718 125.293 18.5205 125.295 18.6704C125.296 18.9714 125.416 19.2596 125.628 19.4724C125.84 19.6853 126.128 19.8056 126.427 19.8075C126.728 19.8075 127.016 19.6877 127.229 19.4744C127.441 19.2612 127.56 18.972 127.56 18.6704C127.56 18.3688 127.441 18.0796 127.229 17.8663C127.016 17.6531 126.728 17.5333 126.427 17.5333ZM127.358 18.6704C127.356 18.9168 127.257 19.1524 127.083 19.326C126.908 19.4995 126.673 19.5969 126.427 19.5969C126.183 19.5969 125.948 19.4993 125.775 19.3255C125.602 19.1518 125.504 18.9161 125.504 18.6704C125.504 18.424 125.601 18.1876 125.774 18.0127C125.947 17.8379 126.182 17.7387 126.427 17.7368C126.674 17.7387 126.909 17.8376 127.083 18.0123C127.257 18.187 127.356 18.4234 127.358 18.6704Z" fill="#616161"></path>
             <path d="M126.791 18.4459C126.794 18.4007 126.785 18.3555 126.767 18.314C126.749 18.2725 126.721 18.236 126.686 18.2073C126.594 18.1494 126.487 18.1224 126.378 18.1301H126.071V19.211H126.253V18.7758H126.427L126.679 19.211H126.882L126.574 18.7337C126.638 18.719 126.695 18.682 126.735 18.6294C126.775 18.5768 126.794 18.5118 126.791 18.4459ZM126.378 18.6354H126.26V18.2845H126.378C126.438 18.2704 126.501 18.2704 126.56 18.2845C126.581 18.2997 126.598 18.3198 126.609 18.3431C126.62 18.3664 126.625 18.3921 126.623 18.4179C126.624 18.4445 126.619 18.471 126.608 18.4953C126.597 18.5197 126.581 18.5412 126.56 18.5582C126.511 18.6053 126.446 18.6327 126.378 18.6354Z" fill="#616161"></path>
           </svg></a>
-        <div class="d-flex text-gray-700"><a href="https://www.facebook.com/EnergySage" target="_blank" class="text-reset pr-150"><span class="sr-only">Facebook</span>
-            <icon-facebook></icon-facebook></a><a href="https://www.linkedin.com/company/energysage/" target="_blank" class="text-reset pr-150"><span class="sr-only">LinkedIn</span>
-            <icon-linkedin></icon-linkedin></a><a href="https://www.instagram.com/energysage_official/" target="_blank" class="text-reset pr-150"><span class="sr-only">Instagram</span>
-            <icon-instagram></icon-instagram></a><a href="https://twitter.com/energysage" target="_blank" class="text-reset pr-150"><span class="sr-only">Twitter</span>
-            <icon-twitter></icon-twitter></a><a href="https://www.youtube.com/c/EnergySage" target="_blank" class="text-reset pr-150"><span class="sr-only">YouTube</span>
+        <div class="d-flex text-gray-700"><a href="https://www.facebook.com/EnergySage" rel="noopener" target="_blank" class="text-reset pr-150"><span class="sr-only">Facebook</span>
+            <icon-facebook></icon-facebook></a><a href="https://www.linkedin.com/company/energysage/" rel="noopener" target="_blank" class="text-reset pr-150"><span class="sr-only">LinkedIn</span>
+            <icon-linkedin></icon-linkedin></a><a href="https://www.instagram.com/energysage_official/" rel="noopener" target="_blank" class="text-reset pr-150"><span class="sr-only">Instagram</span>
+            <icon-instagram></icon-instagram></a><a href="https://twitter.com/energysage" rel="noopener" target="_blank" class="text-reset pr-150"><span class="sr-only">Twitter</span>
+            <icon-twitter></icon-twitter></a><a href="https://www.youtube.com/c/EnergySage" rel="noopener" target="_blank" class="text-reset pr-150"><span class="sr-only">YouTube</span>
             <icon-youtube></icon-youtube></a></div>
       </div>
     </div>
@@ -149,21 +149,21 @@ exports[`EsFooter <EsFooter /> 1`] = `
       © Copyright 2009-2023 EnergySage, Inc. All rights reserved.
     </p>
     <div class="row justify-content-between mb-150">
-      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/terms-of-use/" class="text-reset font-weight-normal">
+      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/terms-of-use/" target="_self" class="text-reset font-weight-normal">
           Terms of use
         </a></div>
-      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/privacy-policy/" class="text-reset font-weight-normal">
+      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/privacy-policy/" target="_self" class="text-reset font-weight-normal">
           Privacy policy
         </a></div>
-      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/mobile-terms-of-use/" class="text-reset font-weight-normal">
+      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/mobile-terms-of-use/" target="_self" class="text-reset font-weight-normal">
           Mobile terms of use
         </a></div>
-      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/nondiscrimination/" class="text-reset font-weight-normal">
+      <div class="col col-6 col-lg font-size-50 mt-25 mb-50"><a href="https://www.energysage.com/nondiscrimination/" target="_self" class="text-reset font-weight-normal">
           Non-discrimination policy
         </a></div>
     </div>
     <div class="d-lg-flex align-items-end"><img src="https://www-static.energysage.com/static/img/doe/doe-logo-179.943fe6467b04.png" aria-hidden="true" width="99" height="25" class="mr-100 mb-100 mb-lg-0">
-      <p class="mb-0"><a href="https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems" target="_blank">
+      <p class="mb-0"><a href="https://www.energy.gov/eere/solar/articles/eere-success-story-doe-funding-helps-build-one-stop-shop-rooftop-pv-systems" rel="noopener" target="_blank" class="">
           Learn more about our success working with the US. Department of Energy.
         </a></p>
     </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-509

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- All links in `EsFooter` and `EsNavBar` now use a new `EsNavBarLink` component
- `EsNavBarLink` by default renders a `<b-link>` tag - if the `href` it's given as a prop starts with a `'/'`, it passes it to the `<b-link>` as a `to` prop, otherwise uses an `href` prop - this will allow consuming Nuxt applications (if they pass in a customized set of links to `EsFooter` or `EsNavBar`, some of which are root-relative rather than absolute) to navigate between Nuxt pages like a single-page application without full page reload

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- First tested this by cloning all EsNavBar code into a Nuxt app and confirming that SPA behavior occurred on root-relative URLs and normal link behavior occurred on other URLs
- Confirmed that a simpler approach of hardcoding all links to be `<b-link>` and to use the `to` prop would **not** work because it rendered absolute URLs in front of the current page's URL like `http://localhost:8500/organisms/https://www.energysage.com` which will not work.
- Tested all types of links in the footer and nav on the ESDS local docs site to confirm they all still work as expected

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
