### PR TITLE
CED-930: zip form tweaks

### DIFF
--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -100,6 +100,33 @@
 
         <div class="mb-450">
             <h2>
+                Side-by-side example with no privacy section
+            </h2>
+            <p class="mb-200">
+                This form has <code>stackUntil</code> set to <code>xs</code> so it is always side-by-side.
+                It also has the privacy section disabled by setting
+                <code>showPrivacySection</code> to <code>false</code>.
+            </p>
+            <b-row class="justify-content-center">
+                <b-col
+                    sm="10"
+                    md="8">
+                    <es-zip-code-form
+                        constrained
+                        input-id="hero-example"
+                        stack-until="xs"
+                        :show-privacy-section="false"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText>
+                            See local offers
+                        </template>
+                    </es-zip-code-form>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="mb-450">
+            <h2>
                 Constrained stacked example
             </h2>
             <p class="mb-200">
@@ -193,9 +220,14 @@ export default {
                     'Shown in the input as placeholder text. Also used as the (visually hidden) label for the input.',
                 ],
                 [
+                    'showPrivacySection',
+                    'true',
+                    'Whether to show the privacy section.',
+                ],
+                [
                     'privacyPolicyLink',
-                    'n/a',
-                    'Required. Link to the privacy policy.',
+                    "''",
+                    'Link to the privacy policy. The link will not be shown if this is left blank.',
                 ],
                 [
                     'privacyPolicyNewTab',

--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -113,7 +113,7 @@
                     md="8">
                     <es-zip-code-form
                         constrained
-                        input-id="hero-example"
+                        input-id="side-by-side-example"
                         stack-until="xs"
                         :show-privacy-section="false"
                         url="https://www.energysage.com/market/start/">

--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="input-wrapper justify-content-end mb-50"
+        class="input-wrapper justify-content-end polite-mb-50"
         :required="required">
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
@@ -185,6 +185,10 @@ export default {
     /* vertically center within the input container */
     top: calc($input-height * 0.5);
     transform: translateY(-50%);
+}
+
+.polite-mb-50 {
+    margin-bottom: 0.5rem;
 }
 
 </style>

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -58,7 +58,9 @@
                 </slot>
             </es-button>
         </b-form>
-        <div :class="{ 'font-size-75': constrained }">
+        <div
+            v-if="showPrivacySection"
+            :class="{ 'font-size-75': constrained }">
             <icon-lock-on
                 class="privacy-lock-icon mr-25 position-relative"
                 height="1.125rem"
@@ -67,6 +69,7 @@
                 <slot name="privacyExplanation"> Your information is safe with us. </slot>
             </span>
             <b-link
+                v-if="privacyPolicyLink"
                 :href="privacyPolicyLink"
                 class="text-nowrap"
                 :class="dark ? 'text-white' : 'text-dark'"
@@ -126,9 +129,13 @@ export default {
             type: String,
             default: 'ZIP code',
         },
+        showPrivacySection: {
+            type: Boolean,
+            default: true,
+        },
         privacyPolicyLink: {
             type: String,
-            required: true,
+            default: '',
         },
         privacyPolicyNewTab: {
             type: Boolean,

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -9,10 +9,11 @@
         v-on="$listeners">
         <b-form
             ref="ctaForm"
-            class="justify-content-center mb-100 w-100"
+            class="justify-content-center w-100"
             :class="{
                 invalid: $v.$dirty && $v.$invalid,
                 [`d-${stackBreak}flex`]: stackUntil,
+                'mb-100': showPrivacySection,
             }"
             :action="url"
             method="get"

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -12,7 +12,7 @@
             class="justify-content-center mb-100 w-100"
             :class="{
                 invalid: $v.$dirty && $v.$invalid,
-                [`d-${stackBreak}flex`]: stackBreak,
+                [`d-${stackBreak}flex`]: stackUntil,
             }"
             :action="url"
             method="get"
@@ -23,7 +23,7 @@
                 :id="inputId"
                 v-model="zipCode"
                 :class="{
-                    [`mb-${stackBreak}0 mr-${stackBreak}25`]: stackBreak,
+                    [`mb-${stackBreak}0 mr-${stackBreak}25`]: stackUntil,
                 }"
                 :name="fieldName"
                 autocomplete="postal-code"
@@ -49,7 +49,7 @@
             <es-button
                 class="text-nowrap w-100"
                 :class="{
-                    [`ml-${stackBreak}25 w-${stackBreak}auto`]: stackBreak,
+                    [`ml-${stackBreak}25 w-${stackBreak}auto`]: stackUntil,
                     'px-100': constrained,
                 }"
                 type="submit">
@@ -150,7 +150,11 @@ export default {
     },
     computed: {
         stackBreak() {
-            return this.stackUntil ? `${this.stackUntil}-` : '';
+            let { stackUntil } = this;
+            if (stackUntil === 'xs') {
+                stackUntil = '';
+            }
+            return stackUntil ? `${stackUntil}-` : '';
         },
     },
     methods: {

--- a/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsFormInput <EsFormInput /> 1`] = `
-"<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end polite-mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <!---->
   <div class="input-holder position-relative">
@@ -14,7 +14,7 @@ exports[`EsFormInput <EsFormInput /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end polite-mb-50"><label for="myID" class="label font-weight-semibold justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <!---->
@@ -30,7 +30,7 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput props /> 1`] = `
-"<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">
+"<div class="input-wrapper justify-content-end polite-mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">
     <!----></label>
   <!---->
   <div class="input-holder position-relative">
@@ -44,7 +44,7 @@ exports[`EsFormInput <EsFormInput props /> 1`] = `
 
 exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 "<div>
-  <div class="input-wrapper justify-content-end mb-50"><label for="testId" class="label font-weight-semibold justify-content-start">
+  <div class="input-wrapper justify-content-end polite-mb-50"><label for="testId" class="label font-weight-semibold justify-content-start">
       <!----></label>
     <!---->
     <div class="input-holder position-relative">
@@ -58,7 +58,7 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput>slots</EsFormInput> 1`] = `
-"<div class="input-wrapper justify-content-end mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end polite-mb-50"><label for="myID" class="label font-weight-semibold justify-content-start">Account Number
     <!----></label>
   <!---->
   <div class="input-holder position-relative">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-930

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Make it possible for the zip code form to remain side-by-side all the way down to the smallest breakpoint (`xs`)
- Make it possible to hide the privacy section on the zip code form
- These changes are needed to create a CTA that emulates the current Django CMS banner.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Manual

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
