### PR TITLE
fix: CED-710 Navigation/homepage post-launch fixes

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -312,7 +312,9 @@ $nav-hover-delay: 300ms;
 
     // Show top headers down chevron icon
     .nav-item {
-      cursor: pointer;
+      .dropdown-toggle, .nav-link {
+        cursor: pointer;
+      }
 
       .top-header-icon {
         // stylelint-disable-next-line property-disallowed-list

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -312,7 +312,8 @@ $nav-hover-delay: 300ms;
 
     // Show top headers down chevron icon
     .nav-item {
-      .dropdown-toggle, .nav-link {
+      .dropdown-toggle,
+      .nav-link {
         cursor: pointer;
       }
 

--- a/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarProductMenu.vue
@@ -5,7 +5,6 @@
             class="product-menu-header-link dropdown-toggle d-none d-lg-block px-lg-100 px-xl-200 py-lg-0 text-decoration-none text-gray"
             :href="link"
             :target="newTab ? '_blank' : null"
-            data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
             <span class="product-menu-header-text d-block position-relative py-lg-50">

--- a/es-vue-base/src/lib-utils/nav-bar-global-content.js
+++ b/es-vue-base/src/lib-utils/nav-bar-global-content.js
@@ -195,7 +195,7 @@ export default (
             name: 'Solar calculator',
             subHeading: 'Check your savings',
             icon: NAV_BAR_ICONS.CALCULATOR,
-            link: `${ES_DOMAIN}/solar/calculator`,
+            link: `${ES_DOMAIN}/solar/calculator/`,
             topics: [],
         },
         {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
- https://energysage.atlassian.net/browse/CED-710
- https://energysage.atlassian.net/browse/CED-711
- https://energysage.atlassian.net/browse/CED-718

PR with ripped nav on es-site: https://github.com/EnergySage/es-site/pull/8453

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Added trailing slash to solar calculator link 
- Changed cursor behavior in menus
- Removed `data-toggle: dropdown` attribute in product menu links

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally for symptoms described in each ticket
- Tried to test the click-ability of product menu links in prod by removing event listeners [like I did for CED-391](https://energysage.atlassian.net/browse/CED-391?focusedCommentId=32314). It looks like 2 event listeners have to be removed/disabled - one depends on the `data-toggle` attribute, and the other might depend on the `dropdown` or `dropdown-toggle` attribute. It looks like this might actually be testable on int/dev, so I'll do that.
  - Update: I [deployed es-site to `dev`](https://github.com/EnergySage/es-site/actions/runs/5404692275) with the ripped nav from this branch, and the links successfully open now. Previously, for `dev` and `int`, the same-site links opened (home solar, backup power, EV charging, business) but the external links did not (comm solar, heat pumps). On `prod`, none of them currently open. I think the only way to really test this will be post-deploy.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
