### PR TITLE
CED-1484: EsNavBar tweaks

### DIFF
--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -306,11 +306,6 @@ $nav-hover-delay: 300ms;
         cursor: pointer;
       }
 
-      .top-header-icon {
-        // stylelint-disable-next-line property-disallowed-list
-        transition: transform 0s;
-        transform: rotate(0deg);
-      }
       .dropdown-menu {
         // prepare menu for delayed hover showing
         display: block;
@@ -383,11 +378,6 @@ $nav-hover-delay: 300ms;
         content: "";
         background: variables.$orange-800;
         border-style: none;
-      }
-
-      .top-header-icon {
-        transition-delay: $nav-hover-delay;
-        transform: rotate(180deg);
       }
     }
 

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -319,6 +319,11 @@ $nav-hover-delay: 300ms;
       }
     }
 
+    .product-menu .nav-item:last-child .product-menu-header-link {
+      /* stylelint-disable-next-line declaration-no-important */
+      padding-right: 2em !important;
+    }
+
     .product-menu-header-link {
       color: variables.$blue-800;
     }

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -272,6 +272,14 @@ $nav-hover-delay: 300ms;
       }
     }
 
+    // when not scrolled down, add top padding to upper navbar elements
+    &:not(.scrolled) {
+      .navbar-brand,
+      .icon-dropdown {
+        padding-top: 1em;
+      }
+    }
+
     // Allow dropdown content to take up the full width of the page
     .dropdown-full-page {
       position: static;
@@ -384,11 +392,6 @@ $nav-hover-delay: 300ms;
         background: variables.$orange-800;
         border-style: none;
       }
-    }
-
-    .navbar-brand,
-    .icon-dropdown {
-      padding-top: 1em;
     }
 
     // primary nav buttons desktop

--- a/es-bs-base/scss/_nav.scss
+++ b/es-bs-base/scss/_nav.scss
@@ -272,14 +272,6 @@ $nav-hover-delay: 300ms;
       }
     }
 
-    // when not scrolled down, add top padding to upper navbar elements
-    &:not(.scrolled) {
-      .navbar-brand,
-      .icon-dropdown {
-        padding-top: 1em;
-      }
-    }
-
     // Allow dropdown content to take up the full width of the page
     .dropdown-full-page {
       position: static;

--- a/es-vue-base/src/lib-components/EsNavBar.vue
+++ b/es-vue-base/src/lib-components/EsNavBar.vue
@@ -73,7 +73,7 @@
                     <!-- top-level items on mobile, full top bar on desktop -->
                     <b-container class="align-items-start d-flex flex-lg-nowrap justify-content-between top-level-nav">
                         <es-nav-bar-link
-                            class="navbar-brand d-none d-lg-block"
+                            class="navbar-brand d-none d-lg-block pt-150"
                             :href="globalContent.home.link">
                             <!-- small desktop logo -->
                             <es-logo
@@ -106,7 +106,7 @@
                         <!-- desktop account menu -->
                         <es-nav-bar-account-menu
                             :auth-items="accountContent.loggedIn.items"
-                            class="d-none d-lg-block"
+                            class="d-none d-lg-block pt-100"
                             :logged-out="accountContent.loggedOut" />
                     </b-container>
                     <!-- mobile+desktop product menus -->

--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -13,11 +13,6 @@
                 aria-expanded="false">
                 <div class="d-lg-flex align-items-center">
                     {{ name }}
-                    <span class="ml-50">
-                        <IconChevronDown
-                            class="top-header-icon"
-                            style="height: 20px; width: 20px;" />
-                    </span>
                 </div>
             </es-nav-bar-link>
             <!-- mobile+desktop top-level link -->


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

- [CED-1484: EsNavBar: remove chevrons and other fixes](https://energysage.atlassian.net/browse/CED-1484)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Removed chevrons from primary navbar items
- Right-align product menu items with account menu icon in LG viewport by removing right padding from final menu item
- Don't apply top padding to logo and account menu when navbar is affixed

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Tested locally
- Changes didn't affect mobile version, just desktop

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I replaced a CSS selector for the padding with some simpler utility classes. The sticky navbar uses different markup.
- The `pt-150` padding over the logo will need to be tweaked when we start using the new logo. The current design shows `16px` above all navbar elements in that section and another `6px` in the logo itself. I approximated that `22px` with `pt-150`, which works out to `24px`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [ ] I have documented testing approach
