### PR TITLE
feat: add optional initial zip code value

### DIFF
--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -305,7 +305,7 @@ export default {
                     'zipCodeInitialValue',
                     "''",
                     'The default zipcode value if passed to the zip code form',
-                ]
+                ],
             ],
             propTableWidths: {
                 md: ['4', '2', '6'],

--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -39,6 +39,30 @@
         </div>
 
         <div class="mb-450">
+            <h2>Pre-populate zipcode example</h2>
+            <p class="mb-200">
+                Same as above, except the zip code form can accept an <code>initial zip code value</code>, facilitating
+                the pre-population of zip codes from a form. This feature is beneficial for scenarios where a
+                pre-determined zip code needs to be set, which users can subsequently modify. If the user does not
+                alter the zip code, it will default to the initial value provided.
+            </p>
+            <b-row class="justify-content-center">
+                <b-col
+                    sm="10"
+                    md="8">
+                    <es-zip-code-form
+                        input-id="prepopulate-hero-example"
+                        privacy-policy-link="https://www.energysage.com/privacy-policy/"
+                        stack-until="lg"
+                        zip-code-initial-value="02150"
+                        url="https://www.energysage.com/market/start/">
+                        <template #buttonText> See local offers </template>
+                    </es-zip-code-form>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="mb-450">
             <h2>
                 Dark responsive example
             </h2>

--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -301,6 +301,11 @@ export default {
                     'n/a',
                     'Specify which product of interest. Options include: solar-pv, heatpump, ev-charger',
                 ],
+                [
+                    'zipCodeInitialValue',
+                    "''",
+                    'The default zipcode value if passed to the zip code form',
+                ]
             ],
             propTableWidths: {
                 md: ['4', '2', '6'],

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -150,10 +150,14 @@ export default {
             type: String,
             required: true,
         },
+        zipCodeInitialValue: {
+            type: String,
+            default: '',
+        },
     },
     data() {
         return {
-            zipCode: '',
+            zipCode: this.zipCodeInitialValue,
         };
     },
     computed: {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/GROW-33

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

_Please read the approaches required to complete the above ticket mentioned in the comment section of the ticket._

**Brief Overview:**

Growth would like to test pre-populating zip code, currently there is no way to send an initial ZipCode to the es-zip-code-form used everywhere. The initial value could be via pre-populating the zipcode  through google maps api or may be something else in future.

The crux however, remains that as every repo is slowly transitioning to use the `EsZipCodeForm` from in es-ds, it makes sense to have this functionality in this new zipCodeForm without disrupting the current functionality.

**Changes**
- Added optional variable `zipCodeInitialValue` to `EsZipCodeForm.vue`
- Set the data field `zipCode` to take value from the above prop thus not altering a lot in the file
- Added an example in Organisms folder - `es-zip-code-form.vue` to give an idea of how the zip code would look like with initial value

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Tested locally:
- Go to http://localhost:8500/organisms/es-zip-code-form.
- Try the **Responsive example** which is the default - make sure it works as it is
- Then try the **Pre-populate zipcode example** make sure it works with initial value and the correct initial value is passed as the query param in onboarding
- Then try the **Pre-populate zipcode example**  again and this time change the zipcode in input field, now the new value should be passed to es-onboarding

<img width="1363" alt="Screenshot 2024-04-26 at 11 27 44 AM" src="https://github.com/EnergySage/es-ds/assets/42462841/cbc9f4e2-ec07-40cc-8aff-c0e428975f5f">

- Also, noting this doesn't create any sort of tech debt in `es-ds` nor in any other repo.

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
