### PR TITLE
CED-1498: form label style update

### DIFF
--- a/es-vue-base/src/lib-components/EsFormInput.vue
+++ b/es-vue-base/src/lib-components/EsFormInput.vue
@@ -5,7 +5,7 @@
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
             :for="id"
-            class="label font-italic font-weight-semibold justify-content-start"
+            class="label justify-content-start"
             :class="{ 'sr-only': labelSrOnly }">
             <slot name="label" />
             <span

--- a/es-vue-base/src/lib-components/EsFormTextarea.vue
+++ b/es-vue-base/src/lib-components/EsFormTextarea.vue
@@ -5,7 +5,7 @@
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
             :for="id"
-            class="label font-italic font-weight-semibold justify-content-start">
+            class="label justify-content-start">
             <slot name="label" />
 
             <span

--- a/es-vue-base/tests/__snapshots__/EsFormTextarea.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsFormTextarea.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsFormTextarea <EsFormTextarea /> 1`] = `
-"<div class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start">Notes
+"<div class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start">Notes
     <!----></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
     <!---->
@@ -12,7 +12,7 @@ exports[`EsFormTextarea <EsFormTextarea /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea <label /> /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
@@ -26,7 +26,7 @@ exports[`EsFormTextarea <EsFormTextarea <label /> /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea props /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea>
@@ -41,7 +41,7 @@ exports[`EsFormTextarea <EsFormTextarea props /> 1`] = `
 
 exports[`EsFormTextarea <EsFormTextarea v-model /> 1`] = `
 "<div>
-  <div class="input-wrapper justify-content-end"><label for="testId" class="label font-italic font-weight-semibold justify-content-start">
+  <div class="input-wrapper justify-content-end"><label for="testId" class="label justify-content-start">
       <!----></label>
     <div class="input-holder"><textarea id="testId" rows="2" wrap="soft" class="es-form-textarea w-100 form-control" data-testid="testTextarea"></textarea>
       <!---->
@@ -53,7 +53,7 @@ exports[`EsFormTextarea <EsFormTextarea v-model /> 1`] = `
 `;
 
 exports[`EsFormTextarea <EsFormTextarea>slots</EsFormTextarea> 1`] = `
-"<div class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start">Notes
+"<div class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start">Notes
     <!----></label>
   <div class="input-holder"><textarea id="myID" rows="2" wrap="soft" class="es-form-textarea w-100 form-control"></textarea> <small class="form-text text-muted">Enter your notes here.</small>
     <div class="invalid-feedback">Please enter a valid value.</div>

--- a/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
+++ b/es-vue-base/tests/__snapshots__/EsForminput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EsFormInput <EsFormInput /> 1`] = `
-"<div class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start">Account Number
     <!----></label>
   <!---->
   <div class="input-holder position-relative">
@@ -14,7 +14,7 @@ exports[`EsFormInput <EsFormInput /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
-"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start"> <span class="text-danger">
+"<div required="required" class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start"> <span class="text-danger">
             *
         </span></label>
   <!---->
@@ -30,7 +30,7 @@ exports[`EsFormInput <EsFormInput <label /> /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput props /> 1`] = `
-"<div class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start">
+"<div class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start">
     <!----></label>
   <!---->
   <div class="input-holder position-relative">
@@ -44,7 +44,7 @@ exports[`EsFormInput <EsFormInput props /> 1`] = `
 
 exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 "<div>
-  <div class="input-wrapper justify-content-end"><label for="testId" class="label font-italic font-weight-semibold justify-content-start">
+  <div class="input-wrapper justify-content-end"><label for="testId" class="label justify-content-start">
       <!----></label>
     <!---->
     <div class="input-holder position-relative">
@@ -58,7 +58,7 @@ exports[`EsFormInput <EsFormInput v-model /> 1`] = `
 `;
 
 exports[`EsFormInput <EsFormInput>slots</EsFormInput> 1`] = `
-"<div class="input-wrapper justify-content-end"><label for="myID" class="label font-italic font-weight-semibold justify-content-start">Account Number
+"<div class="input-wrapper justify-content-end"><label for="myID" class="label justify-content-start">Account Number
     <!----></label>
   <!---->
   <div class="input-holder position-relative">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://energysage.atlassian.net/browse/CED-1498

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Remove italics from form labels
- Remove the font weight override so that the weight matches the Figma

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Manual testing on http://localhost:8500/organisms/es-form

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
