### PR TITLE
fix: breadcrumbs bottom margin

### DIFF
--- a/es-bs-base/scss/_breadcrumb.scss
+++ b/es-bs-base/scss/_breadcrumb.scss
@@ -15,6 +15,8 @@
 }
 
 .breadcrumb-item {
+  margin-bottom: 0;
+
   // The separator between breadcrumbs (by default, a forward-slash: "/")
   + .breadcrumb-item {
     padding-left: variables.$breadcrumb-item-padding;

--- a/es-design-system/pages/molecules/es-breadcrumbs.vue
+++ b/es-design-system/pages/molecules/es-breadcrumbs.vue
@@ -13,6 +13,9 @@
         <div class="my-500">
             <es-breadcrumbs :items="items" />
         </div>
+        <div class="my-500">
+            <es-breadcrumbs :items="longerItems" />
+        </div>
         <ds-doc-source
             :comp-code="compCode"
             comp-source="es-vue-base/src/lib-components/EsBreadcrumbs.vue"
@@ -40,6 +43,20 @@ export default {
                 {
                     text: 'Search',
                     active: true,
+                },
+            ],
+            longerItems: [
+                {
+                    text: 'EnergySage',
+                    to: '#',
+                },
+                {
+                    text: 'Cost of solar',
+                    to: '#',
+                },
+                {
+                    text: 'Solar cost in California',
+                    to: '#',
                 },
             ],
         };


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-1513

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Override the default bottom margin for `<li>` tags in the case of EsBreadcrumbs to prevent wrapped breadcrumbs on mobile from pushing content below the fold unnecessarily

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on EsBreadcrumbs docs page with new longer example

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
