### PR TITLE
Enhancements to EsCtaBanner, EsCtaCard, EsZipCodeForm

### DIFF
--- a/es-design-system/pages/organisms/es-cta-banner.vue
+++ b/es-design-system/pages/organisms/es-cta-banner.vue
@@ -19,58 +19,49 @@
         </b-row>
 
         <div class="mb-450">
-            <h2 class="mb-200">
+            <h2>
                 Default with zip code form
             </h2>
+            <p class="mb-200">
+                This is the default layout, designed to show a zip code form and display nicely within a
+                limited-width container. The second example has <code>dark</code> set to <code>true</code>.
+            </p>
             <b-row class="justify-content-center">
                 <b-col
-                    sm="10"
-                    md="8"
-                    lg="12"
-                    xl="10">
-                    <es-cta-banner>
+                    cols="12"
+                    lg="8"
+                    xl="7">
+                    <es-cta-banner class="mb-200">
                         <template #heading>
                             Switch to solar and save
                         </template>
                         <template #cta>
                             <es-zip-code-form
+                                constrained
                                 input-id="no-image-with-zip-form"
                                 privacy-policy-link="https://www.energysage.com/privacy-policy/"
-                                stack-until="lg"
+                                stack-until="md"
                                 url="https://www.energysage.com/market/start/">
                                 <template #buttonText>
-                                    Compare solar quotes
+                                    Compare quotes
                                 </template>
                             </es-zip-code-form>
                         </template>
                     </es-cta-banner>
-                </b-col>
-            </b-row>
-        </div>
-
-        <div class="mb-450">
-            <h2 class="mb-200">
-                Dark with zip code form
-            </h2>
-            <b-row class="justify-content-center">
-                <b-col
-                    sm="10"
-                    md="8"
-                    lg="12"
-                    xl="10">
                     <es-cta-banner dark>
                         <template #heading>
-                            Easily find what solar<br>costs in your area
+                            Easily find what solar costs in your area
                         </template>
                         <template #cta>
                             <es-zip-code-form
+                                constrained
                                 dark
                                 input-id="no-image-with-zip-form"
                                 privacy-policy-link="https://www.energysage.com/privacy-policy/"
-                                stack-until="lg"
+                                stack-until="md"
                                 url="https://www.energysage.com/market/start/">
                                 <template #buttonText>
-                                    Compare solar quotes
+                                    Compare quotes
                                 </template>
                             </es-zip-code-form>
                         </template>
@@ -81,23 +72,21 @@
 
         <div class="mb-450">
             <h2>
-                Dark with subtitle and button
+                Default with subtitle and button
             </h2>
             <p class="mb-200">
-                This example also shows using the <code>lgFirst</code> and <code>lgSecond</code> props to
-                change the default grid layout on desktop from 6 columns each to 8 and 4 columns, giving the
-                heading and subtitle more room and preventing the button from being too wide.
+                By default, the <code>cta</code> section will display at a larger width to accommodate a zip code form.
+                When using a button, set the <code>hasButton</code> prop to <code>true</code>, and the CTA section will
+                reduce in width.
             </p>
             <b-row class="justify-content-center">
                 <b-col
-                    sm="10"
-                    md="8"
-                    lg="12"
-                    xl="10">
+                    cols="12"
+                    lg="8"
+                    xl="7">
                     <es-cta-banner
                         dark
-                        lg-first="8"
-                        lg-second="4">
+                        has-button>
                         <template #heading>
                             Check availability in your area
                         </template>
@@ -106,7 +95,7 @@
                         </template>
                         <template #cta>
                             <es-button
-                                class="w-100"
+                                class="px-100 w-100"
                                 href="https://heatpumps.energysage.com/welcome">
                                 Get heat pump quotes
                             </es-button>
@@ -114,6 +103,81 @@
                     </es-cta-banner>
                 </b-col>
             </b-row>
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                Wide with zip code form
+            </h2>
+            <p class="mb-200">
+                Set the <code>variant</code> prop to <code>'wide'</code> when the banner will display full width on
+                a page. The <code>heading</code> text will appear larger on desktop, and the side padding will
+                increase.
+            </p>
+            <es-cta-banner
+                class="mb-200"
+                variant="wide">
+                <template #heading>
+                    Switch to solar and save
+                </template>
+                <template #cta>
+                    <es-zip-code-form
+                        input-id="no-image-with-zip-form"
+                        privacy-policy-link="https://www.energysage.com/privacy-policy/"
+                        stack-until="md"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText>
+                            Compare quotes
+                        </template>
+                    </es-zip-code-form>
+                </template>
+            </es-cta-banner>
+            <es-cta-banner
+                dark
+                variant="wide">
+                <template #heading>
+                    Switch to solar and save
+                </template>
+                <template #cta>
+                    <es-zip-code-form
+                        dark
+                        input-id="no-image-with-zip-form"
+                        privacy-policy-link="https://www.energysage.com/privacy-policy/"
+                        stack-until="md"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText>
+                            Compare quotes
+                        </template>
+                    </es-zip-code-form>
+                </template>
+            </es-cta-banner>
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                Wide with subtitle and button
+            </h2>
+            <p class="mb-200">
+                By default, the <code>cta</code> section will display at a larger width to accommodate a zip code form.
+                When using a button, set the <code>hasButton</code> prop to <code>true</code>, and the CTA section will
+                reduce in width.
+            </p>
+            <es-cta-banner
+                dark
+                has-button
+                variant="wide">
+                <template #heading>
+                    Check availability in your area
+                </template>
+                <template #subtitle>
+                    Our installer network is growing every day. Explore options in your state.
+                </template>
+                <template #cta>
+                    <es-button href="https://heatpumps.energysage.com/welcome">
+                        Get heat pump quotes
+                    </es-button>
+                </template>
+            </es-cta-banner>
         </div>
 
         <div class="mb-450">
@@ -156,14 +220,16 @@ export default {
                     'Renders the banner with white text on a dark background.',
                 ],
                 [
-                    'lgFirst',
-                    "'6'",
-                    'The number of grid columns within which the heading and subtitle should render on desktop.',
+                    'hasButton',
+                    'false',
+                    `If true, will give the heading (and subtitle, if any) more room on desktop, and reduce the width
+                        of the button container.`,
                 ],
                 [
-                    'lgSecond',
-                    "'6'",
-                    'The number of grid columns within which the CTA should render on desktop.',
+                    'variant',
+                    "'default'",
+                    `Accepts 'default' or 'wide'. The default variant has a smaller heading size and reduced padding.
+                        The wide variant has a larger heading size and larger padding on desktop.`,
                 ],
             ],
             slotTableRows: [

--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -69,28 +69,59 @@
 
         <div class="mb-450">
             <h2>
-                Narrow card example
+                Constrained responsive example
             </h2>
             <p class="mb-200">
-                This example remains stacked at every breakpoint. It shows how the form renders in a card
-                kept at a smaller width by a specific grid column layout.
+                This form has <code>stackUntil</code> set to <code>sm</code> and appears within a
+                smaller-width container. It has <code>constrained</code> set to <code>true</code>
+                in order to make better use of the limited space. This reduces the horizontal padding
+                on the submit button and reduces the size of the privacy text.
             </p>
-            <b-row class="justify-content-center justify-content-lg-start">
+            <b-row class="justify-content-center">
                 <b-col
-                    sm="10"
-                    md="8"
+                    sm="8"
+                    md="6"
+                    lg="5"
+                    xl="4"
+                    xxl="3">
+                    <es-zip-code-form
+                        constrained
+                        input-id="hero-example"
+                        privacy-policy-link="https://www.energysage.com/privacy-policy/"
+                        stack-until="sm"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText>
+                            See local offers
+                        </template>
+                    </es-zip-code-form>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="mb-450">
+            <h2>
+                Constrained stacked example
+            </h2>
+            <p class="mb-200">
+                This example remains stacked at every breakpoint, in a limited-width container. This shows how
+                the form would display within a card on the sidebar of a page.
+            </p>
+            <b-row class="justify-content-center">
+                <b-col
+                    sm="8"
+                    md="6"
                     lg="4"
-                    xl="3">
-                    <es-card class="px-100">
-                        <es-zip-code-form
-                            input-id="narrow-card-example"
-                            privacy-policy-link="https://www.energysage.com/privacy-policy/"
-                            url="https://www.energysage.com/market/start/">
-                            <template #buttonText>
-                                See local offers
-                            </template>
-                        </es-zip-code-form>
-                    </es-card>
+                    xl="3"
+                    xxl="2">
+                    <es-zip-code-form
+                        constrained
+                        input-id="narrow-card-example"
+                        privacy-policy-link="https://www.energysage.com/privacy-policy/"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText>
+                            See local offers
+                        </template>
+                    </es-zip-code-form>
                 </b-col>
             </b-row>
         </div>
@@ -130,6 +161,12 @@ export default {
             compCode: '',
             docCode: '',
             propTableRows: [
+                [
+                    'constrained',
+                    'false',
+                    `Reduces the button padding and privacy text font size to better accommodate
+                        limited-width layouts.`,
+                ],
                 [
                     'dark',
                     'false',

--- a/es-vue-base/src/lib-components/EsCtaBanner.vue
+++ b/es-vue-base/src/lib-components/EsCtaBanner.vue
@@ -1,15 +1,20 @@
 <template>
     <es-card
-        class="px-100 px-lg-300"
-        :class="[{ 'bg-gray text-white': dark }]"
+        :class="[{
+            'bg-gray text-white': dark,
+            'px-100 px-lg-200': variant === 'default',
+            'px-100 px-lg-300': variant === 'wide',
+        }]"
         v-bind="$attrs"
         v-on="$listeners">
         <b-row>
             <b-col
                 class="mb-200 my-lg-auto text-center text-lg-left"
-                :lg="lgFirst">
+                :lg="lgFirst"
+                :xxl="xxlFirst">
                 <h2
                     :class="{
+                        'font-size-300': variant === 'default',
                         'mb-50': $slots.subtitle,
                         'mb-0': !$slots.subtitle,
                         'text-white': dark,
@@ -26,7 +31,8 @@
             </b-col>
             <b-col
                 class="d-flex justify-content-center justify-content-lg-end my-auto"
-                :lg="lgSecond">
+                :lg="lgSecond"
+                :xxl="xxlSecond">
                 <slot name="cta" />
             </b-col>
         </b-row>
@@ -46,14 +52,45 @@ export default {
             type: Boolean,
             default: false,
         },
-        lgFirst: {
-            type: String,
-            default: '6',
+        hasButton: {
+            type: Boolean,
+            default: false,
         },
-        lgSecond: {
+        // default or wide
+        variant: {
             type: String,
-            default: '6',
+            default: 'default',
         },
     },
+    computed: {
+        lgFirst() {
+            if (this.variant === 'wide') {
+                return this.hasButton ? '8' : '6';
+            }
+
+            return this.hasButton ? '7' : '4';
+        },
+        lgSecond() {
+            if (this.variant === 'wide') {
+                return this.hasButton ? '4' : '6';
+            }
+
+            return this.hasButton ? '5' : '8';
+        },
+        xxlFirst() {
+            if (this.variant === 'wide') {
+                return this.hasButton ? '8' : '6';
+            }
+
+            return this.hasButton ? '8' : '5';
+        },
+        xxlSecond() {
+            if (this.variant === 'wide') {
+                return this.hasButton ? '4' : '6';
+            }
+
+            return this.hasButton ? '4' : '7';
+        },
+    }
 };
 </script>

--- a/es-vue-base/src/lib-components/EsCtaBanner.vue
+++ b/es-vue-base/src/lib-components/EsCtaBanner.vue
@@ -91,6 +91,6 @@ export default {
 
             return this.hasButton ? '4' : '7';
         },
-    }
+    },
 };
 </script>

--- a/es-vue-base/src/lib-components/EsCtaCard.vue
+++ b/es-vue-base/src/lib-components/EsCtaCard.vue
@@ -16,7 +16,7 @@
         </h2>
         <div
             v-if="$slots.image"
-            class="mx-auto"
+            class="mx-auto w-100"
             :class="verticalSpacing">
             <slot name="image" />
         </div>

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -108,7 +108,7 @@ export default {
     props: {
         constrained: {
             type: Boolean,
-            default: false
+            default: false,
         },
         dark: {
             type: Boolean,

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -41,15 +41,18 @@
                     {{ placeholder }}
                 </template>
                 <template #errorMessage>
-                    <slot name="errorMessage">
-                        Please enter a 5-digit zip code.
-                    </slot>
+                    <span :class="{ 'text-white': dark }">
+                        <slot name="errorMessage">
+                            Please enter a 5-digit zip code.
+                        </slot>
+                    </span>
                 </template>
             </es-form-input>
             <es-button
                 class="text-nowrap w-100"
                 :class="{
-                    [`ml-${stackBreak}25 w-${stackBreak}auto`]: stackBreak
+                    [`ml-${stackBreak}25 w-${stackBreak}auto`]: stackBreak,
+                    'px-100': constrained,
                 }"
                 type="submit">
                 <slot name="buttonText">
@@ -57,7 +60,7 @@
                 </slot>
             </es-button>
         </b-form>
-        <div>
+        <div :class="{ 'font-size-75': constrained }">
             <icon-lock-on
                 class="privacy-lock-icon mr-25 position-relative"
                 height="1.125rem"
@@ -103,6 +106,10 @@ export default {
     },
     mixins: [formMixins],
     props: {
+        constrained: {
+            type: Boolean,
+            default: false
+        },
         dark: {
             type: Boolean,
             default: false,


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-664

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixed an issue with EsCtaCard where images without an inherent width wouldn't display
- Fixed an issue with EsZipCodeForm where error message text was difficult to read in dark mode
- Added a new `constrained` prop to EsZipCodeForm so it is able to display within constrained-width layouts
- Removed `lgFirst` and `lgSecond` props from EsCtaBanner, in favor of a simpler (and more prescriptive) approach with new props `hasButton` and `variant`, which control font size, column layout, and side padding.
- Added new docs examples for EsCtaBanner for the `wide` variant and corrected the column width of the width-constrained banners to be more realistic.

#### New constrained EsZipCodeForm examples
<img width="1172" alt="Screen Shot 2023-08-01 at 8 11 14 PM" src="https://github.com/EnergySage/es-ds/assets/1350363/ba69f6e0-87e6-47dc-b460-7f54a9f48485">

#### New constrained EsCtaBanner examples
<img width="1170" alt="Screen Shot 2023-08-01 at 8 11 56 PM" src="https://github.com/EnergySage/es-ds/assets/1350363/e695df8c-1dab-4856-914e-47aaf0291591">

#### New wide EsCtaBanner examples
<img width="1167" alt="Screen Shot 2023-08-01 at 8 12 25 PM" src="https://github.com/EnergySage/es-ds/assets/1350363/4679e174-e5a3-4dbc-ab64-830c0946db47">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested with the old and new examples on the docs pages for the components

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
