### PR TITLE
fix: center one line popovers

### DIFF
--- a/es-vue-base/src/lib-components/EsPopover.vue
+++ b/es-vue-base/src/lib-components/EsPopover.vue
@@ -31,17 +31,16 @@
         <template #default>
             <div class="d-flex">
                 <slot />
-                <div v-if="!hasTitle">
-                    <es-button
-                        inline
-                        variant="link"
-                        class="es-popover-close p-0 pl-50"
-                        @click="onClose">
-                        <XIcon
-                            height="20px"
-                            width="20px" />
-                    </es-button>
-                </div>
+                <es-button
+                    v-if="!hasTitle"
+                    inline
+                    variant="link"
+                    class="es-popover-close p-0 pl-50"
+                    @click="onClose">
+                    <XIcon
+                        height="20px"
+                        width="20px" />
+                </es-button>
             </div>
         </template>
     </b-popover>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1615

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
* Centers one line popovers by removing unnecessary outer div
* 
### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
* Tested locally at http://localhost:8500/molecules/es-popover by editing one of the popovers without a title or button to be one line
Before:
<img width="239" alt="image" src="https://github.com/EnergySage/es-ds/assets/166626696/8b4fdb6d-1fab-4f28-bda7-fd7a8b12d323">
After:
<img width="252" alt="image" src="https://github.com/EnergySage/es-ds/assets/166626696/5c7cac98-4128-4a14-a49a-72916d8c5952">

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
