### PR TITLE
fix: increase viewbox length of es logo

### DIFF
--- a/es-design-system/components/ds-es-logo.vue
+++ b/es-design-system/components/ds-es-logo.vue
@@ -5,7 +5,7 @@
             height: height,
             width: width,
         }"
-        viewBox="0 0 205 45"
+        viewBox="0 0 215 45"
         fill="none"
         xmlns="http://www.w3.org/2000/svg">
         <!-- eslint-disable -->
@@ -34,7 +34,7 @@ export default {
          */
         width: {
             type: String,
-            default: '205px',
+            default: '215px',
             required: false,
         },
         /**


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[CED-1646: Design System: EnergySage logo gets clipped along right edge](https://energysage.atlassian.net/browse/CED-1646)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Increased viewbox of `ds-es-logo.vue` to allow SVG to scale without being clipped by bounding box
- I didn't see any CSS that set a specific width for the logo

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Tested navbar and footer locally at http://localhost:8500/organisms/es-nav-bar
- Logo looks fine at any page magnification

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- Are there any downsides to doing this?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
