### PR TITLE
CED-1593: nav bar font weights

### DIFF
--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -23,7 +23,7 @@
                 class="nav-link d-flex d-lg-none align-items-center w-100 h-100 px-0 py-lg-100 px-100 font-weight-bold justify-content-between"
                 :class="{ 'dropdown-label': !link }"
                 :for="link ? undefined : checkboxId"
-                :href="link || '#'"
+                :href="link || undefined"
                 :target="newTab ? '_blank' : undefined">
                 <div class="align-items-center d-flex">
                     {{ name }}

--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -10,7 +10,7 @@
                 :href="link || '#'"
                 data-toggle="dropdown"
                 aria-haspopup="true"
-                :aria-expanded="link">
+                :aria-expanded="link ? 'true' : 'false'">
                 <div class="d-lg-flex align-items-center">
                     {{ name }}
                 </div>

--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -3,27 +3,28 @@
         class="nav-item top-header mx-0"
         :class="{ 'has-dropdown': !link }">
         <div class="top-header-inner w-100">
-            <!-- desktop fly-out menu trigger -->
+            <!-- desktop link and fly-out menu trigger -->
             <es-nav-bar-link
                 class="nav-link d-none d-lg-block py-100 font-weight-bolder"
                 :class="{ 'dropdown-toggle': !link }"
                 :href="link || '#'"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                :aria-expanded="link ? 'true' : 'false'">
+                :data-toggle="link ? undefined : 'dropdown'"
+                :aria-haspopup="link ? undefined : true"
+                :aria-expanded="link ? undefined : false"
+                :target="link && newTab ? '_blank' : undefined">
                 <div class="d-lg-flex align-items-center">
                     {{ name }}
                 </div>
             </es-nav-bar-link>
-            <!-- mobile fly-out menu trigger -->
+            <!-- mobile link and fly-out menu trigger -->
             <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
             <component
                 :is="link ? 'es-nav-bar-link' : 'label'"
                 class="nav-link d-flex d-lg-none align-items-center w-100 h-100 px-0 py-lg-100 px-100 font-weight-bold justify-content-between"
                 :class="{ 'dropdown-label': !link }"
-                :for="checkboxId"
+                :for="link ? undefined : checkboxId"
                 :href="link || '#'"
-                :target="newTab ? '_blank' : null">
+                :target="newTab ? '_blank' : undefined">
                 <div class="align-items-center d-flex">
                     {{ name }}
                 </div>

--- a/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
+++ b/es-vue-base/src/lib-components/EsNavBarTopLevelMenu.vue
@@ -5,43 +5,33 @@
         <div class="top-header-inner w-100">
             <!-- desktop fly-out menu trigger -->
             <es-nav-bar-link
-                v-if="!link"
-                class="nav-link dropdown-toggle d-none d-lg-block py-100 font-weight-bolder"
-                href="#"
+                class="nav-link d-none d-lg-block py-100 font-weight-bolder"
+                :class="{ 'dropdown-toggle': !link }"
+                :href="link || '#'"
                 data-toggle="dropdown"
                 aria-haspopup="true"
-                aria-expanded="false">
+                :aria-expanded="link">
                 <div class="d-lg-flex align-items-center">
                     {{ name }}
                 </div>
             </es-nav-bar-link>
-            <!-- mobile+desktop top-level link -->
-            <es-nav-bar-link
-                v-else
-                class="nav-link d-flex align-items-center w-100 h-100 px-0 py-lg-100 px-100 font-weight-bold"
-                :href="link"
-                :target="newTab ? '_blank' : null">
-                <div class="d-flex d-lg-block top-level-label">
-                    <div
-                        class="d-lg-flex align-items-center">
-                        {{ name }}
-                    </div>
-                </div>
-            </es-nav-bar-link>
             <!-- mobile fly-out menu trigger -->
             <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-            <label
-                v-if="!link"
+            <component
+                :is="link ? 'es-nav-bar-link' : 'label'"
+                class="nav-link d-flex d-lg-none align-items-center w-100 h-100 px-0 py-lg-100 px-100 font-weight-bold justify-content-between"
+                :class="{ 'dropdown-label': !link }"
                 :for="checkboxId"
-                class="dropdown-label nav-link d-flex d-lg-none px-100 w-100 h-100 align-items-center
-                justify-content-between font-weight-bold">
+                :href="link || '#'"
+                :target="newTab ? '_blank' : null">
                 <div class="align-items-center d-flex">
                     {{ name }}
                 </div>
                 <IconArrowRight
+                    v-if="!link"
                     class="expand-icon"
                     style="height: 24px;" />
-            </label>
+            </component>
             <input
                 v-if="!link"
                 :id="checkboxId"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1593

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes the nav bar inconsistent font weights by reusing elements rather than having separate ones conditional on `link`

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on mobile and desktop at http://localhost:8500/organisms/es-nav-bar

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
