### PR TITLE
fix: aria-required-children-es-accordion

### DIFF
--- a/es-vue-base/src/lib-components/EsAccordion.vue
+++ b/es-vue-base/src/lib-components/EsAccordion.vue
@@ -6,8 +6,7 @@
             'rounded-bottom': variant !== 'minimal',
         }"
         role="tab">
-        <header
-            class="position-relative">
+        <header class="position-relative">
             <component
                 :is="headingTag"
                 class="EsAccordion-heading mb-0 align-items-center d-flex font-weight-bold justify-content-between py-100 rounded-0 text-body text-body"
@@ -30,7 +29,8 @@
         <b-collapse
             :id="id"
             :visible="isVisible"
-            role="tabpanel">
+            role="tabpanel"
+            tabindex="0">
             <div
                 class="EsAccordion-content pb-25"
                 :class="{

--- a/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsAccordionList.spec.js.snap
@@ -10,7 +10,7 @@ exports[`EsAccordion EsAccordionList expands one item and collapses another 1`] 
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">expand</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-1" class="collapse" style="display: none;">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 1.</p>
@@ -24,7 +24,7 @@ exports[`EsAccordion EsAccordionList expands one item and collapses another 1`] 
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">collapse</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-2" class="collapse show">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 2.</p>
@@ -43,7 +43,7 @@ exports[`EsAccordion EsAccordionList mounts with initial expand; collapse also w
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">collapse</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id" class="collapse show">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content.</p>
@@ -62,7 +62,7 @@ exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">collapse</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-1" class="collapse show">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 1.</p>
@@ -76,7 +76,7 @@ exports[`EsAccordion EsAccordionList performs multi-expand correctly 1`] = `
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">expand</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-2" class="collapse" style="display: none;">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 2.</p>
@@ -97,7 +97,7 @@ exports[`EsAccordion EsAccordionList v-model test 1`] = `
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">collapse</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-1" class="collapse show">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 1.</p>
@@ -113,7 +113,7 @@ exports[`EsAccordion EsAccordionList v-model test 1`] = `
           <path fill-rule="evenodd" clip-rule="evenodd" d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z"></path>
         </svg></h3> <button class="EsAccordion-button position-absolute w-100 h-100 border-0 bg-transparent"><span class="sr-only">expand</span></button>
     </header>
-    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel">
+    <transition-stub css="true" enterclass="" leaveclass="collapse show" entertoclass="collapse show" leavetoclass="collapse" enteractiveclass="collapsing" leaveactiveclass="collapsing" role="tabpanel" tabindex="0">
       <div id="accordion-id-2" class="collapse" style="display: none;">
         <div class="EsAccordion-content pb-25 bg-white pt-100 px-100 px-sm-200">
           <p>My content 2.</p>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1053
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Move the `role="tab"` to the top div of the EsAccordion so that tab is the direct child of `tablist`
- Add `tabindex="0"` to the tabpanel in b-collapse
### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Running Lighthouse in Chrome Devtools for [EsAccordion](http://localhost:8500/molecules/es-accordion) example page in es-ds does not show `aria-required-children` anymore under the accessibility test report after making the changes.

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- Overall. Would this change cause 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
