### PR TITLE
fix(bug): change CTA headlines to not use a heading tag

### DIFF
--- a/es-vue-base/src/lib-components/EsCtaBanner.vue
+++ b/es-vue-base/src/lib-components/EsCtaBanner.vue
@@ -15,7 +15,7 @@
                 :lg="lgFirst"
                 :xxl="xxlFirst">
                 <!-- avoiding use of an <h2> tag here for long-form content SEO reasons,
-                    but preserving heading semantics for screen readers" -->
+                    but preserving heading semantics for screen readers -->
                 <div
                     role="heading"
                     aria-level="2"

--- a/es-vue-base/src/lib-components/EsCtaBanner.vue
+++ b/es-vue-base/src/lib-components/EsCtaBanner.vue
@@ -14,6 +14,8 @@
                 class="mb-200 my-lg-auto text-center text-lg-left"
                 :lg="lgFirst"
                 :xxl="xxlFirst">
+                <!-- avoiding use of an <h2> tag here for long-form content SEO reasons,
+                    but preserving heading semantics for screen readers" -->
                 <div
                     role="heading"
                     aria-level="2"
@@ -23,6 +25,7 @@
                         'mb-50': $slots.subtitle,
                         'mb-0': !$slots.subtitle,
                         'text-white': dark,
+                        'h2': variant === 'wide'
                     }">
                     <slot name="heading">
                         Easily find what solar costs in your area

--- a/es-vue-base/src/lib-components/EsCtaBanner.vue
+++ b/es-vue-base/src/lib-components/EsCtaBanner.vue
@@ -1,10 +1,12 @@
 <template>
     <es-card
-        :class="[{
-            'bg-gray text-white': dark,
-            'px-100 px-lg-200': variant === 'default',
-            'px-100 px-lg-300': variant === 'wide',
-        }]"
+        :class="[
+            {
+                'bg-gray text-white': dark,
+                'px-100 px-lg-200': variant === 'default',
+                'px-100 px-lg-300': variant === 'wide',
+            },
+        ]"
         v-bind="$attrs"
         v-on="$listeners">
         <b-row>
@@ -12,7 +14,10 @@
                 class="mb-200 my-lg-auto text-center text-lg-left"
                 :lg="lgFirst"
                 :xxl="xxlFirst">
-                <h2
+                <div
+                    role="heading"
+                    aria-level="2"
+                    class="font-weight-semibold"
                     :class="{
                         'font-size-300': variant === 'default',
                         'mb-50': $slots.subtitle,
@@ -22,7 +27,7 @@
                     <slot name="heading">
                         Easily find what solar costs in your area
                     </slot>
-                </h2>
+                </div>
                 <p
                     v-if="$slots.subtitle"
                     class="mb-0">

--- a/es-vue-base/src/lib-components/EsCtaCard.vue
+++ b/es-vue-base/src/lib-components/EsCtaCard.vue
@@ -4,6 +4,8 @@
         :class="horizontalPadding"
         v-bind="$attrs"
         v-on="$listeners">
+        <!-- avoiding use of an <h2> tag here for long-form content SEO reasons,
+            but preserving heading semantics for screen readers" -->
         <div
             role="heading"
             aria-level="2"

--- a/es-vue-base/src/lib-components/EsCtaCard.vue
+++ b/es-vue-base/src/lib-components/EsCtaCard.vue
@@ -5,7 +5,7 @@
         v-bind="$attrs"
         v-on="$listeners">
         <!-- avoiding use of an <h2> tag here for long-form content SEO reasons,
-            but preserving heading semantics for screen readers" -->
+            but preserving heading semantics for screen readers -->
         <div
             role="heading"
             aria-level="2"

--- a/es-vue-base/src/lib-components/EsCtaCard.vue
+++ b/es-vue-base/src/lib-components/EsCtaCard.vue
@@ -4,16 +4,15 @@
         :class="horizontalPadding"
         v-bind="$attrs"
         v-on="$listeners">
-        <h2
-            class="font-size-300"
-            :class="[
-                { 'order-1': imageFirst },
-                verticalSpacing
-            ]">
+        <div
+            role="heading"
+            aria-level="2"
+            class="font-weight-semibold font-size-300"
+            :class="[{ 'order-1': imageFirst }, verticalSpacing]">
             <slot name="heading">
                 Easily find what solar costs in your area
             </slot>
-        </h2>
+        </div>
         <div
             v-if="$slots.image"
             class="mx-auto w-100"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-860

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- change from `<h2>` to `<div role="heading" aria-level="2">` wrapper of the slot that accepts the heading tag for `EsCtaCard` and `EsCtaBanner`

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Manual testing - [EsCtaCard](http://localhost:8500/organisms/es-cta-card), [EsCtaBanner](http://localhost:8500/organisms/es-cta-banner)

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
