### PR TITLE
feat: added chart colors to Colors docs page

### DIFF
--- a/es-design-system/pages/atoms/color.vue
+++ b/es-design-system/pages/atoms/color.vue
@@ -9,7 +9,7 @@
             introducing new unamed colors.
         </p>
         <p>
-            All colors have CSS utility classes associated with them.
+            All colors (except restricted colors) have CSS utility classes associated with them.
             <code>text-{COLOR_NAME}</code> for text color and <code>bg-{COLOR_NAME}</code>
             for background color.
         </p>
@@ -32,7 +32,6 @@
                             'white', 'soft-blue', 'medium-blue', 'warm-orange'
                         ].includes(alias)"
                         :hex="value"
-                        :show-border="['white', 'soft-blue'].includes(alias)"
                         :token="alias" />
                     <p class="font-weight-semibold mb-0 mt-50">
                         {{ coreColorNames[alias] || alias }}
@@ -181,6 +180,41 @@
                                 :token="alias" />
                         </b-col>
                     </b-row>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Restricted colors
+            </h2>
+            <p>
+                Use only for charts and data.
+            </p>
+            <b-row>
+                <b-col
+                    v-for="(value, alias) in chartColors"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="[
+                            'myrtle-cactus-blue',
+                            'sunny-yellow',
+                            'petal-purple',
+                            'white-oak',
+                            'earthy-brown'
+                        ].includes(alias)"
+                        :hex="value"
+                        :show-border="['white', 'soft-blue'].includes(alias)"
+                        :style="{ backgroundColor: value }"
+                        :token="alias" />
+                    <p class="font-weight-semibold mb-0 mt-50">
+                        {{ chartColorNames[alias] || alias }}
+                    </p>
                 </b-col>
             </b-row>
         </div>
@@ -520,13 +554,32 @@ export default {
                 orange: 'ES Orange',
             },
             blues: prepareColors(sassBlues),
+            // defining chart colors here just for documentation purposes
+            // they should NOT be put into SASS and should NOT have bg-color utility classes
+            // TODO: move these into a set of JS const variables exported from es-vue-base?
+            chartColors: {
+                'myrtle-cactus-blue': '#3ea2bd',
+                'sunny-yellow': '#ffc021',
+                'petal-purple': '#ca77d1',
+                'leaf-green': '#4a9158',
+                'white-oak': '#d4b595',
+                'earthy-brown': '#9a6d51',
+            },
+            chartColorNames: {
+                'myrtle-cactus-blue': 'ES myrtle cactus blue',
+                'sunny-yellow': 'ES sunny yellow',
+                'petal-purple': 'ES petal purple',
+                'leaf-green': 'ES leaf green',
+                'white-oak': 'ES white oak',
+                'earthy-brown': 'ES earthy brown',
+            },
             coreColors: sassCoreColors,
             coreColorNames: {
-                white: 'ES White',
-                'soft-blue': 'ES Soft Blue',
-                'medium-blue': 'ES Medium Blue',
-                'dark-blue': 'ES Dark Blue',
-                'warm-orange': 'ES Warm Orange',
+                white: 'ES white',
+                'soft-blue': 'ES soft blue',
+                'medium-blue': 'ES medium blue',
+                'dark-blue': 'ES dark blue',
+                'warm-orange': 'ES warm orange',
             },
             errorColors: prepareColors(sassErrorColors),
             grays: sassGrays,


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added chart colors to Colors docs page for documentation and reference purposes, so the Shopping Experience team can reference now, and CED can reference later when doing charts
- Intentionally did not add them as SASS variables, as they should not be used as background colors or text colors; only in charts and data, which are generally specified in JS (but don't yet have a direct use case in the wild)
- Captured a potential TODO to move the color values into JS const variables in es-vue-base, though that might be our first instance of exporting JS const variables from es-vue-base so worth discussing later

<img width="1185" alt="Screen Shot 2024-06-17 at 4 35 21 PM" src="https://github.com/EnergySage/es-ds/assets/1350363/ae49a9d7-8e53-4086-9b9a-e9a8e06e6afe">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
