### PR TITLE
fix: stop the new VLP links from opening in a new tab

### DIFF
--- a/es-vue-base/src/lib-utils/nav-bar-global-content.js
+++ b/es-vue-base/src/lib-utils/nav-bar-global-content.js
@@ -315,7 +315,6 @@ export default (
                     name: 'Community solar',
                     subHeading: 'Go solar with no equipment',
                     link: `${ES_DOMAIN}/shop/community-solar/`,
-                    newTab: true,
                     showItemsOnMobile: false,
                     subtopics: [
                         {
@@ -342,7 +341,6 @@ export default (
         {
             name: 'Community solar',
             link: `${ES_DOMAIN}/shop/community-solar/`,
-            newTab: true,
             items: [
                 {
                     name: 'Community solar guide',
@@ -359,7 +357,6 @@ export default (
         {
             name: 'Heating & cooling',
             link: `${ES_DOMAIN}/shop/heat-pumps/`,
-            newTab: true,
             items: [
                 {
                     name: 'Heat pump guide',


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-768

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- EsNavBar links were updated to point to the new VLPs on www.energysage.com in https://github.com/EnergySage/es-ds/pull/1138, but the CSM and HPM links that were previously linking to a subdomain (and therefore were set to open in a new tab) were not changed to no longer open in a new tab. This PR makes that change.

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested clicking all links locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
