### PR TITLE
feat: toggle programmatic collapse priority for es-collapse

### DIFF
--- a/es-design-system/package-lock.json
+++ b/es-design-system/package-lock.json
@@ -2725,9 +2725,9 @@
             }
         },
         "node_modules/@energysage/es-vue-base": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-0.25.8.tgz",
-            "integrity": "sha512-eXxGqOCCPdJDEhaS3BU4on51HVfFIlL7wV/cnaOcuuMTpnOSkqpMUGqu/Jd/+IrZToYAzrPQNJSDM1xTW+WQdw==",
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-0.25.9.tgz",
+            "integrity": "sha512-6Rfh8GGuAyf7ayNv2GzYL6JLAdYpKHgk8GO3GXxJw6mFZTtMvweQq77LhXmMm0hzWA8hV0QIK3j2RX8d0XUWog==",
             "dependencies": {
                 "path": "^0.12.7"
             },
@@ -26598,9 +26598,9 @@
             "requires": {}
         },
         "@energysage/es-vue-base": {
-            "version": "0.25.8",
-            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-0.25.8.tgz",
-            "integrity": "sha512-eXxGqOCCPdJDEhaS3BU4on51HVfFIlL7wV/cnaOcuuMTpnOSkqpMUGqu/Jd/+IrZToYAzrPQNJSDM1xTW+WQdw==",
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/@energysage/es-vue-base/-/es-vue-base-0.25.9.tgz",
+            "integrity": "sha512-6Rfh8GGuAyf7ayNv2GzYL6JLAdYpKHgk8GO3GXxJw6mFZTtMvweQq77LhXmMm0hzWA8hV0QIK3j2RX8d0XUWog==",
             "requires": {
                 "path": "^0.12.7"
             }

--- a/es-design-system/pages/molecules/es-collapse.vue
+++ b/es-design-system/pages/molecules/es-collapse.vue
@@ -8,46 +8,118 @@
                 bootstrap-vue collapse
             </b-link>
         </p>
-        <form>
-            <label for="suggestedVisibleInput">
-                <input
-                    id="suggestedVisibleInput"
-                    v-model="suggestedVisible"
-                    type="checkbox">
-                Toggle collapse programmatically (will be honored until a manual expand or collapse)
-            </label>
-            <br>
-            <label for="prioritizeSuggestedVisibleInput">
-                <input
-                    id="prioritizeSuggestedVisibleInput"
-                    v-model="prioritizeSuggestedVisible"
-                    type="checkbox">
-                Toggle prioritizing programmatic collapse over user interaction
-            </label>
-        </form>
-        <EsCollapse
-            id="testId"
-            :visible="suggestedVisible"
-            :prioritize-suggested-visible="prioritizeSuggestedVisible"
-            class="p-450 my-450"
-            @shown="shownEvent"
-            @toggled="toggledEvent">
-            <template #title>
-                <h2 class="mb-0">
-                    My Title
-                </h2>
-            </template>
-            <!-- eslint-disable max-len -->
+        <div class="mt-450 mb-450">
+            <h2>
+                Default EsCollapse
+            </h2>
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
-                Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
-                vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
-                ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
-                Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
-                Donec eleifend elit quam.
+                A normal EsCollapse component. Click it to toggle showing it's contents!
             </p>
-        <!-- eslint-enable max-len -->
-        </EsCollapse>
+            <EsCollapse
+                id="defaultCollapse"
+                class="ml-450 mr-450">
+                <template #title>
+                    <h2 class="mb-0">
+                        My Title
+                    </h2>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                    Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                    vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                    ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                    Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                    Donec eleifend elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </EsCollapse>
+        </div>
+
+        <div class="mt-450 mb-450">
+            <h2>
+                Programmatic EsCollapse
+            </h2>
+            <p>
+                An EsCollapse component that takes a "visible" prop. Click the checkbox to toggle showing it's
+                contents! If you click the collapse itself, the "visible" prop will no longer be honored.
+            </p>
+            <form class="ml-450 mr-450 mt-5">
+                <label for="suggestedVisibleInput">
+                    <input
+                        id="suggestedVisibleInput"
+                        v-model="suggestedVisible"
+                        type="checkbox">
+                    Toggle collapse programmatically (will be honored until a manual expand or collapse)
+                </label>
+            </form>
+            <EsCollapse
+                id="testId"
+                :visible="suggestedVisible"
+                class="p-450"
+                @shown="shownEvent"
+                @toggled="toggledEvent">
+                <template #title>
+                    <h2 class="mb-0">
+                        My Title
+                    </h2>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                    Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                    vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                    ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                    Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                    Donec eleifend elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </EsCollapse>
+        </div>
+
+        <div class="mt-450 mb-450">
+            <h2>
+                Programmatic EsCollapse with Priority
+            </h2>
+            <p>
+                An EsCollapse component that takes a "visible" prop with "prioritize-suggested-visible" true. Click the
+                checkbox to toggle showing it's contents! Unlike the previous example, if you click the collapse
+                itself, the "visible" prop will continue to be honored.
+            </p>
+            <form class="ml-450 mr-450">
+                <label for="suggestedVisibleForPriorityInput">
+                    <input
+                        id="suggestedVisibleForPriorityInput"
+                        v-model="suggestedVisibleForPriority"
+                        type="checkbox">
+                    Toggle collapse programmatically (will always be honored)
+                </label>
+            </form>
+            <EsCollapse
+                id="testId"
+                :visible="suggestedVisibleForPriority"
+                :prioritize-suggested-visible="true"
+                class="p-450"
+                @shown="shownEvent"
+                @toggled="toggledEvent">
+                <template #title>
+                    <h2 class="mb-0">
+                        My Title
+                    </h2>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                    Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                    vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                    ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                    Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                    Donec eleifend elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </EsCollapse>
+        </div>
+
         <div class="mb-450">
             <h2>
                 EsCollapse props
@@ -72,18 +144,24 @@ export default {
             compCode: '',
             docCode: '',
             suggestedVisible: true,
-            prioritizeSuggestedVisible: false,
+            suggestedVisibleForPriority: false,
             propTableRows: [
                 [
                     'visible',
                     'false',
                     'Suggested visibility state. Will be ignored if and when the user '
-                    + 'interacts with the collapse.',
+                    + 'interacts with the collapse (unless "prioritizeSuggestedVisible" is true).',
+                ],
+                [
+                    'prioritizeSuggestedVisible',
+                    'false',
+                    'Priority for the "visible" prop. When true, "visible" will continue to affect the component '
+                    + 'even after the user interacts with the collapse.',
                 ],
             ],
             tableWidths: {
-                md: ['3', '4', '5'],
-                lg: ['2', '5', '5'],
+                md: ['4', '3', '5'],
+                lg: ['4', '3', '5'],
             },
         };
     },

--- a/es-design-system/pages/molecules/es-collapse.vue
+++ b/es-design-system/pages/molecules/es-collapse.vue
@@ -82,26 +82,26 @@
                 Programmatic EsCollapse with Priority
             </h2>
             <p>
-                An EsCollapse component that takes a "visible" prop with "prioritize-suggested-visible" true. Click the
-                checkbox to toggle showing it's contents! Unlike the previous example, if you click the collapse
+                An EsCollapse component that takes a "visible" prop with "is-programmatic-until-user-input" true. Click
+                the checkbox to toggle showing it's contents! Unlike the previous example, if you click the collapse
                 itself, the "visible" prop will continue to be honored.
             </p>
             <form class="ml-450 mr-450">
-                <label for="suggestedVisibleForPriorityInput">
+                <label for="visible">
                     <input
-                        id="suggestedVisibleForPriorityInput"
-                        v-model="suggestedVisibleForPriority"
+                        id="visible"
+                        v-model="visible"
                         type="checkbox">
                     Toggle collapse programmatically (will always be honored)
                 </label>
             </form>
             <EsCollapse
                 id="testId"
-                :visible="suggestedVisibleForPriority"
-                :prioritize-suggested-visible="true"
+                v-model="visible"
+                :is-programmatic-until-user-input="false"
                 class="p-450"
                 @shown="shownEvent"
-                @toggled="toggledEvent">
+                @toggled="toggledEventInSuggestedVisibleExample">
                 <template #title>
                     <h2 class="mb-0">
                         My Title
@@ -139,23 +139,24 @@
 
 export default {
     name: 'EsCollapseDocs',
+
     data() {
         return {
             compCode: '',
             docCode: '',
             suggestedVisible: true,
-            suggestedVisibleForPriority: false,
+            visible: false,
             propTableRows: [
                 [
                     'visible',
                     'false',
                     'Suggested visibility state. Will be ignored if and when the user '
-                    + 'interacts with the collapse (unless "prioritizeSuggestedVisible" is true).',
+                    + 'interacts with the collapse (unless "isProgrammaticUntilUserInput" is false).',
                 ],
                 [
-                    'prioritizeSuggestedVisible',
-                    'false',
-                    'Priority for the "visible" prop. When true, "visible" will continue to affect the component '
+                    'isProgrammaticUntilUserInput',
+                    'true',
+                    'Priority for the "visible" prop. When false, "visible" will continue to affect the component '
                     + 'even after the user interacts with the collapse.',
                 ],
             ],
@@ -185,6 +186,11 @@ export default {
         toggledEvent(newValue) {
             // eslint-disable-next-line no-console
             console.log(`toggled to ${newValue}`);
+        },
+        toggledEventInSuggestedVisibleExample(newValue) {
+            // eslint-disable-next-line no-console
+            console.log(`toggled to ${newValue}`);
+            this.visible = newValue;
         },
     },
 };

--- a/es-design-system/pages/molecules/es-collapse.vue
+++ b/es-design-system/pages/molecules/es-collapse.vue
@@ -16,10 +16,19 @@
                     type="checkbox">
                 Toggle collapse programmatically (will be honored until a manual expand or collapse)
             </label>
+            <br>
+            <label for="prioritizeSuggestedVisibleInput">
+                <input
+                    id="prioritizeSuggestedVisibleInput"
+                    v-model="prioritizeSuggestedVisible"
+                    type="checkbox">
+                Toggle prioritizing programmatic collapse over user interaction
+            </label>
         </form>
         <EsCollapse
             id="testId"
             :visible="suggestedVisible"
+            :prioritize-suggested-visible="prioritizeSuggestedVisible"
             class="p-450 my-450"
             @shown="shownEvent"
             @toggled="toggledEvent">
@@ -63,6 +72,7 @@ export default {
             compCode: '',
             docCode: '',
             suggestedVisible: true,
+            prioritizeSuggestedVisible: false,
             propTableRows: [
                 [
                     'visible',

--- a/es-design-system/pages/molecules/es-collapse.vue
+++ b/es-design-system/pages/molecules/es-collapse.vue
@@ -10,14 +10,14 @@
         </p>
         <div class="mt-450 mb-450">
             <h2>
-                Default EsCollapse
+                Default
             </h2>
             <p>
-                A normal EsCollapse component. Click it to toggle showing it's contents!
+                A normal EsCollapse component. Click it to toggle showing its contents!
             </p>
             <EsCollapse
                 id="defaultCollapse"
-                class="ml-450 mr-450">
+                class="ml-450 mr-450 mt-450">
                 <template #title>
                     <h2 class="mb-0">
                         My Title
@@ -38,13 +38,13 @@
 
         <div class="mt-450 mb-450">
             <h2>
-                Programmatic EsCollapse
+                Programmatic, with user override
             </h2>
             <p>
-                An EsCollapse component that takes a "visible" prop. Click the checkbox to toggle showing it's
+                An EsCollapse component that takes a "visible" prop. Click the checkbox to toggle showing its
                 contents! If you click the collapse itself, the "visible" prop will no longer be honored.
             </p>
-            <form class="ml-450 mr-450 mt-5">
+            <form class="ml-450 mr-450 mt-450">
                 <label for="suggestedVisibleInput">
                     <input
                         id="suggestedVisibleInput"
@@ -79,14 +79,14 @@
 
         <div class="mt-450 mb-450">
             <h2>
-                Programmatic EsCollapse with Priority
+                Programmatic, with Priority
             </h2>
             <p>
                 An EsCollapse component that takes a "visible" prop with "is-programmatic-until-user-input" true. Click
-                the checkbox to toggle showing it's contents! Unlike the previous example, if you click the collapse
+                the checkbox to toggle showing its contents! Unlike the previous example, if you click the collapse
                 itself, the "visible" prop will continue to be honored.
             </p>
-            <form class="ml-450 mr-450">
+            <form class="ml-450 mr-450 mt-sm-n450">
                 <label for="visible">
                     <input
                         id="visible"

--- a/es-vue-base/src/lib-components/EsCollapse.vue
+++ b/es-vue-base/src/lib-components/EsCollapse.vue
@@ -68,6 +68,15 @@ export default {
             default: false,
         },
         /**
+         * prioritizeSuggestedVisible
+         * Prioritize the visible prop over the user's interaction with the collapse.
+         */
+        prioritizeSuggestedVisible: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+        /**
          * Border
          * Show the border or not
          */
@@ -98,6 +107,11 @@ export default {
     watch: {
         userSpecifiedIsExpanded(newValue) {
             this.$emit('toggled', newValue);
+        },
+        visible(newValue) {
+            if (this.prioritizeSuggestedVisible) {
+                this.userSpecifiedIsExpanded = newValue;
+            }
         },
     },
 };

--- a/es-vue-base/src/lib-components/EsCollapse.vue
+++ b/es-vue-base/src/lib-components/EsCollapse.vue
@@ -89,13 +89,15 @@ export default {
     data() {
         return {
             userSpecifiedIsExpanded: null,
+            isExpanded: null, // We use a second variable to track the expanded state so that we only emit the toggled
+            // event when the user interacts with the collapse.
         };
     },
     computed: {
         expanded: {
             get() {
                 if (this.userSpecifiedIsExpanded !== null) {
-                    return this.userSpecifiedIsExpanded;
+                    return this.isExpanded;
                 }
                 return this.visible;
             },
@@ -106,11 +108,12 @@ export default {
     },
     watch: {
         userSpecifiedIsExpanded(newValue) {
+            this.isExpanded = newValue;
             this.$emit('toggled', newValue);
         },
         visible(newValue) {
             if (this.prioritizeSuggestedVisible) {
-                this.userSpecifiedIsExpanded = newValue;
+                this.isExpanded = newValue;
             }
         },
     },

--- a/es-vue-base/src/lib-components/EsCollapse.vue
+++ b/es-vue-base/src/lib-components/EsCollapse.vue
@@ -7,7 +7,7 @@
             class="collapse-holder pb-100 p-0 text-left font-weight-bold text-black d-flex align-items-center justify-content-between text-decoration-none text-body"
             inline
             variant="link"
-            @click="userSpecifiedIsExpanded = !expanded">
+            @click="userClick">
             <div>
                 <slot name="title" />
             </div>
@@ -50,6 +50,10 @@ export default {
     components: {
         EsButton, BCollapse, IconChevronDown,
     },
+    model: {
+        prop: 'visible',
+        event: 'userClick',
+    },
     props: {
         /**
          * ID
@@ -68,13 +72,13 @@ export default {
             default: false,
         },
         /**
-         * prioritizeSuggestedVisible
+         * isProgrammaticUntilUserInput
          * Prioritize the visible prop over the user's interaction with the collapse.
          */
-        prioritizeSuggestedVisible: {
+        isProgrammaticUntilUserInput: {
             type: Boolean,
             required: false,
-            default: false,
+            default: true,
         },
         /**
          * Border
@@ -96,8 +100,8 @@ export default {
     computed: {
         expanded: {
             get() {
-                if (this.userSpecifiedIsExpanded !== null) {
-                    return this.isExpanded;
+                if (this.isProgrammaticUntilUserInput && this.userSpecifiedIsExpanded !== null) {
+                    return this.userSpecifiedIsExpanded;
                 }
                 return this.visible;
             },
@@ -112,9 +116,15 @@ export default {
             this.$emit('toggled', newValue);
         },
         visible(newValue) {
-            if (this.prioritizeSuggestedVisible) {
+            if (!this.isProgrammaticUntilUserInput) {
                 this.isExpanded = newValue;
             }
+        },
+    },
+    methods: {
+        userClick() {
+            this.userSpecifiedIsExpanded = !this.expanded;
+            this.$emit('userClick', !this.expanded);
         },
     },
 };


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[ESDS-162](https://energysage.atlassian.net/browse/ESDS-162)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Adds `prioritizeSuggestedVisible` to the `ESCollapse` component. When false, the `visible` prop is ignored once the user interacts with the collapse. When true, the `visible` prop begins affecting the component even when the user interacts with it.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Ensured existing functionality behaves as expected
- Turned on and off the priority toggle, and made sure the behavior was as expected

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

Nathaniel 👀

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach


[ESDS-162]: https://energysage.atlassian.net/browse/ESDS-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ