### PR TITLE
CSM-2855: Displaying an error if empty folder is added

### DIFF
--- a/es-design-system/pages/molecules/es-file-input.vue
+++ b/es-design-system/pages/molecules/es-file-input.vue
@@ -11,6 +11,7 @@
                 :file-types="['image/png', 'application/pdf']"
                 @fileSizeError="fileSizeError"
                 @fileTypeError="fileTypeError"
+                @fileIsAFolderError="fileIsAFolderError"
                 @readyToUpload="readyToUpload"
                 @uploadSuccess="uploadSuccess"
                 @uploadFailure="uploadFailure"
@@ -46,6 +47,7 @@
                 :collapsed="true"
                 @fileSizeError="fileSizeError"
                 @fileTypeError="fileTypeError"
+                @fileIsAFolderError="fileIsAFolderError"
                 @readyToUpload="readyToUpload"
                 @uploadSuccess="uploadSuccess"
                 @uploadFailure="uploadFailure"
@@ -227,7 +229,12 @@ export default {
                 + 'emitted. The payload is the name of the file.',
             },
             {
-                name: '@fileTypeError',
+                name: '@fileIsAFolderError',
+                payload: 'String',
+                description: 'If the user tries to upload a folder.',
+            },
+            {
+                name: '@file',
                 payload: 'String',
                 description: 'If the file type of a file picked is not in the fileTypes array defined as a '
                 + 'prop, this event is emitted. The payload is the name of the file that was not accepted.',
@@ -273,6 +280,9 @@ export default {
     methods: {
         fileTypeError(fileName) {
             this.events.push({ msg: `fileTypeError for file: ${fileName}`, variant: 'danger' });
+        },
+        fileIsAFolderError() {
+            this.events.push({ msg: 'fileIsAFolderError', variant: 'danger' });
         },
         onSubmit() {
             this.uploadUrls = this.fileObjects.map(({ name }) => ({

--- a/es-vue-base/src/lib-components/EsFileInput.vue
+++ b/es-vue-base/src/lib-components/EsFileInput.vue
@@ -206,7 +206,7 @@ export default {
             this.pickedItems = [];
         },
         async verifyMimeType(file) {
-            // If a folder then trigger fileTypeError
+            // If an empty folder then trigger fileTypeError
             if (file.type === '') {
                 this.$emit('fileIsAFolderError');
             }

--- a/es-vue-base/src/lib-components/EsFileInput.vue
+++ b/es-vue-base/src/lib-components/EsFileInput.vue
@@ -208,7 +208,7 @@ export default {
         async verifyMimeType(file) {
             // If a folder then trigger fileTypeError
             if (file.type === '') {
-                this.$emit('fileTypeError', file.name);
+                this.$emit('fileIsAFolderError');
             }
             return new Promise((resolve, reject) => {
                 const fileReader = new FileReader();

--- a/es-vue-base/src/lib-components/EsFileInput.vue
+++ b/es-vue-base/src/lib-components/EsFileInput.vue
@@ -206,6 +206,10 @@ export default {
             this.pickedItems = [];
         },
         async verifyMimeType(file) {
+            // If a folder then trigger fileTypeError
+            if (file.type === '') {
+                this.$emit('fileTypeError', file.name);
+            }
             return new Promise((resolve, reject) => {
                 const fileReader = new FileReader();
                 fileReader.onload = (evt) => {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CSM-2855

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Earlier we wouldn't trigger/display any message when the user tried to upload  a folder but now we do

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Run `es-ds` in local using `make dev`. Adding a folder would trigger/emit `fileTypeError`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
