### PR TITLE
chore: Tweaks to catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     github.com/project-slug: EnergySage/es-ds
     backstage.io/techdocs-ref: dir:.
+    backstage.io/code-coverage: enabled
 spec:
   type: library
   owner: guests

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,9 +2,15 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: es-ds
+  description: |
+    EnergySage Design System Monorepo 
+  links:
+    - title: Github Org
+      url: https://github.com/EnergySage/
   annotations:
     github.com/project-slug: EnergySage/es-ds
+    backstage.io/techdocs-ref: dir:.
 spec:
-  type: other
-  lifecycle: unknown
+  type: library
   owner: guests
+  lifecycle: experimental


### PR DESCRIPTION
### Context

NON FEATURE CHANGE

This is a yaml file which is used to have our own internal services read information from this repo. It will have no impact on the core features or execution or usage of this module. 


### Description of changes

* Added `description` field to metadata ([description-optional docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#description-optional))
* Added a `link` just to test out putting something there, it links to the org's page on github for this one ([links docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional))
* changes the spec type to `library` which is for npm modules and such ([spec type docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required))
* changed `lifecycle` to experimental ([lifecycle docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required))

ok this last thing, 
> An object with arbitrary non-identifying metadata attached to the entity, identical in use to [Kubernetes object annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).

I think this will make the readme and some more technical documents show up, but unsure of the format. 

```
backstage.io/techdocs-ref: dir:.
```

those type of annotations basically each unlock new features, from the [Annotation documentation](https://backstage.io/docs/features/software-catalog/descriptor-format/#annotations-optional) I am very excited to see how some of those look. 
