### PR TITLE
feat: made side nav persistent on XL and XXL breakpoints

### DIFF
--- a/es-design-system/components/ds-atoms-list.vue
+++ b/es-design-system/components/ds-atoms-list.vue
@@ -1,29 +1,29 @@
 <template>
-    <ul>
+    <ul class="list-unstyled pl-100">
         <li>
-            <b-link to="/atoms/color">
+            <ds-link to="/atoms/color">
                 Color
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/atoms/typography">
+            <ds-link to="/atoms/typography">
                 Typography
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/atoms/layout">
+            <ds-link to="/atoms/layout">
                 Layout
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/atoms/spacing">
+            <ds-link to="/atoms/spacing">
                 Spacing
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/atoms/icons">
+            <ds-link to="/atoms/icons">
                 Icons
-            </b-link>
+            </ds-link>
         </li>
     </ul>
 </template>

--- a/es-design-system/components/ds-examples-list.vue
+++ b/es-design-system/components/ds-examples-list.vue
@@ -1,24 +1,24 @@
 <template>
-    <ul>
+    <ul class="list-unstyled pl-100">
         <li>
-            <b-link :to="{ name: 'examples-nuxt-components___en' }">
+            <ds-link to="/examples/nuxt-components">
                 Nuxt Components
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link :to="{ name: 'examples-form-field-validation___en' }">
+            <ds-link to="/examples/form-field-validation">
                 Form with Field Validation
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link :to="{ name: 'examples-form-validation___en' }">
+            <ds-link to="/examples/form-validation">
                 Form with (form level) Validation
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link :to="{ name: 'examples-file-upload___en' }">
+            <ds-link to="/examples/file-upload">
                 File Upload
-            </b-link>
+            </ds-link>
         </li>
     </ul>
 </template>

--- a/es-design-system/components/ds-link-list.vue
+++ b/es-design-system/components/ds-link-list.vue
@@ -45,11 +45,5 @@
 <script>
 export default {
     name: 'DsLinkList',
-    props: {
-        currentPath: {
-            type: String,
-            required: true,
-        },
-    },
 };
 </script>

--- a/es-design-system/components/ds-link-list.vue
+++ b/es-design-system/components/ds-link-list.vue
@@ -53,11 +53,3 @@ export default {
     },
 };
 </script>
-
-<style lang="scss" scoped>
-.ds-link-list {
-    li {
-        list-style-type: none;
-    }
-}
-</style>

--- a/es-design-system/components/ds-link-list.vue
+++ b/es-design-system/components/ds-link-list.vue
@@ -1,43 +1,43 @@
 <template>
-    <ul>
+    <ul class="ds-link-list list-unstyled">
         <li>
             <div class="h4">
-                <b-link to="/">
-                    Bootstrap 4
-                </b-link>
+                <ds-link to="/">
+                    Home
+                </ds-link>
             </div>
         </li>
         <li>
             <div class="h4">
-                <b-link to="/atoms">
+                <ds-link to="/atoms">
                     Atoms
-                </b-link>
+                </ds-link>
             </div>
-            <DsAtomsList />
+            <ds-atoms-list class="mb-100" />
         </li>
         <li>
             <div class="h4">
-                <b-link to="/molecules">
+                <ds-link to="/molecules">
                     Molecules
-                </b-link>
+                </ds-link>
             </div>
-            <DsMoleculesList />
+            <ds-molecules-list class="mb-100" />
         </li>
         <li>
             <div class="h4">
-                <b-link to="/organisms">
+                <ds-link to="/organisms">
                     Organisms
-                </b-link>
+                </ds-link>
             </div>
-            <DsOrganismsList />
+            <ds-organisms-list class="mb-100" />
         </li>
         <li>
             <div class="h4">
-                <b-link to="/examples">
+                <ds-link to="/examples">
                     Examples
-                </b-link>
+                </ds-link>
             </div>
-            <DsExamplesList />
+            <ds-examples-list class="mb-100" />
         </li>
     </ul>
 </template>
@@ -45,5 +45,19 @@
 <script>
 export default {
     name: 'DsLinkList',
+    props: {
+        currentPath: {
+            type: String,
+            required: true,
+        },
+    },
 };
 </script>
+
+<style lang="scss" scoped>
+.ds-link-list {
+    li {
+        list-style-type: none;
+    }
+}
+</style>

--- a/es-design-system/components/ds-link.vue
+++ b/es-design-system/components/ds-link.vue
@@ -1,0 +1,25 @@
+<template>
+    <component
+        :is="element"
+        class="font-weight-semibold"
+        :to="to">
+        <slot />
+    </component>
+</template>
+
+<script>
+export default {
+    name: 'DsLink',
+    props: {
+        to: {
+            type: String,
+            required: true,
+        },
+    },
+    computed: {
+        element() {
+            return this.$route.path === this.to ? 'div' : 'b-link';
+        },
+    },
+};
+</script>

--- a/es-design-system/components/ds-molecules-list.vue
+++ b/es-design-system/components/ds-molecules-list.vue
@@ -1,129 +1,129 @@
 <template>
-    <ul>
+    <ul class="list-unstyled pl-100">
         <li>
-            <b-link to="/molecules/es-accordion">
+            <ds-link to="/molecules/es-accordion">
                 EsAccordion
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-badge">
+            <ds-link to="/molecules/es-badge">
                 EsBadge
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-breadcrumbs">
+            <ds-link to="/molecules/es-breadcrumbs">
                 EsBreadcrumbs
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-button">
+            <ds-link to="/molecules/es-button">
                 EsButton
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-card">
+            <ds-link to="/molecules/es-card">
                 EsCard
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-collapse">
+            <ds-link to="/molecules/es-collapse">
                 EsCollapse
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-data-table">
+            <ds-link to="/molecules/es-data-table">
                 EsDataTable
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-file-input">
+            <ds-link to="/molecules/es-file-input">
                 EsFileInput
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-form-input">
+            <ds-link to="/molecules/es-form-input">
                 EsFormInput
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-form-msg">
+            <ds-link to="/molecules/es-form-msg">
                 EsFormMsg
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-form-radio-cards">
+            <ds-link to="/molecules/es-form-radio-cards">
                 EsFormRadioCards
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-form-textarea">
+            <ds-link to="/molecules/es-form-textarea">
                 EsFormTextarea
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-horizontal-list">
+            <ds-link to="/molecules/es-horizontal-list">
                 EsHorizontalList
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-modal">
+            <ds-link to="/molecules/es-modal">
                 EsModal
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-pagination">
+            <ds-link to="/molecules/es-pagination">
                 EsPagination
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-popover">
+            <ds-link to="/molecules/es-popover">
                 EsPopover
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-progress">
+            <ds-link to="/molecules/es-progress">
                 EsProgress
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-progress-circle">
+            <ds-link to="/molecules/es-progress-circle">
                 EsProgressCircle
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-rating">
+            <ds-link to="/molecules/es-rating">
                 EsRating
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-slider">
+            <ds-link to="/molecules/es-slider">
                 EsSlider
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-support">
+            <ds-link to="/molecules/es-support">
                 EsSupport
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-tabs">
+            <ds-link to="/molecules/es-tabs">
                 EsTabs
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-verification-code">
+            <ds-link to="/molecules/es-verification-code">
                 EsVerificationCode
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-video">
+            <ds-link to="/molecules/es-video">
                 EsVideo
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/molecules/es-view-more">
+            <ds-link to="/molecules/es-view-more">
                 EsViewMore
-            </b-link>
+            </ds-link>
         </li>
     </ul>
 </template>

--- a/es-design-system/components/ds-organisms-list.vue
+++ b/es-design-system/components/ds-organisms-list.vue
@@ -1,69 +1,69 @@
 <template>
-    <ul>
+    <ul class="list-unstyled pl-100">
         <li>
-            <b-link to="/organisms/es-cta-banner">
+            <ds-link to="/organisms/es-cta-banner">
                 EsCtaBanner
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-cta-card">
+            <ds-link to="/organisms/es-cta-card">
                 EsCtaCard
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-error-page">
+            <ds-link to="/organisms/es-error-page">
                 EsErrorPage
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-footer">
+            <ds-link to="/organisms/es-footer">
                 EsFooter
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-form">
+            <ds-link to="/organisms/es-form">
                 EsForm
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-nav-bar">
+            <ds-link to="/organisms/es-nav-bar">
                 EsNavBar
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-review">
+            <ds-link to="/organisms/es-review">
                 EsReview
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-reviews-list">
+            <ds-link to="/organisms/es-reviews-list">
                 EsReviewsList
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-reviews-io-card-carousel">
+            <ds-link to="/organisms/es-reviews-io-card-carousel">
                 EsReviewsIoCardCarousel
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-support-card">
+            <ds-link to="/organisms/es-support-card">
                 EsSupportCard
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-file-thumbnail">
+            <ds-link to="/organisms/es-file-thumbnail">
                 EsFileThumbnail
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-file-preview-modal">
+            <ds-link to="/organisms/es-file-preview-modal">
                 EsFilePreviewModal
-            </b-link>
+            </ds-link>
         </li>
         <li>
-            <b-link to="/organisms/es-zip-code-form">
+            <ds-link to="/organisms/es-zip-code-form">
                 EsZipCodeForm
-            </b-link>
+            </ds-link>
         </li>
     </ul>
 </template>

--- a/es-design-system/layouts/default.vue
+++ b/es-design-system/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <b-navbar
-            class="mb-3"
+            class="d-xl-none mb-100"
             type="dark"
             variant="primary">
             <b-navbar-nav>
@@ -12,23 +12,29 @@
         </b-navbar>
         <b-sidebar
             id="sidebar-1"
+            class="d-xl-none"
             :title="`ES DS ${$config.version}`"
             shadow>
-            <DsLinkList />
+            <ds-link-list class="mx-100" />
         </b-sidebar>
-        <b-container>
-            <b-row class="mb-3">
-                <b-col cols="12">
-                    <es-breadcrumbs :items="breadcrumbs" />
-                </b-col>
-            </b-row>
-            <b-row>
-                <b-col
-                    cols="12">
-                    <Nuxt />
-                </b-col>
-            </b-row>
-        </b-container>
+        <div class="d-flex justify-content-xl-center">
+            <div class="ds-side-nav d-none d-xl-block flex-shrink-0 p-100">
+                <ds-link-list />
+            </div>
+            <b-container class="pt-xl-100 mx-0">
+                <b-row class="mb-100">
+                    <b-col cols="12">
+                        <es-breadcrumbs :items="breadcrumbs" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        cols="12">
+                        <Nuxt />
+                    </b-col>
+                </b-row>
+            </b-container>
+        </div>
     </div>
 </template>
 
@@ -58,3 +64,9 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+.ds-side-nav {
+    width: 300px;
+}
+</style>

--- a/es-design-system/pages/index.vue
+++ b/es-design-system/pages/index.vue
@@ -4,7 +4,7 @@
             EnergySage Design System
         </h1>
         <p>
-            Our designs system is based upon the
+            Our design system is based upon the
             <b-link href="https://getbootstrap.com/docs/4.6/getting-started/introduction/">
                 bootstrap 4
             </b-link> and


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- n/a

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- For easier navigability and discoverability on desktop, exposed the side nav and made it persistent on the `xl` and `xxl` breakpoints (i.e. as soon as there's enough room) - reduces the need to dive in and out of category pages to navigate between child/leaf pages (i.e. fewer clicks) and gives newcomers an idea, at a single glance, of what our design system contains
- Retained `<b-container>` around the page content so it still goes up to the full max width, except on lower `xl` breakpoint where it's slightly constrained below its max width
- Enhanced the navigation to indicate the current page within its list of links
- Fixed a typo on the home page
- EsNavBar and EsFooter pages are unchanged, as those use a different layout, need to display at full viewport width, and are being removed from the design system soon anyway

#### XL breakpoint with side nav shown
<img width="1429" alt="Screen Shot 2024-04-17 at 7 26 39 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/d21558f1-3aba-4bd5-a862-fbfa3f742195">

#### Upper XL breakpoint with room enough that the entire layout centers within viewport, as before
<img width="929" alt="Screen Shot 2024-04-17 at 7 27 08 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/e043ea92-a153-46f0-ac41-a28dd10504cb">

#### XXL breakpoint
<img width="978" alt="Screen Shot 2024-04-17 at 7 27 20 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/20cc55a3-be20-4aba-92fa-ef22b2b67953">

#### LG breakpoint and below remain unchanged
<img width="1147" alt="Screen Shot 2024-04-17 at 7 26 18 AM" src="https://github.com/EnergySage/es-ds/assets/1350363/565d927d-3e5c-4d64-aabe-b31ca0bcffa3">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
