### PR TITLE
fix: make the featured article image in the nav lazy load

### DIFF
--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -125,6 +125,7 @@
                             :link="featuredArticle.linkUrl"
                             :new-tab="featuredArticle.newTab"
                             :name="featuredArticle.lede"
+                            loading="lazy"
                             :image500="featuredArticle.image500"
                             :image-alt="featuredArticle.imageAlt" />
                     </b-row>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 [Linked issue](https://energysage.atlassian.net/browse/CED-1226)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change should get rid of a lighthouse error regarding the size of a payload. In this case specifically the size of this image and it's loading time.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

-

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have documented testing approach
