### PR TITLE
CSM-2802: Add Spacing Between Review Star Rating

### DIFF
--- a/es-vue-base/src/lib-components/EsReviewModal.vue
+++ b/es-vue-base/src/lib-components/EsReviewModal.vue
@@ -14,7 +14,7 @@
             class="modal-container">
             <b-row>
                 <b-col
-                    class="p-0"
+                    class="p-0 pr-3"
                     cols="12"
                     md="8"
                     order="2"

--- a/es-vue-base/src/lib-components/EsReviewModal.vue
+++ b/es-vue-base/src/lib-components/EsReviewModal.vue
@@ -14,7 +14,7 @@
             class="modal-container">
             <b-row>
                 <b-col
-                    class="p-0 pr-3"
+                    class="p-0 pr-lg-200"
                     cols="12"
                     md="8"
                     order="2"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

- https://energysage.atlassian.net/browse/CSM-2802

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Before the change was made, the review column and ratings column in ReviewModal had no space in between. After the changes in this PR, there is a 0.75rem right padding in the ratings column in ReviewModal. 

### 🥼 Testing

- Check EsReviewList in Organisms. Click on 'View All Ratings' and inspect the modal. There will be a padding-right (=0.75rem) in the ratings column

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- Does the spacing seems to be right (should it be less or more)?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have documented testing approach
