### PR TITLE
fix: updated es zip code form to not be centered

### DIFF
--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -362,4 +362,3 @@ export default {
     },
 };
 </script>
-

--- a/es-design-system/pages/organisms/es-zip-code-form.vue
+++ b/es-design-system/pages/organisms/es-zip-code-form.vue
@@ -23,6 +23,7 @@
             </p>
             <b-row class="justify-content-center">
                 <b-col
+                    class="d-flex justify-content-center"
                     sm="10"
                     md="8">
                     <es-zip-code-form
@@ -48,6 +49,7 @@
             </p>
             <b-row class="justify-content-center">
                 <b-col
+                    class="d-flex justify-content-center"
                     sm="10"
                     md="8">
                     <es-zip-code-form
@@ -73,6 +75,7 @@
             <div class="bg-dark-blue rounded p-200">
                 <b-row class="justify-content-center">
                     <b-col
+                        class="d-flex justify-content-center"
                         sm="10"
                         md="8">
 
@@ -103,6 +106,7 @@
             </p>
             <b-row class="justify-content-center">
                 <b-col
+                    class="d-flex justify-content-center"
                     sm="8"
                     md="6"
                     lg="5"
@@ -132,6 +136,7 @@
             </p>
             <b-row class="justify-content-center">
                 <b-col
+                    class="d-flex justify-content-center"
                     sm="10"
                     md="8">
                     <es-zip-code-form
@@ -186,6 +191,7 @@
             </p>
             <b-row class="justify-content-center">
                 <b-col
+                    class="d-flex justify-content-center"
                     sm="10"
                     md="8">
                     <es-zip-code-form
@@ -356,3 +362,4 @@ export default {
     },
 };
 </script>
+

--- a/es-vue-base/src/lib-components/EsZipCodeForm.vue
+++ b/es-vue-base/src/lib-components/EsZipCodeForm.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="EsZipCodeForm d-flex justify-content-center"
+        class="EsZipCodeForm d-flex"
         :class="{
             'EsZipCodeForm--constrained': constrained,
             'text-white': dark,


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Excluded `justify-content-center` from EsZipCodeForm.vue template 
- Updated es-zip-code-form.vue template to have the zip code forms centered. 

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- tested on http://localhost:8500/organisms/es-zip-code-form

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- Does the layout for "Constrained stacked example" look all right for `lg` and above viewports

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
