### PR TITLE
fix: spacing on EsAccordion for long text

### DIFF
--- a/es-vue-base/src/lib-components/EsAccordion.vue
+++ b/es-vue-base/src/lib-components/EsAccordion.vue
@@ -2,7 +2,7 @@
     <div class="EsAccordion border-bottom border-light rounded-bottom">
         <header role="tab">
             <es-button
-                class="EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100"
+                class="EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100"
                 :class="{
                     'bg-light': isVisible,
                     'bg-white': !isVisible,

--- a/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
@@ -5,7 +5,7 @@ exports[`EsAccordion <EsAccordionList /> 1`] = `"<div role="tablist" class="roun
 exports[`EsAccordion EsAccordionList expands one item and collapses another 1`] = `
 "<div role="tablist" class="rounded">
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">My Title 1 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">My Title 1 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></button></header>
     <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
@@ -17,7 +17,7 @@ exports[`EsAccordion EsAccordionList expands one item and collapses another 1`] 
     </transition-stub>
   </div>
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title 2 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title 2 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></button></header>
     <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
@@ -34,7 +34,7 @@ exports[`EsAccordion EsAccordionList expands one item and collapses another 1`] 
 exports[`EsAccordion EsAccordionList mounts with initial expand; collapse also works 1`] = `
 "<div role="tablist" class="rounded">
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></button></header>
     <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
@@ -51,7 +51,7 @@ exports[`EsAccordion EsAccordionList mounts with initial expand; collapse also w
 exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
 "<div role="tablist" class="rounded">
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title 1 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">My Title 1 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></button></header>
     <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
@@ -63,7 +63,7 @@ exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
     </transition-stub>
   </div>
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">My Title 2 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">My Title 2 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></button></header>
     <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
@@ -80,7 +80,7 @@ exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
 exports[`EsAccordion EsAccordionList v-model test 1`] = `
 "<div role="tablist" class="rounded" data-testid="testInput" id="testId">
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-light EsAccordion-button--visible">
         My Title 1
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
@@ -94,7 +94,7 @@ exports[`EsAccordion EsAccordionList v-model test 1`] = `
     </transition-stub>
   </div>
   <div class="EsAccordion border-bottom border-light rounded-bottom">
-    <header role="tab"><button type="button" class="btn EsAccordion-button align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">
+    <header role="tab"><button type="button" class="btn EsAccordion-button h-auto align-items-center d-flex font-weight-bold justify-content-between px-100 px-sm-200 py-100 rounded-0 text-body text-left text-decoration-none w-100 btn-link btn-md bg-white">
         My Title 2
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="height: 24px; width: 24px;" class="EsAccordion-icon flex-shrink-0 ml-200">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/ESDS-141

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
* This is a small tweak: If question text wrapped in EsAccordion (mostly on mobile), the fixed height of `es-button` didn't leave enough padding.  Set height to `h-auto` instead, padding now consistent across viewports.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
* Tested manually on all viewports

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have documented testing approach
