### PR TITLE
feat: foundation and initial content for es-ds-docs site

### DIFF
--- a/es-bs-base/scss/_transitions.scss
+++ b/es-bs-base/scss/_transitions.scss
@@ -21,3 +21,36 @@
   overflow: hidden;
   @include transition.transition(variables.$transition-collapse);
 }
+
+/* es-collapse built on primevue panel */
+
+.es-collapse-toggler svg {
+  transition: transform .5s ease;
+}
+
+.es-collapse-toggler[aria-expanded="true"] svg {
+  transform: rotate(180deg);
+}
+
+.es-collapse-enter-active,
+.es-collapse-leave-active {
+  overflow: hidden;
+}
+
+.es-collapse-enter-active {
+  @include transition.transition(variables.$transition-collapse-primevue-expand);
+}
+
+.es-collapse-leave-active {
+  @include transition.transition(variables.$transition-collapse-primevue-collapse);
+}
+
+.es-collapse-enter-from,
+.es-collapse-leave-to {
+  max-height: 0;
+}
+
+.es-collapse-enter-to,
+.es-collapse-leave-from {
+  max-height: 1000px;
+}

--- a/es-bs-base/scss/_transitions.scss
+++ b/es-bs-base/scss/_transitions.scss
@@ -52,5 +52,5 @@
 
 .es-collapse-enter-to,
 .es-collapse-leave-from {
-  max-height: 1000px;
+  max-height: 3000px;
 }

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -656,7 +656,7 @@ $transition-collapse:         height .35s ease !default;
 
 // primevue collapse transition
 $transition-collapse-primevue-expand: max-height 1s ease-in-out !default;
-$transition-collapse-primevue-collapse: max-height .45s cubic-bezier(0, 1, 0, 1) !default;
+$transition-collapse-primevue-collapse: max-height .75s cubic-bezier(0, 1, 0, 1) !default;
 
 $embed-responsive-aspect-ratios: () !default;
 $embed-responsive-aspect-ratios: list.join(

--- a/es-bs-base/scss/_variables.scss
+++ b/es-bs-base/scss/_variables.scss
@@ -654,6 +654,10 @@ $transition-base:             all .2s ease-in-out !default;
 $transition-fade:             opacity .15s linear !default;
 $transition-collapse:         height .35s ease !default;
 
+// primevue collapse transition
+$transition-collapse-primevue-expand: max-height 1s ease-in-out !default;
+$transition-collapse-primevue-collapse: max-height .45s cubic-bezier(0, 1, 0, 1) !default;
+
 $embed-responsive-aspect-ratios: () !default;
 $embed-responsive-aspect-ratios: list.join(
   (

--- a/es-bs-base/scss/modules/blues.module.scss
+++ b/es-bs-base/scss/modules/blues.module.scss
@@ -1,0 +1,15 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  blue-50: variables.$blue-50;
+  blue-100: variables.$blue-100;
+  blue-200: variables.$blue-200;
+  blue-300: variables.$blue-300;
+  blue-400: variables.$blue-400;
+  blue-500: variables.$blue-500;
+  blue-600: variables.$blue-600;
+  blue-700: variables.$blue-700;
+  blue-800: variables.$blue-800;
+  blue-900: variables.$blue-900;
+}

--- a/es-bs-base/scss/modules/brand-colors.module.scss
+++ b/es-bs-base/scss/modules/brand-colors.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "../variables";
+
+:export {
+  cyan: variables.$cyan;
+  gray: variables.$gray;
+  pink: variables.$pink;
+  teal: variables.$teal;
+  yellow: variables.$yellow;
+  orange: variables.$orange;
+}

--- a/es-bs-base/scss/modules/core-colors.module.scss
+++ b/es-bs-base/scss/modules/core-colors.module.scss
@@ -1,0 +1,11 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "../variables";
+
+:export {
+  white: variables.$white;
+  soft-blue: variables.$soft-blue;
+  medium-blue: variables.$medium-blue;
+  dark-blue: variables.$dark-blue;
+  warm-orange: variables.$warm-orange;
+}

--- a/es-bs-base/scss/modules/cyans.module.scss
+++ b/es-bs-base/scss/modules/cyans.module.scss
@@ -1,0 +1,14 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "../variables";
+
+:export {
+  cyan-100: variables.$cyan-100;
+  cyan-200: variables.$cyan-200;
+  cyan-300: variables.$cyan-300;
+  cyan-400: variables.$cyan-400;
+  cyan-500: variables.$cyan-500;
+  cyan-600: variables.$cyan-600;
+  cyan-700: variables.$cyan-700;
+  cyan-800: variables.$cyan-800;
+}

--- a/es-bs-base/scss/modules/error-colors.module.scss
+++ b/es-bs-base/scss/modules/error-colors.module.scss
@@ -1,0 +1,8 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  error-50: variables.$error-50;
+  error-500: variables.$error-500;
+  error-900: variables.$error-900;
+}

--- a/es-bs-base/scss/modules/grays.module.scss
+++ b/es-bs-base/scss/modules/grays.module.scss
@@ -1,0 +1,20 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  white: variables.$white;
+  gray-100: variables.$gray-100;
+  gray-150: variables.$gray-150;
+  gray-200: variables.$gray-200;
+  gray-300: variables.$gray-300;
+  gray-400: variables.$gray-400;
+  gray-500: variables.$gray-500;
+  gray-600: variables.$gray-600;
+  gray-700: variables.$gray-700;
+  gray-800: variables.$gray-800;
+  gray-900: variables.$gray-900;
+  gray-1000: variables.$gray-1000;
+  gray-1100: variables.$gray-1100;
+  gray-1200: variables.$gray-1200;
+  black: variables.$black;
+}

--- a/es-bs-base/scss/modules/neutrals.module.scss
+++ b/es-bs-base/scss/modules/neutrals.module.scss
@@ -1,0 +1,15 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  gray-50: variables.$gray-50;
+  gray-100: variables.$gray-100;
+  gray-200: variables.$gray-200;
+  gray-300: variables.$gray-300;
+  gray-400: variables.$gray-400;
+  gray-500: variables.$gray-500;
+  gray-600: variables.$gray-600;
+  gray-700: variables.$gray-700;
+  gray-800: variables.$gray-800;
+  gray-900: variables.$gray-900;
+}

--- a/es-bs-base/scss/modules/oranges.module.scss
+++ b/es-bs-base/scss/modules/oranges.module.scss
@@ -1,0 +1,16 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "../variables";
+
+:export {
+  orange-50: variables.$orange-50;
+  orange-100: variables.$orange-100;
+  orange-200: variables.$orange-200;
+  orange-300: variables.$orange-300;
+  orange-400: variables.$orange-400;
+  orange-500: variables.$orange-500;
+  orange-600: variables.$orange-600;
+  orange-700: variables.$orange-700;
+  orange-800: variables.$orange-800;
+  orange-900: variables.$orange-900;
+}

--- a/es-bs-base/scss/modules/pinks.module.scss
+++ b/es-bs-base/scss/modules/pinks.module.scss
@@ -1,0 +1,13 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  pink-100: variables.$pink-100;
+  pink-200: variables.$pink-200;
+  pink-300: variables.$pink-300;
+  pink-400: variables.$pink-400;
+  pink-500: variables.$pink-500;
+  pink-600: variables.$pink-600;
+  pink-700: variables.$pink-700;
+  pink-800: variables.$pink-800;
+}

--- a/es-bs-base/scss/modules/success-colors.module.scss
+++ b/es-bs-base/scss/modules/success-colors.module.scss
@@ -1,0 +1,8 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  success-50: variables.$success-50;
+  success-500: variables.$success-500;
+  success-900: variables.$success-900;
+}

--- a/es-bs-base/scss/modules/teals.module.scss
+++ b/es-bs-base/scss/modules/teals.module.scss
@@ -1,0 +1,13 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  teal-100: variables.$teal-100;
+  teal-200: variables.$teal-200;
+  teal-300: variables.$teal-300;
+  teal-400: variables.$teal-400;
+  teal-500: variables.$teal-500;
+  teal-600: variables.$teal-600;
+  teal-700: variables.$teal-700;
+  teal-800: variables.$teal-800;
+}

--- a/es-bs-base/scss/modules/variants.module.scss
+++ b/es-bs-base/scss/modules/variants.module.scss
@@ -1,0 +1,13 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  primary: variables.$primary;
+  secondary: variables.$secondary;
+  success: variables.$success;
+  info: variables.$info;
+  warning: variables.$warning;
+  danger: variables.$danger;
+  light: variables.$light;
+  dark: variables.$dark;
+}

--- a/es-bs-base/scss/modules/warning-colors.module.scss
+++ b/es-bs-base/scss/modules/warning-colors.module.scss
@@ -1,0 +1,8 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  warning-50: variables.$warning-50;
+  warning-500: variables.$warning-500;
+  warning-900: variables.$warning-900;
+}

--- a/es-bs-base/scss/modules/yellows.module.scss
+++ b/es-bs-base/scss/modules/yellows.module.scss
@@ -1,0 +1,13 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  yellow-100: variables.$yellow-100;
+  yellow-200: variables.$yellow-200;
+  yellow-300: variables.$yellow-300;
+  yellow-400: variables.$yellow-400;
+  yellow-500: variables.$yellow-500;
+  yellow-600: variables.$yellow-600;
+  yellow-700: variables.$yellow-700;
+  yellow-800: variables.$yellow-800;
+}

--- a/es-ds-components/components/TestComponent.vue
+++ b/es-ds-components/components/TestComponent.vue
@@ -1,5 +1,0 @@
-<template>
-    <div>
-        This is a test component from es-ds-components
-    </div>
-</template>

--- a/es-ds-components/components/b-col.vue
+++ b/es-ds-components/components/b-col.vue
@@ -1,0 +1,25 @@
+<template>
+    <div
+        class="col"
+        :class="{
+            [`col-${cols}`]: cols,
+            [`col-sm-${sm}`]: sm,
+            [`col-md-${md}`]: md,
+            [`col-lg-${lg}`]: lg,
+            [`col-xl-${xl}`]: xl,
+            [`col-xxl-${xxl}`]: xxl,
+        }">
+        <slot />
+    </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  cols?: string,
+  sm?: string,
+  md?: string,
+  lg?: string,
+  xl?: string,
+  xxl?: string
+}>();
+</script>

--- a/es-ds-components/components/b-container.vue
+++ b/es-ds-components/components/b-container.vue
@@ -1,0 +1,5 @@
+<template>
+    <div class="container">
+        <slot />
+    </div>
+</template>

--- a/es-ds-components/components/b-row.vue
+++ b/es-ds-components/components/b-row.vue
@@ -1,0 +1,5 @@
+<template>
+    <div class="row">
+        <slot />
+    </div>
+</template>

--- a/es-ds-components/components/es-breadcrumbs.vue
+++ b/es-ds-components/components/es-breadcrumbs.vue
@@ -1,0 +1,60 @@
+<template>
+    <breadcrumb
+        :model="model"
+        :pt="{
+            menu: 'breadcrumb',
+            menuitem: 'breadcrumb-item'
+        }">
+        <template #item="{ item, props }">
+            <!--
+                primevue breadcrumb doesn't support an active non-link state out of the box,
+                so we have to implement it via this slot
+                https://v3.primevue.org/breadcrumb/#api.options.MenuItem
+            -->
+            <span v-if="item.active" aria-current="location" class="font-weight-bold">
+                {{ item.label }}
+            </span>
+            <!--
+                primevue breadcrumb doesn't support NuxtLink out of the box,
+                so we have to implement it via this slot
+                https://v3.primevue.org/breadcrumb/#router
+            -->
+            <nuxt-link v-else-if="item.to" :to="item.to">
+                {{ item.label }}
+            </nuxt-link>
+            <a v-else-if="item.url" :href="item.url" :target="item.target">
+                {{ item.label }}
+            </a>
+            <span v-else>
+                {{ item.label }}
+            </span>
+        </template>
+        <template #separator>
+            <span aria-hidden class="mx-50">/</span>
+        </template>
+    </breadcrumb>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+    items: {
+        type: Array,
+        required: true
+    }
+});
+
+const route = useRoute();
+const model = computed(() => {
+    if (!props.items) {
+        return [];
+    }
+
+    return props.items.map(item => ({
+        ...item,
+        // mark breadcrumb as active if manually set or if it matches this route
+        active: item.active || route.path === item.to || route.path === item.href,
+        label: item.text,
+        url: item.href
+    }));
+});
+</script>

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -1,0 +1,79 @@
+<template>
+    <panel
+        :collapsed="!expanded"
+        :pt="{
+            header: 'align-items-center d-flex justify-content-between position-relative py-100',
+            icons: 'h-100 position-absolute w-100',
+            root: border ? 'border-bottom border-top' : '',
+            toggler: {
+                class: 'es-collapse-toggler align-items-center btn btn-link d-flex h-100 inline justify-content-end rounded-0 p-0 position-absolute text-body w-100',
+            },
+            // https://vuejs.org/guide/built-ins/transition
+            transition: {
+                enterActiveClass: 'es-collapse-enter-active',
+                enterFromClass: 'es-collapse-enter-from',
+                enterToClass: 'es-collapse-enter-to',
+                leaveActiveClass: 'es-collapse-leave-active',
+                leaveFromClass: 'es-collapse-leave-from',
+                leaveToClass: 'es-collapse-leave-to'
+            },
+        }"
+        toggleable
+        @toggle="onClick">
+        <template #header>
+            <slot name="title" />
+        </template>
+        <template #togglericon>
+            <icon-chevron-down />
+        </template>
+        <slot />
+    </panel>
+</template>
+
+<script setup lang="ts">
+const emit = defineEmits(['toggled', 'userClick']);
+const model = defineModel();
+const props = defineProps({
+    border: {
+        type: Boolean,
+        default: true,
+    },
+    isProgrammaticUntilUserInput: {
+        type: Boolean,
+        default: true
+    },
+    visible: {
+        type: Boolean,
+        default: false
+    }
+});
+
+const userDeterminedState = ref(null);
+
+// directly determines the expanded/collapsed state of the panel
+const expanded = computed(() => {
+    // if we are meant to start ignoring the programmatic incoming state as soon as the
+    // user interacts with the collapse, and if the user has interacted with the collapse,
+    // use the value from the user's interaction
+    if (props.isProgrammaticUntilUserInput && userDeterminedState.value !== null) {
+        return userDeterminedState.value;
+    }
+
+    // otherwise, use the one-way visible prop or the two-way v-model value
+    return props.visible || model.value;
+});
+
+const onClick = ({ value }) => {
+    // save the state toggled by the user
+    // convert from "collapsed" semantics internal to the primevue panel
+    // to the "expanded" semantics exposed by this component
+    userDeterminedState.value = !value;
+
+    // inform the v-model (if any) that the state has changed
+    model.value = !value;
+
+    // emit events indicating the state has changed
+    emit('toggled', !value);
+    emit('userClick', !value);
+};
+</script>

--- a/es-ds-components/components/icon-chevron-down.vue
+++ b/es-ds-components/components/icon-chevron-down.vue
@@ -1,0 +1,39 @@
+<template>
+    <svg
+        :style="{
+            height: height,
+            width: width,
+        }"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor">
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M3.293 8.293a1 1 0 0 1 1.414 0L12 15.586l7.293-7.293a1 1 0 1 1 1.414 1.414l-8 8a1 1 0 0 1-1.414 0l-8-8a1 1 0 0 1 0-1.414Z" />
+    </svg>
+</template>
+
+<script>
+export default {
+    name: 'IconChevronDown',
+    props: {
+        /**
+         * Width
+         */
+        width: {
+            type: String,
+            default: '24px',
+            required: false,
+        },
+        /**
+         * Height
+         */
+        height: {
+            type: String,
+            default: '24px',
+            required: false,
+        },
+    },
+};
+</script>

--- a/es-ds-components/components/icon-chevron-right.vue
+++ b/es-ds-components/components/icon-chevron-right.vue
@@ -1,0 +1,39 @@
+<template>
+    <svg
+        :style="{
+            height: height,
+            width: width,
+        }"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor">
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M7.293 3.293a1 1 0 0 1 1.414 0l8 8a1 1 0 0 1 0 1.414l-8 8a1 1 0 0 1-1.414-1.414L14.586 12 7.293 4.707a1 1 0 0 1 0-1.414Z" />
+    </svg>
+</template>
+
+<script>
+export default {
+    name: 'IconChevronRight',
+    props: {
+        /**
+         * Width
+         */
+        width: {
+            type: String,
+            default: '24px',
+            required: false,
+        },
+        /**
+         * Height
+         */
+        height: {
+            type: String,
+            default: '24px',
+            required: false,
+        },
+    },
+};
+</script>

--- a/es-ds-docs/app.vue
+++ b/es-ds-docs/app.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-    hello world
-    <test-component />
-  </div>
+  <nuxt-layout>
+    <nuxt-page />
+  </nuxt-layout>
 </template>

--- a/es-ds-docs/components/ds-atoms-list.vue
+++ b/es-ds-docs/components/ds-atoms-list.vue
@@ -1,0 +1,34 @@
+<template>
+    <ul class="list-unstyled pl-100">
+        <li>
+            <ds-link to="/atoms/color">
+                Color
+            </ds-link>
+        </li>
+        <li>
+            <ds-link to="/atoms/corners">
+                Corners
+            </ds-link>
+        </li>
+        <li>
+            <ds-link to="/atoms/icons">
+                Icons
+            </ds-link>
+        </li>
+        <li>
+            <ds-link to="/atoms/layout">
+                Layout
+            </ds-link>
+        </li>
+        <li>
+            <ds-link to="/atoms/spacing">
+                Spacing
+            </ds-link>
+        </li>
+        <li>
+            <ds-link to="/atoms/typography">
+                Typography
+            </ds-link>
+        </li>
+    </ul>
+</template>

--- a/es-ds-docs/components/ds-code-block.vue
+++ b/es-ds-docs/components/ds-code-block.vue
@@ -1,0 +1,35 @@
+<template>
+    <!-- eslint-disable vue/no-v-html -->
+    <div class="prism">
+        <pre
+            class="line-numbers"
+            :class="`language-${lang}`"
+            ><code
+                class="match-braces"
+                :data-source="source"
+                v-html="code" />
+        </pre>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'CodeBlock',
+    props: {
+        lang: {
+            type: String,
+            default: 'javascript',
+        },
+        code: {
+            type: String,
+            required: false,
+            default: '',
+        },
+        source: {
+            type: String,
+            required: false,
+            default: '',
+        },
+    },
+};
+</script>

--- a/es-ds-docs/components/ds-color-swatch.vue
+++ b/es-ds-docs/components/ds-color-swatch.vue
@@ -1,0 +1,42 @@
+<template>
+    <div
+        class="font-size-75 px-50 py-200 rounded text-center"
+        :class="{
+            [`bg-${token}`]: true,
+            'border': showBorder,
+            'text-white': !isLight,
+            'text-dark': isLight
+        }">
+        <p class="mb-50">
+            {{ uppercaseHex }}
+        </p>
+        <p class="m-0">
+            {{ token }}
+        </p>
+    </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+    hex: {
+        type: String,
+        required: true,
+    },
+    isLight: {
+        type: Boolean,
+        default: false,
+    },
+    showBorder: {
+        type: Boolean,
+        default: false,
+    },
+    token: {
+        type: String,
+        required: true,
+    },
+});
+
+const uppercaseHex = computed(() => {
+    return props.hex.toUpperCase();
+});
+</script>

--- a/es-ds-docs/components/ds-doc-source.vue
+++ b/es-ds-docs/components/ds-doc-source.vue
@@ -1,0 +1,59 @@
+<template>
+    <div class="mt-500">
+        <client-only>
+            <es-collapse
+                v-if="compCode"
+                id="compsource">
+                <template #title>
+                    <h2 class="mb-0">
+                        Component source
+                    </h2>
+                </template>
+                <ds-code-block
+                    :code="compCode"
+                    :source="compSource" />
+            </es-collapse>
+            <es-collapse
+                v-if="docCode"
+                id="docsource"
+                class="mt-500">
+                <template #title>
+                    <h2 class="mb-0">
+                        Documentation source
+                    </h2>
+                </template>
+                <ds-code-block
+                    :code="docCode"
+                    :source="docSource" />
+            </es-collapse>
+        </client-only>
+    </div>
+</template>
+<script>
+
+export default {
+    name: 'DsDocSource',
+    props: {
+        compCode: {
+            type: String,
+            default: '',
+            required: false,
+        },
+        compSource: {
+            type: String,
+            default: '',
+            required: false,
+        },
+        docCode: {
+            type: String,
+            default: '',
+            required: false,
+        },
+        docSource: {
+            type: String,
+            default: '',
+            required: false,
+        },
+    },
+};
+</script>

--- a/es-ds-docs/components/ds-link-list.vue
+++ b/es-ds-docs/components/ds-link-list.vue
@@ -1,0 +1,26 @@
+<template>
+    <ul class="ds-link-list list-unstyled">
+        <li>
+            <div class="h4">
+                <ds-link to="/">
+                    Home
+                </ds-link>
+            </div>
+        </li>
+        <li>
+            <div class="h4">
+                <ds-link to="/atoms">
+                    Atoms
+                </ds-link>
+            </div>
+            <ds-atoms-list class="mb-100" />
+        </li>
+        <li>
+            <div class="h4">
+                <ds-link to="/molecules">
+                    Molecules
+                </ds-link>
+            </div>
+        </li>
+    </ul>
+</template>

--- a/es-ds-docs/components/ds-link-list.vue
+++ b/es-ds-docs/components/ds-link-list.vue
@@ -21,6 +21,7 @@
                     Molecules
                 </ds-link>
             </div>
+            <ds-molecules-list class="mb-100" />
         </li>
     </ul>
 </template>

--- a/es-ds-docs/components/ds-link.vue
+++ b/es-ds-docs/components/ds-link.vue
@@ -1,0 +1,39 @@
+<template>
+    <component
+        :is="isCurrentPage ? 'div' : NuxtLink"
+        class="d-inline-block font-weight-semibold position-relative"
+        :to="to">
+        <icon-chevron-right
+            v-if="isCurrentPage"
+            class="ds-link-icon position-absolute"
+            height="0.75rem"
+            width="0.75rem" />
+        <slot />
+    </component>
+</template>
+
+<script setup lang="ts">
+// specific workaround for getting a reference to an auto-imported but not globally registered
+// component like NuxtLink, so that it can be used in a <component :is=""> context.
+// this resolves to an import statement, according to:
+// https://github.com/nuxt/nuxt/issues/13659#issuecomment-1573568006
+const NuxtLink = resolveComponent('NuxtLink');
+
+const props = defineProps<{
+  to: string
+}>();
+
+const route = useRoute();
+
+const isCurrentPage = computed(() => {
+    return route.path === props.to;
+});
+</script>
+
+<style lang="scss" scoped>
+.ds-link-icon {
+    left: -1rem;
+    top: 50%;
+    transform: translateY(-45%);
+}
+</style>

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -1,0 +1,9 @@
+<template>
+    <ul class="list-unstyled pl-100">
+        <li>
+            <ds-link to="/molecules/collapse">
+                Collapse
+            </ds-link>
+        </li>
+    </ul>
+</template>

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -1,6 +1,11 @@
 <template>
     <ul class="list-unstyled pl-100">
         <li>
+            <ds-link to="/molecules/breadcrumbs">
+                Breadcrumbs
+            </ds-link>
+        </li>
+        <li>
             <ds-link to="/molecules/collapse">
                 Collapse
             </ds-link>

--- a/es-ds-docs/components/ds-prop-table.vue
+++ b/es-ds-docs/components/ds-prop-table.vue
@@ -1,0 +1,47 @@
+<template>
+    <ds-responsive-table>
+        <ds-responsive-table-row
+            v-for="row in rows"
+            :key="row[0]">
+            <ds-responsive-table-column
+                v-for="(column, columnIndex) in columns"
+                :key="column"
+                :md="widths.md[columnIndex]"
+                :lg="widths.lg && widths.lg[columnIndex] || null">
+                <template #name>
+                    {{ column }}
+                </template>
+                <template #value>
+                    <code v-if="columnIndex < 2 && row[columnIndex] !== 'n/a'">
+                        {{ row[columnIndex] }}
+                    </code>
+                    <span v-else>
+                        {{ row[columnIndex] }}
+                    </span>
+                </template>
+            </ds-responsive-table-column>
+        </ds-responsive-table-row>
+    </ds-responsive-table>
+</template>
+
+<script lang="js">
+export default {
+    name: 'DsPropTable',
+    props: {
+        columns: {
+            type: Array,
+            default: () => ['Name', 'Default', 'Description'],
+        },
+        rows: {
+            type: Array,
+            required: true,
+        },
+        widths: {
+            type: Object,
+            default: () => ({
+                md: ['3', '3', '6'],
+            }),
+        },
+    },
+};
+</script>

--- a/es-ds-docs/components/ds-responsive-table-column.vue
+++ b/es-ds-docs/components/ds-responsive-table-column.vue
@@ -1,0 +1,129 @@
+<template>
+    <dl :class="columnClass">
+        <dt>
+            <slot name="name" />
+        </dt>
+        <dd>
+            <slot name="value" />
+        </dd>
+    </dl>
+</template>
+
+<script lang="js">
+export default {
+    name: 'DsResponsiveTableColumn',
+    props: {
+        md: {
+            type: String,
+            default: '4',
+        },
+        lg: {
+            type: String,
+            default: '',
+        },
+        xl: {
+            type: String,
+            default: '',
+        },
+        xxl: {
+            type: String,
+            default: '',
+        },
+    },
+    computed: {
+        columnClass() {
+            const classes = [
+                'responsive-table-column',
+                'col',
+                `col-md-${this.md}`,
+            ];
+
+            if (this.lg) {
+                classes.push(`col-lg-${this.lg}`);
+            }
+
+            if (this.xl) {
+                classes.push(`col-xl-${this.xl}`);
+            }
+
+            if (this.xxl) {
+                classes.push(`col-xxl-${this.xxl}`);
+            }
+
+            return classes.join(' ');
+        },
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+@use "@energysage/es-bs-base/scss/mixins/breakpoints" as breakpoints;
+
+.responsive-table-column {
+    display: flex;
+    margin: 0;
+    /* override the padding of the various col classes */
+    padding: 0 !important;
+
+    dt {
+        margin-bottom: 0.5rem;
+        width: 30%;
+    }
+
+    dd {
+        margin-bottom: 0.5rem;
+        width: 70%;
+    }
+}
+
+@include breakpoints.media-breakpoint-up(sm) {
+    .responsive-table-column {
+        dt {
+            width: 24%;
+        }
+
+        dd {
+            width: 76%;
+        }
+    }
+}
+
+@include breakpoints.media-breakpoint-up(md) {
+    .responsive-table-column {
+        /* undo mobile styles */
+        display: block;
+        margin: 0;
+        padding: 0;
+
+        dt,
+        dd {
+            margin: 0;
+            padding: 0;
+            width: auto;
+        }
+
+        /* ensure background is full height of row */
+        dd {
+            height: 100%;
+            padding-bottom: 0.5rem;
+            padding-top: 0.5rem;
+        }
+
+        /* side padding on left-most cells */
+        &:first-child {
+            dd,
+            dt {
+                padding-left: 0.5rem;
+            }
+        }
+
+        /* side padding on right-most cells */
+        &:last-child {
+            dd,
+            dt {
+                padding-right: 0.5rem;
+            }
+        }
+    }
+}
+</style>

--- a/es-ds-docs/components/ds-responsive-table-row.vue
+++ b/es-ds-docs/components/ds-responsive-table-row.vue
@@ -33,8 +33,8 @@ export default {
     border-bottom: variables.$border-width solid variables.$border-color;
     padding: 0.5rem 0.5rem 0;
 
-    &.vertically-center-content ::v-deep dd,
-    &.vertically-center-content ::v-deep dt {
+    &.vertically-center-content :deep(dd),
+    &.vertically-center-content :deep(dt) {
         align-items: center;
         display: flex;
     }
@@ -60,19 +60,19 @@ export default {
         }
 
         &:first-child {
-            ::v-deep dl {
+            :deep(dl) {
                 display: flex;
                 flex-flow: column;
             }
 
-            ::v-deep dt {
+            :deep(dt) {
                 border-bottom: variables.$border-width solid variables.$border-color;
                 border-top: variables.$border-width solid variables.$border-color;
                 padding-bottom: 0.5rem;
                 padding-top: 0.5rem;
             }
 
-            ::v-deep dd {
+            :deep(dd) {
                 flex-grow: 1;
                 height: auto;
             }
@@ -80,7 +80,7 @@ export default {
 
         /* visually hide table columns within all rows except the first */
         &:not(:first-child) {
-            ::v-deep dt {
+            :deep(dt) {
                 /* don't use display none because then screen readers won't read out the label */
                 left: -9999em;
                 position: absolute;
@@ -89,13 +89,13 @@ export default {
 
         /* zebra-stripe every odd row, if enabled */
         &.zebra:nth-child(odd) {
-            ::v-deep dd {
+            :deep(dd) {
                 background-color: variables.$gray-50;
             }
         }
 
         /* if zebra striping disabled, add a border below each row */
-        &:not(.zebra):not(:last-child) ::v-deep .responsive-table-column {
+        &:not(.zebra):not(:last-child) :deep(.responsive-table-column) {
             border-bottom: variables.$border-width solid variables.$border-color;
         }
     }

--- a/es-ds-docs/components/ds-responsive-table-row.vue
+++ b/es-ds-docs/components/ds-responsive-table-row.vue
@@ -1,0 +1,104 @@
+<template>
+    <div
+        class="responsive-table-row"
+        :class="{
+            'vertically-center-content': verticallyCenterContent,
+            'zebra': zebraStripes
+        }">
+        <slot />
+    </div>
+</template>
+
+<script lang="js">
+export default {
+    name: 'DsResponsiveTableRow',
+    props: {
+        verticallyCenterContent: {
+            type: Boolean,
+            default: false,
+        },
+        zebraStripes: {
+            type: Boolean,
+            default: false,
+        },
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+@use "@energysage/es-bs-base/scss/variables" as variables;
+@use "@energysage/es-bs-base/scss/mixins/breakpoints" as breakpoints;
+
+.responsive-table-row {
+    border-bottom: variables.$border-width solid variables.$border-color;
+    padding: 0.5rem 0.5rem 0;
+
+    &.vertically-center-content ::v-deep dd,
+    &.vertically-center-content ::v-deep dt {
+        align-items: center;
+        display: flex;
+    }
+
+    &.zebra:nth-child(even) {
+        background-color: variables.$gray-50;
+    }
+
+    &:last-child {
+        border-bottom-style: none;
+    }
+}
+
+@include breakpoints.media-breakpoint-up(md) {
+    .responsive-table-row {
+        /* undo mobile styles */
+        border-bottom-style: none;
+        display: flex;
+        padding: 0;
+
+        &.zebra:nth-child(even) {
+            background-color: transparent;
+        }
+
+        &:first-child {
+            ::v-deep dl {
+                display: flex;
+                flex-flow: column;
+            }
+
+            ::v-deep dt {
+                border-bottom: variables.$border-width solid variables.$border-color;
+                border-top: variables.$border-width solid variables.$border-color;
+                padding-bottom: 0.5rem;
+                padding-top: 0.5rem;
+            }
+
+            ::v-deep dd {
+                flex-grow: 1;
+                height: auto;
+            }
+        }
+
+        /* visually hide table columns within all rows except the first */
+        &:not(:first-child) {
+            ::v-deep dt {
+                /* don't use display none because then screen readers won't read out the label */
+                left: -9999em;
+                position: absolute;
+            }
+        }
+
+        /* zebra-stripe every odd row, if enabled */
+        &.zebra:nth-child(odd) {
+            ::v-deep dd {
+                background-color: variables.$gray-50;
+            }
+        }
+
+        /* if zebra striping disabled, add a border below each row */
+        &:not(.zebra):not(:last-child) ::v-deep .responsive-table-column {
+            border-bottom: variables.$border-width solid variables.$border-color;
+        }
+    }
+}
+
+</style>

--- a/es-ds-docs/components/ds-responsive-table.vue
+++ b/es-ds-docs/components/ds-responsive-table.vue
@@ -1,0 +1,27 @@
+<template>
+    <div class="responsive-table">
+        <slot />
+    </div>
+</template>
+
+<script lang="js">
+export default {
+    name: 'DsResponsiveTable',
+};
+</script>
+
+<style lang="scss" scoped>
+@use "@energysage/es-bs-base/scss/variables" as variables;
+@use "@energysage/es-bs-base/scss/mixins/breakpoints" as breakpoints;
+
+.responsive-table {
+    border-top: variables.$border-width solid variables.$border-color;
+}
+
+@include breakpoints.media-breakpoint-up(md) {
+    .responsive-table {
+        /* undo mobile styles */
+        border-top-style: none;
+    }
+}
+</style>

--- a/es-ds-docs/layouts/default.vue
+++ b/es-ds-docs/layouts/default.vue
@@ -1,0 +1,23 @@
+<template>
+    <div>
+        <div class="d-flex justify-content-center">
+            <div class="ds-side-nav d-none d-xl-block flex-shrink-0 p-100">
+                <ds-link-list />
+            </div>
+            <b-container class="pt-xl-100 mx-0">
+                <b-row class="mb-100">
+                    <b-col cols="12">
+                        breadcrumbs
+                        <!--<es-breadcrumbs :items="breadcrumbs" />-->
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        cols="12">
+                        <slot />
+                    </b-col>
+                </b-row>
+            </b-container>
+        </div>
+    </div>
+</template>

--- a/es-ds-docs/layouts/default.vue
+++ b/es-ds-docs/layouts/default.vue
@@ -13,6 +13,7 @@
                 </b-row>
                 <b-row>
                     <b-col
+                        class="mb-300"
                         cols="12">
                         <slot />
                     </b-col>

--- a/es-ds-docs/layouts/default.vue
+++ b/es-ds-docs/layouts/default.vue
@@ -7,8 +7,7 @@
             <b-container class="pt-xl-100 mx-0">
                 <b-row class="mb-100">
                     <b-col cols="12">
-                        breadcrumbs
-                        <!--<es-breadcrumbs :items="breadcrumbs" />-->
+                        <es-breadcrumbs :items="breadcrumbs" />
                     </b-col>
                 </b-row>
                 <b-row>
@@ -22,3 +21,28 @@
         </div>
     </div>
 </template>
+
+<script setup>
+const route = useRoute();
+
+const breadcrumbs = computed(() => {
+    let pathSoFar = '';
+    const paths = route.path.split('/');
+
+    // Set removes dupes from path
+    return [...new Set(paths)].map((path) => {
+        pathSoFar += path ? `/${path}` : '';
+
+        let text = 'Home';
+        // Convert to CamelCase to be in line with component naming
+        if (path) {
+            text = path.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+            text = text[0].toUpperCase() + text.slice(1);
+        }
+        return {
+            text,
+            to: pathSoFar || '/',
+        };
+    });
+});
+</script>

--- a/es-ds-docs/nuxt.config.ts
+++ b/es-ds-docs/nuxt.config.ts
@@ -27,11 +27,15 @@ export default defineNuxtConfig({
         },
     },
 
-
     modules: [
         // https://google-fonts.nuxtjs.org/getting-started/setup
         "@nuxtjs/google-fonts"
     ],
+
+    sourcemap: {
+        server: true,
+        client: true
+    },
 
     // https://nuxt.com/docs/getting-started/deployment#static-hosting
     ssr: true

--- a/es-ds-docs/nuxt.config.ts
+++ b/es-ds-docs/nuxt.config.ts
@@ -29,8 +29,16 @@ export default defineNuxtConfig({
 
     modules: [
         // https://google-fonts.nuxtjs.org/getting-started/setup
-        "@nuxtjs/google-fonts"
+        '@nuxtjs/google-fonts',
+        // https://v3.primevue.org/nuxt
+        'nuxt-primevue'
     ],
+
+    primevue: {
+        options: {
+            unstyled: true
+        }
+    },
 
     sourcemap: {
         server: true,

--- a/es-ds-docs/package-lock.json
+++ b/es-ds-docs/package-lock.json
@@ -10,8 +10,10 @@
         "@energysage/es-bs-base": "^2.0.4",
         "@energysage/es-ds-components": "^0.0.1",
         "@nuxtjs/google-fonts": "^3.2.0",
+        "clipboard": "^2.0.11",
         "nuxt": "^3.12.4",
         "primevue": "^3.53.0",
+        "prismjs": "^1.29.0",
         "vue": "^3.4.34"
       },
       "devDependencies": {
@@ -3548,6 +3550,16 @@
         "node": "*"
       }
     },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "node_modules/clipboardy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
@@ -4185,6 +4197,11 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -5380,6 +5397,14 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dependencies": {
+        "delegate": "^3.1.2"
+      }
     },
     "node_modules/google-fonts-helper": {
       "version": "3.6.0",
@@ -8315,6 +8340,14 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8869,6 +8902,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="
+    },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -9669,6 +9707,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/es-ds-docs/package-lock.json
+++ b/es-ds-docs/package-lock.json
@@ -11,9 +11,11 @@
         "@energysage/es-ds-components": "^0.0.1",
         "@nuxtjs/google-fonts": "^3.2.0",
         "nuxt": "^3.12.4",
+        "primevue": "^3.53.0",
         "vue": "^3.4.34"
       },
       "devDependencies": {
+        "nuxt-primevue": "^3.0.0",
         "sass": "^1.77.8"
       }
     },
@@ -7355,6 +7357,17 @@
         }
       }
     },
+    "node_modules/nuxt-primevue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nuxt-primevue/-/nuxt-primevue-3.0.0.tgz",
+      "integrity": "sha512-MC3ubLTF0hzUEsQ2gYzzlzaW1gXN9/wrpbWnS9xwK47TWw1gcfim8idu5mcOx+l66CPAtTLOR1QJahkDc4m9XA==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/kit": "^3.7.3",
+        "pathe": "^1.1.2",
+        "primevue": "^3.51.0"
+      }
+    },
     "node_modules/nypm": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.3.9.tgz",
@@ -8292,6 +8305,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/primevue": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.53.0.tgz",
+      "integrity": "sha512-mRqTPGGZX+3AQokaCCjxLVSNEjGEA7LaPdBT4qSpGEdMstK6vhUBCxgLH7IPjHudbaSi4Xo3CIO62pXQxbz8dQ==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/process": {

--- a/es-ds-docs/package.json
+++ b/es-ds-docs/package.json
@@ -13,8 +13,10 @@
     "@energysage/es-bs-base": "^2.0.4",
     "@energysage/es-ds-components": "^0.0.1",
     "@nuxtjs/google-fonts": "^3.2.0",
+    "clipboard": "^2.0.11",
     "nuxt": "^3.12.4",
     "primevue": "^3.53.0",
+    "prismjs": "^1.29.0",
     "vue": "^3.4.34"
   },
   "devDependencies": {

--- a/es-ds-docs/package.json
+++ b/es-ds-docs/package.json
@@ -14,9 +14,11 @@
     "@energysage/es-ds-components": "^0.0.1",
     "@nuxtjs/google-fonts": "^3.2.0",
     "nuxt": "^3.12.4",
+    "primevue": "^3.53.0",
     "vue": "^3.4.34"
   },
   "devDependencies": {
+    "nuxt-primevue": "^3.0.0",
     "sass": "^1.77.8"
   }
 }

--- a/es-ds-docs/pages/atoms/color.vue
+++ b/es-ds-docs/pages/atoms/color.vue
@@ -220,19 +220,12 @@
             </b-row>
         </div>
 
-        <!-- TODO: replace with real Collapse component -->
-        <h2>
-            Legacy color names
-        </h2>
-        <!--<es-collapse
-            id="legacy-collapse"
-            v-model="legacyCollapseVisible"
-            :is-programmatic-until-user-input="false">
+        <es-collapse>
             <template #title>
                 <h2 class="mb-0">
                     Legacy color names
                 </h2>
-            </template>-->
+            </template>
             <p>
                 These legacy color names have all been updated to pull from the new brand colors above.
                 Care was taken to match the old colors to the closest new color available, but you may still find
@@ -518,7 +511,7 @@
                     </b-col>
                 </b-row>
             </div>
-        <!--</es-collapse>-->
+        </es-collapse>
     </div>
 </template>
 
@@ -610,8 +603,6 @@ const tealShades = slice(sassTeals, ['teal-600', 'teal-700', 'teal-800']);
 const tealTints = slice(sassTeals, ['teal-400', 'teal-300', 'teal-200', 'teal-100']);
 const yellowShades = slice(sassYellows, ['yellow-600', 'yellow-700', 'yellow-800']);
 const yellowTints = slice(sassYellows, ['yellow-400', 'yellow-300', 'yellow-200', 'yellow-100']);
-
-const legacyCollapseVisible = ref(false);
 
 /*export default {
     name: 'AtomsColor',

--- a/es-ds-docs/pages/atoms/color.vue
+++ b/es-ds-docs/pages/atoms/color.vue
@@ -32,6 +32,7 @@
                             'white', 'soft-blue', 'medium-blue', 'warm-orange'
                         ].includes(alias)"
                         :hex="value"
+                        :show-border="['white'].includes(alias)"
                         :token="alias" />
                     <p class="font-weight-semibold mb-0 mt-50">
                         {{ coreColorNames[alias] || alias }}

--- a/es-ds-docs/pages/atoms/color.vue
+++ b/es-ds-docs/pages/atoms/color.vue
@@ -557,7 +557,7 @@ const brandColorNames = {
 const blues = prepareColors(sassBlues);
 // defining chart colors here just for documentation purposes
 // they should NOT be put into SASS and should NOT have bg-color utility classes
-// TODO: move these into a set of JS const variables exported from es-vue-base?
+// TODO: move these into a set of JS const variables exported from es-ds-components?
 const chartColors = {
     'myrtle-cactus-blue': '#3ea2bd',
     'sunny-yellow': '#ffc021',

--- a/es-ds-docs/pages/atoms/color.vue
+++ b/es-ds-docs/pages/atoms/color.vue
@@ -1,0 +1,719 @@
+<template>
+    <div>
+        <h1>
+            Colors
+        </h1>
+        <p>
+            Below you will find our named color definitions. They are meant to convey the meaning of the color
+            using a defined naming convention. When working, please use these color definitions and try to avoid
+            introducing new unamed colors.
+        </p>
+        <p>
+            All colors (except restricted colors) have CSS utility classes associated with them.
+            <code>text-{COLOR_NAME}</code> for text color and <code>bg-{COLOR_NAME}</code>
+            for background color.
+        </p>
+
+        <div class="my-500">
+            <h2>
+                Core colors
+            </h2>
+            <b-row>
+                <b-col
+                    v-for="(value, alias) in coreColors"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="[
+                            'white', 'soft-blue', 'medium-blue', 'warm-orange'
+                        ].includes(alias)"
+                        :hex="value"
+                        :token="alias" />
+                    <p class="font-weight-semibold mb-0 mt-50">
+                        {{ coreColorNames[alias] || alias }}
+                    </p>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Primary
+            </h2>
+            <b-row>
+                <b-col
+                    v-for="[alias, value] in blues"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="[
+                            'blue-50', 'blue-100', 'blue-200', 'blue-300', 'blue-400'
+                        ].includes(alias)"
+                        :hex="value"
+                        :show-border="['blue-50', 'blue-100'].includes(alias)"
+                        :token="alias" />
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Secondary
+            </h2>
+            <b-row>
+                <b-col
+                    v-for="[alias, value] in oranges"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="true"
+                        :hex="value"
+                        :show-border="['orange-50', 'orange-100'].includes(alias)"
+                        :token="alias" />
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Neutrals
+            </h2>
+            <b-row>
+                <b-col
+                    v-for="[alias, value] in neutrals"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="[
+                            'gray-50', 'gray-100', 'gray-200', 'gray-300', 'gray-400', 'gray-500'
+                        ].includes(alias)"
+                        :hex="value"
+                        :show-border="['gray-50', 'gray-100'].includes(alias)"
+                        :token="alias" />
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Feedback
+            </h2>
+
+            <b-row class="mt-200">
+                <b-col lg="6">
+                    <h3>
+                        Success
+                    </h3>
+                    <b-row>
+                        <b-col
+                            v-for="[alias, value] in successColors"
+                            :key="alias"
+                            cols="6"
+                            sm="4"
+                            md="3"
+                            lg="4"
+                            class="mb-100 text-center">
+                            <ds-color-swatch
+                                :is-light="true"
+                                :hex="value"
+                                :show-border="['success-50'].includes(alias)"
+                                :token="alias" />
+                        </b-col>
+                    </b-row>
+                </b-col>
+
+                <b-col lg="6">
+                    <h3>
+                        Warning
+                    </h3>
+                    <b-row>
+                        <b-col
+                            v-for="[alias, value] in warningColors"
+                            :key="alias"
+                            cols="6"
+                            sm="4"
+                            md="3"
+                            lg="4"
+                            class="mb-100 text-center">
+                            <ds-color-swatch
+                                :is-light="true"
+                                :hex="value"
+                                :show-border="['warning-50'].includes(alias)"
+                                :token="alias" />
+                        </b-col>
+                    </b-row>
+                </b-col>
+
+                <b-col lg="6">
+                    <h3>
+                        Error
+                    </h3>
+                    <b-row>
+                        <b-col
+                            v-for="[alias, value] in errorColors"
+                            :key="alias"
+                            cols="6"
+                            sm="4"
+                            md="3"
+                            lg="4"
+                            class="mb-100 text-center">
+                            <ds-color-swatch
+                                :is-light="true"
+                                :hex="value"
+                                :show-border="['error-50'].includes(alias)"
+                                :token="alias" />
+                        </b-col>
+                    </b-row>
+                </b-col>
+            </b-row>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Restricted colors
+            </h2>
+            <p>
+                Use only for charts and data.
+            </p>
+            <b-row>
+                <b-col
+                    v-for="(value, alias) in chartColors"
+                    :key="alias"
+                    cols="6"
+                    sm="4"
+                    md="3"
+                    lg="2"
+                    class="mb-100 text-center">
+                    <ds-color-swatch
+                        :is-light="[
+                            'myrtle-cactus-blue',
+                            'sunny-yellow',
+                            'petal-purple',
+                            'white-oak',
+                            'earthy-brown'
+                        ].includes(alias)"
+                        :hex="value"
+                        :show-border="['white', 'soft-blue'].includes(alias)"
+                        :style="{ backgroundColor: value }"
+                        :token="alias" />
+                    <p class="font-weight-semibold mb-0 mt-50">
+                        {{ chartColorNames[alias] || alias }}
+                    </p>
+                </b-col>
+            </b-row>
+        </div>
+
+        <!-- TODO: replace with real Collapse component -->
+        <h2>
+            Legacy color names
+        </h2>
+        <!--<es-collapse
+            id="legacy-collapse"
+            v-model="legacyCollapseVisible"
+            :is-programmatic-until-user-input="false">
+            <template #title>
+                <h2 class="mb-0">
+                    Legacy color names
+                </h2>
+            </template>-->
+            <p>
+                These legacy color names have all been updated to pull from the new brand colors above.
+                Care was taken to match the old colors to the closest new color available, but you may still find
+                differences when upgrading to the new visual identity.
+            </p>
+            <p>
+                Please be sure to check all screens
+                and pages of your app and make adjustments as necessary, paying close attention to whether text
+                color is still accessible against the new background color using the
+                <a
+                    href="https://webaim.org/resources/contrastchecker/"
+                    target="_blank">
+                    WebAIM color contrast checker
+                </a>.
+            </p>
+
+            <div class="my-200">
+                <h3>
+                    Brand Colors
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in brandColors"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-100 text-center">
+                        <ds-color-swatch
+                            :is-light="['teal', 'yellow', 'pink', 'orange'].includes(alias)"
+                            :hex="value"
+                            :token="alias" />
+                        <p class="font-weight-semibold mb-0 mt-50">
+                            {{ brandColorNames[alias] || alias }}
+                        </p>
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Primary Tints
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in cyanTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :is-light="['cyan-100', 'cyan-200', 'cyan-300'].includes(alias)"
+                            :hex="value"
+                            :show-border="['cyan-100'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row class="mb-200">
+                    <b-col
+                        v-for="(value, alias) in grayTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :is-light="['gray-500'].includes(alias)"
+                            :hex="value"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Secondary Tints
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in pinkTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            is-light
+                            :hex="value"
+                            :show-border="['pink-100'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in tealTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            is-light
+                            :hex="value"
+                            :show-border="['teal-100'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in yellowTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            is-light
+                            :hex="value"
+                            :show-border="['yellow-100'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in orangeTints"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            is-light
+                            :hex="value"
+                            :show-border="['orange-100'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Primary Shades
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in cyanShades"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row class="mb-200">
+                    <b-col
+                        v-for="(value, alias) in grayShades"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Secondary Shades
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in pinkShades"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :is-light="true"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in tealShades"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in yellowShades"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :is-light="true"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Grayscale
+                </h3>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in grays"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :is-light="[
+                                'white', 'gray-100', 'gray-150', 'gray-200', 'gray-300', 'gray-400', 'gray-500'
+                            ].includes(alias)"
+                            :show-border="['white', 'gray-100', 'gray-150'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+
+            <div class="my-200">
+                <h3>
+                    Product Colors
+                </h3>
+                <p>
+                    These colors are used to generate
+                    <a
+                        href="https://bootstrap-vue.org/docs/reference/color-variants"
+                        target="_blank">
+                        variants of Bootstrap components.
+                    </a>
+                    Primary and secondary are the most commonly-used variants. The others may be deprecated
+                    for certain components; see the component documentation for details.
+                </p>
+                <b-row>
+                    <b-col
+                        v-for="(value, alias) in variants"
+                        :key="alias"
+                        cols="6"
+                        sm="4"
+                        md="3"
+                        lg="2"
+                        class="mb-200">
+                        <ds-color-swatch
+                            :hex="value"
+                            :is-light="['danger', 'info', 'light', 'success', 'warning'].includes(alias)"
+                            :token="alias" />
+                    </b-col>
+                </b-row>
+            </div>
+        <!--</es-collapse>-->
+    </div>
+</template>
+
+<script setup lang="ts">
+// with vite, sass variable exports must be defined as xyz.module.scss in order to be
+// imported into JS as an object rather than a string of the file contents
+// https://github.com/vitejs/vite/discussions/9601#discussioncomment-3359769
+import sassBlues from '@energysage/es-bs-base/scss/modules/blues.module.scss';
+import sassCoreColors from '@energysage/es-bs-base/scss/modules/core-colors.module.scss';
+import sassErrorColors from '@energysage/es-bs-base/scss/modules/error-colors.module.scss';
+import sassNeutrals from '@energysage/es-bs-base/scss/modules/neutrals.module.scss';
+import sassOranges from '@energysage/es-bs-base/scss/modules/oranges.module.scss';
+import sassSuccessColors from '@energysage/es-bs-base/scss/modules/success-colors.module.scss';
+import sassWarningColors from '@energysage/es-bs-base/scss/modules/warning-colors.module.scss';
+
+import sassBrandColors from '@energysage/es-bs-base/scss/modules/brand-colors.module.scss';
+import sassCyans from '@energysage/es-bs-base/scss/modules/cyans.module.scss';
+import sassGrays from '@energysage/es-bs-base/scss/modules/grays.module.scss';
+import sassPinks from '@energysage/es-bs-base/scss/modules/pinks.module.scss';
+import sassTeals from '@energysage/es-bs-base/scss/modules/teals.module.scss';
+import sassYellows from '@energysage/es-bs-base/scss/modules/yellows.module.scss';
+import sassVariants from '@energysage/es-bs-base/scss/modules/variants.module.scss';
+
+// utility functions
+const prepareColors = (colors) => Object.entries(colors).reverse();
+const slice = (colors, tokens) => {
+    const result = {};
+    tokens.forEach((token) => {
+        result[token] = colors[token];
+    });
+    return result;
+};
+
+const brandColors = sassBrandColors;
+const brandColorNames = {
+    cyan: 'ES Blue',
+    gray: 'ES Slate',
+    pink: 'ES Pink',
+    teal: 'ES Teal',
+    yellow: 'ES Yellow',
+    orange: 'ES Orange',
+};
+const blues = prepareColors(sassBlues);
+// defining chart colors here just for documentation purposes
+// they should NOT be put into SASS and should NOT have bg-color utility classes
+// TODO: move these into a set of JS const variables exported from es-vue-base?
+const chartColors = {
+    'myrtle-cactus-blue': '#3ea2bd',
+    'sunny-yellow': '#ffc021',
+    'petal-purple': '#ca77d1',
+    'leaf-green': '#4a9158',
+    'white-oak': '#d4b595',
+    'earthy-brown': '#9a6d51',
+};
+const chartColorNames = {
+    'myrtle-cactus-blue': 'ES myrtle cactus blue',
+    'sunny-yellow': 'ES sunny yellow',
+    'petal-purple': 'ES petal purple',
+    'leaf-green': 'ES leaf green',
+    'white-oak': 'ES white oak',
+    'earthy-brown': 'ES earthy brown',
+};
+const coreColors = sassCoreColors;
+const coreColorNames = {
+    white: 'ES white',
+    'soft-blue': 'ES soft blue',
+    'medium-blue': 'ES medium blue',
+    'dark-blue': 'ES dark blue',
+    'warm-orange': 'ES warm orange',
+};
+const errorColors = prepareColors(sassErrorColors);
+const grays = sassGrays;
+const neutrals = prepareColors(sassNeutrals);
+const oranges = prepareColors(sassOranges);
+const successColors = prepareColors(sassSuccessColors);
+const variants = sassVariants;
+const warningColors = prepareColors(sassWarningColors);
+
+const cyan = slice(sassCyans, ['cyan-500']);
+const cyanShades = slice(sassCyans, ['cyan-600', 'cyan-700', 'cyan-800']);
+const cyanTints = slice(sassCyans, ['cyan-400', 'cyan-300', 'cyan-200', 'cyan-100']);
+const orangeTints = slice(sassOranges, ['orange-400', 'orange-300', 'orange-200', 'orange-100']);
+const pinkShades = slice(sassPinks, ['pink-600', 'pink-700', 'pink-800']);
+const pinkTints = slice(sassPinks, ['pink-400', 'pink-300', 'pink-200', 'pink-100']);
+const gray = slice(sassGrays, ['gray-900']);
+const grayShades = slice(sassGrays, ['gray-1000', 'gray-1100', 'gray-1200']);
+const grayTints = slice(sassGrays, ['gray-800', 'gray-700', 'gray-600', 'gray-500']);
+const tealShades = slice(sassTeals, ['teal-600', 'teal-700', 'teal-800']);
+const tealTints = slice(sassTeals, ['teal-400', 'teal-300', 'teal-200', 'teal-100']);
+const yellowShades = slice(sassYellows, ['yellow-600', 'yellow-700', 'yellow-800']);
+const yellowTints = slice(sassYellows, ['yellow-400', 'yellow-300', 'yellow-200', 'yellow-100']);
+
+const legacyCollapseVisible = ref(false);
+
+/*export default {
+    name: 'AtomsColor',
+    data() {
+        return {
+            brandColors: sassBrandColors,
+            brandColorNames: {
+                cyan: 'ES Blue',
+                gray: 'ES Slate',
+                pink: 'ES Pink',
+                teal: 'ES Teal',
+                yellow: 'ES Yellow',
+                orange: 'ES Orange',
+            },
+            blues: prepareColors(sassBlues),
+            // defining chart colors here just for documentation purposes
+            // they should NOT be put into SASS and should NOT have bg-color utility classes
+            // TODO: move these into a set of JS const variables exported from es-vue-base?
+            chartColors: {
+                'myrtle-cactus-blue': '#3ea2bd',
+                'sunny-yellow': '#ffc021',
+                'petal-purple': '#ca77d1',
+                'leaf-green': '#4a9158',
+                'white-oak': '#d4b595',
+                'earthy-brown': '#9a6d51',
+            },
+            chartColorNames: {
+                'myrtle-cactus-blue': 'ES myrtle cactus blue',
+                'sunny-yellow': 'ES sunny yellow',
+                'petal-purple': 'ES petal purple',
+                'leaf-green': 'ES leaf green',
+                'white-oak': 'ES white oak',
+                'earthy-brown': 'ES earthy brown',
+            },
+            coreColors: sassCoreColors,
+            coreColorNames: {
+                white: 'ES white',
+                'soft-blue': 'ES soft blue',
+                'medium-blue': 'ES medium blue',
+                'dark-blue': 'ES dark blue',
+                'warm-orange': 'ES warm orange',
+            },
+            errorColors: prepareColors(sassErrorColors),
+            grays: sassGrays,
+            legacyCollapseVisible: false,
+            neutrals: prepareColors(sassNeutrals),
+            oranges: prepareColors(sassOranges),
+            successColors: prepareColors(sassSuccessColors),
+            variants: sassVariants,
+            warningColors: prepareColors(sassWarningColors),
+            compCode: '',
+            docCode: '',
+        };
+    },
+    computed: {
+        cyan() {
+            return this.slice(sassCyans, ['cyan-500']);
+        },
+        cyanShades() {
+            return this.slice(sassCyans, ['cyan-600', 'cyan-700', 'cyan-800']);
+        },
+        cyanTints() {
+            return this.slice(sassCyans, ['cyan-400', 'cyan-300', 'cyan-200', 'cyan-100']);
+        },
+        orangeTints() {
+            return this.slice(sassOranges, ['orange-400', 'orange-300', 'orange-200', 'orange-100']);
+        },
+        pinkShades() {
+            return this.slice(sassPinks, ['pink-600', 'pink-700', 'pink-800']);
+        },
+        pinkTints() {
+            return this.slice(sassPinks, ['pink-400', 'pink-300', 'pink-200', 'pink-100']);
+        },
+        gray() {
+            return this.slice(sassGrays, ['gray-900']);
+        },
+        grayShades() {
+            return this.slice(sassGrays, ['gray-1000', 'gray-1100', 'gray-1200']);
+        },
+        grayTints() {
+            return this.slice(sassGrays, ['gray-800', 'gray-700', 'gray-600', 'gray-500']);
+        },
+        tealShades() {
+            return this.slice(sassTeals, ['teal-600', 'teal-700', 'teal-800']);
+        },
+        tealTints() {
+            return this.slice(sassTeals, ['teal-400', 'teal-300', 'teal-200', 'teal-100']);
+        },
+        yellowShades() {
+            return this.slice(sassYellows, ['yellow-600', 'yellow-700', 'yellow-800']);
+        },
+        yellowTints() {
+            return this.slice(sassYellows, ['yellow-400', 'yellow-300', 'yellow-200', 'yellow-100']);
+        },
+    },
+    methods: {
+        slice(colors, tokens) {
+            const result = {};
+            tokens.forEach((token) => {
+                result[token] = colors[token];
+            });
+            return result;
+        },
+    },
+};*/
+</script>

--- a/es-ds-docs/pages/atoms/color.vue
+++ b/es-ds-docs/pages/atoms/color.vue
@@ -512,6 +512,10 @@
                 </b-row>
             </div>
         </es-collapse>
+
+        <ds-doc-source
+            :doc-code="docCode"
+            doc-source="es-ds-docs/atoms/color.vue" />
     </div>
 </template>
 
@@ -604,108 +608,15 @@ const tealTints = slice(sassTeals, ['teal-400', 'teal-300', 'teal-200', 'teal-10
 const yellowShades = slice(sassYellows, ['yellow-600', 'yellow-700', 'yellow-800']);
 const yellowTints = slice(sassYellows, ['yellow-400', 'yellow-300', 'yellow-200', 'yellow-100']);
 
-/*export default {
-    name: 'AtomsColor',
-    data() {
-        return {
-            brandColors: sassBrandColors,
-            brandColorNames: {
-                cyan: 'ES Blue',
-                gray: 'ES Slate',
-                pink: 'ES Pink',
-                teal: 'ES Teal',
-                yellow: 'ES Yellow',
-                orange: 'ES Orange',
-            },
-            blues: prepareColors(sassBlues),
-            // defining chart colors here just for documentation purposes
-            // they should NOT be put into SASS and should NOT have bg-color utility classes
-            // TODO: move these into a set of JS const variables exported from es-vue-base?
-            chartColors: {
-                'myrtle-cactus-blue': '#3ea2bd',
-                'sunny-yellow': '#ffc021',
-                'petal-purple': '#ca77d1',
-                'leaf-green': '#4a9158',
-                'white-oak': '#d4b595',
-                'earthy-brown': '#9a6d51',
-            },
-            chartColorNames: {
-                'myrtle-cactus-blue': 'ES myrtle cactus blue',
-                'sunny-yellow': 'ES sunny yellow',
-                'petal-purple': 'ES petal purple',
-                'leaf-green': 'ES leaf green',
-                'white-oak': 'ES white oak',
-                'earthy-brown': 'ES earthy brown',
-            },
-            coreColors: sassCoreColors,
-            coreColorNames: {
-                white: 'ES white',
-                'soft-blue': 'ES soft blue',
-                'medium-blue': 'ES medium blue',
-                'dark-blue': 'ES dark blue',
-                'warm-orange': 'ES warm orange',
-            },
-            errorColors: prepareColors(sassErrorColors),
-            grays: sassGrays,
-            legacyCollapseVisible: false,
-            neutrals: prepareColors(sassNeutrals),
-            oranges: prepareColors(sassOranges),
-            successColors: prepareColors(sassSuccessColors),
-            variants: sassVariants,
-            warningColors: prepareColors(sassWarningColors),
-            compCode: '',
-            docCode: '',
-        };
-    },
-    computed: {
-        cyan() {
-            return this.slice(sassCyans, ['cyan-500']);
-        },
-        cyanShades() {
-            return this.slice(sassCyans, ['cyan-600', 'cyan-700', 'cyan-800']);
-        },
-        cyanTints() {
-            return this.slice(sassCyans, ['cyan-400', 'cyan-300', 'cyan-200', 'cyan-100']);
-        },
-        orangeTints() {
-            return this.slice(sassOranges, ['orange-400', 'orange-300', 'orange-200', 'orange-100']);
-        },
-        pinkShades() {
-            return this.slice(sassPinks, ['pink-600', 'pink-700', 'pink-800']);
-        },
-        pinkTints() {
-            return this.slice(sassPinks, ['pink-400', 'pink-300', 'pink-200', 'pink-100']);
-        },
-        gray() {
-            return this.slice(sassGrays, ['gray-900']);
-        },
-        grayShades() {
-            return this.slice(sassGrays, ['gray-1000', 'gray-1100', 'gray-1200']);
-        },
-        grayTints() {
-            return this.slice(sassGrays, ['gray-800', 'gray-700', 'gray-600', 'gray-500']);
-        },
-        tealShades() {
-            return this.slice(sassTeals, ['teal-600', 'teal-700', 'teal-800']);
-        },
-        tealTints() {
-            return this.slice(sassTeals, ['teal-400', 'teal-300', 'teal-200', 'teal-100']);
-        },
-        yellowShades() {
-            return this.slice(sassYellows, ['yellow-600', 'yellow-700', 'yellow-800']);
-        },
-        yellowTints() {
-            return this.slice(sassYellows, ['yellow-400', 'yellow-300', 'yellow-200', 'yellow-100']);
-        },
-    },
-    methods: {
-        slice(colors, tokens) {
-            const result = {};
-            tokens.forEach((token) => {
-                result[token] = colors[token];
-            });
-            return result;
-        },
-    },
-};*/
+const { $prism } = useNuxtApp();
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const docSource = await import('./color.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
 </script>

--- a/es-ds-docs/pages/atoms/corners.vue
+++ b/es-ds-docs/pages/atoms/corners.vue
@@ -3,9 +3,3 @@
         atoms - corners
     </div>
 </template>
-
-<script setup lang="ts">
-import sassBlues from '@energysage/es-bs-base/scss/modules/blues.module.scss';
-
-console.log('sass blues', sassBlues);
-</script>

--- a/es-ds-docs/pages/atoms/corners.vue
+++ b/es-ds-docs/pages/atoms/corners.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+        atoms - corners
+    </div>
+</template>
+
+<script setup lang="ts">
+import sassBlues from '@energysage/es-bs-base/scss/modules/blues.module.scss';
+
+console.log('sass blues', sassBlues);
+</script>

--- a/es-ds-docs/pages/atoms/icons.vue
+++ b/es-ds-docs/pages/atoms/icons.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        atoms - icons
+    </div>
+</template>

--- a/es-ds-docs/pages/atoms/index.vue
+++ b/es-ds-docs/pages/atoms/index.vue
@@ -1,5 +1,8 @@
 <template>
     <div>
-        atoms
+        <h1>
+            Atoms
+        </h1>
+        <ds-atoms-list />
     </div>
 </template>

--- a/es-ds-docs/pages/atoms/index.vue
+++ b/es-ds-docs/pages/atoms/index.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        atoms
+    </div>
+</template>

--- a/es-ds-docs/pages/atoms/layout.vue
+++ b/es-ds-docs/pages/atoms/layout.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        atoms - layout
+    </div>
+</template>

--- a/es-ds-docs/pages/atoms/spacing.vue
+++ b/es-ds-docs/pages/atoms/spacing.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        atoms - spacing
+    </div>
+</template>

--- a/es-ds-docs/pages/atoms/typography.vue
+++ b/es-ds-docs/pages/atoms/typography.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        atoms - typography
+    </div>
+</template>

--- a/es-ds-docs/pages/index.vue
+++ b/es-ds-docs/pages/index.vue
@@ -1,0 +1,33 @@
+<template>
+    <div>
+        <h1>
+            EnergySage Design System
+        </h1>
+        <p>
+            Our design system is based upon the
+            <a href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" target="_blank">
+                Bootstrap 4
+            </a> and
+            <a href="https://primevue.org/introduction/" target="_blank">
+                PrimeVue
+            </a> projects. If something is documented in those projects but not here, it is
+            still very likely you can use it in our system. For example if a component does not exist
+            here but exists in
+            <a href="https://primevue.org/introduction/" target="_blank">
+                PrimeVue
+            </a> you are encouraged to use it.
+        </p>
+        <ul>
+            <li>
+                <nuxt-link to="/atoms">
+                    Atoms
+                </nuxt-link>
+            </li>
+            <li>
+                <nuxt-link to="/molecules">
+                    Molecules
+                </nuxt-link>
+            </li>
+        </ul>
+    </div>
+</template>

--- a/es-ds-docs/pages/index.vue
+++ b/es-ds-docs/pages/index.vue
@@ -8,12 +8,12 @@
             <a href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" target="_blank">
                 Bootstrap 4
             </a> and
-            <a href="https://primevue.org/introduction/" target="_blank">
-                PrimeVue
+            <a href="https://v3.primevue.org/introduction/" target="_blank">
+                PrimeVue v3
             </a> projects. If something is documented in those projects but not here, it is
             still very likely you can use it in our system. For example if a component does not exist
             here but exists in
-            <a href="https://primevue.org/introduction/" target="_blank">
+            <a href="https://v3.primevue.org/introduction/" target="_blank">
                 PrimeVue
             </a> you are encouraged to use it.
         </p>

--- a/es-ds-docs/pages/molecules/breadcrumbs.vue
+++ b/es-ds-docs/pages/molecules/breadcrumbs.vue
@@ -1,0 +1,76 @@
+<template>
+    <div>
+        <h1>
+            Breadcrumbs
+        </h1>
+        <p>
+            Extended from <a
+                href="https://v3.primevue.org/breadcrumb/"
+                target="_blank">
+                PrimeVue Breadcrumb
+            </a>
+        </p>
+
+        <div class="my-500">
+            <es-breadcrumbs :items="items" />
+        </div>
+        <div class="my-500">
+            <es-breadcrumbs :items="longerItems" />
+        </div>
+
+        <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/components/es-breadcrumbs.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/breadcrumbs.vue" />
+    </div>
+</template>
+
+<script setup>
+const items = [
+    {
+        text: 'Home',
+        to: '/',
+    },
+    {
+        text: 'Atoms',
+        to: '/atoms',
+    },
+    {
+        text: 'Typography',
+        active: true
+    },
+];
+const longerItems = [
+    {
+        href: 'https://www.energysage.com/',
+        target: '_blank',
+        text: 'EnergySage',
+    },
+    {
+        href: 'https://www.energysage.com/local-data/solar-panel-cost/',
+        target: '_blank',
+        text: 'Cost of solar',
+    },
+    {
+        active: true,
+        href: 'https://www.energysage.com/local-data/solar-panel-cost/ca/',
+        text: 'Solar cost in California',
+    },
+];
+
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-breadcrumbs.vue?raw');
+    const docSource = await import('./breadcrumbs.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    compCode.value = $prism.normalizeCode(compSource.default);
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -194,58 +194,70 @@
                 :rows="propTableRows"
                 :widths="tableWidths" />-->
         </div>
+
+        <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/src/lib-components/es-collapse.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/es-collapse.vue" />
     </div>
 </template>
 
-<script>
-export default {
-    name: 'EsCollapseDocs',
 
-    data() {
-        return {
-            compCode: '',
-            docCode: '',
-            suggestedVisible: true,
-            visible: false,
-            propTableRows: [
-                [
-                    'visible',
-                    'false',
-                    'Suggested visibility state. Will be ignored if and when the user '
-                    + 'interacts with the collapse (unless "isProgrammaticUntilUserInput" is false).',
-                ],
-                [
-                    'isProgrammaticUntilUserInput',
-                    'true',
-                    'Priority for the "visible" prop. When false, "visible" will continue to affect the component '
-                    + 'even after the user interacts with the collapse.',
-                ],
-                [
-                    'border',
-                    'true',
-                    'Will hide/show borders',
-                ],
-            ],
-            tableWidths: {
-                md: ['4', '3', '5'],
-                lg: ['4', '3', '5'],
-            },
-        };
-    },
-    methods: {
-        shownEvent() {
-            // eslint-disable-next-line no-console
-            console.log('shown');
-        },
-        toggledEvent(newValue) {
-            // eslint-disable-next-line no-console
-            console.log(`toggled to ${newValue}`);
-        },
-        toggledEventInSuggestedVisibleExample(newValue) {
-            // eslint-disable-next-line no-console
-            console.log(`toggled to ${newValue}`);
-            this.visible = newValue;
-        },
-    },
+<script setup>
+const suggestedVisible = ref(true);
+const visible = ref(false);
+
+const propTableRows = [
+    [
+        'visible',
+        'false',
+        'Suggested visibility state. Will be ignored if and when the user '
+        + 'interacts with the collapse (unless "isProgrammaticUntilUserInput" is false).',
+    ],
+    [
+        'isProgrammaticUntilUserInput',
+        'true',
+        'Priority for the "visible" prop. When false, "visible" will continue to affect the component '
+        + 'even after the user interacts with the collapse.',
+    ],
+    [
+        'border',
+        'true',
+        'Will hide/show borders',
+    ],
+];
+const tableWidths = {
+    md: ['4', '3', '5'],
+    lg: ['4', '3', '5'],
 };
+
+const shownEvent = () => {
+    // eslint-disable-next-line no-console
+    console.log('shown');
+};
+const toggledEvent = (newValue) => {
+    // eslint-disable-next-line no-console
+    console.log(`toggled to ${newValue}`);
+};
+const toggledEventInSuggestedVisibleExample = (newValue) => {
+    // eslint-disable-next-line no-console
+    console.log(`toggled to ${newValue}`);
+    visible.value = newValue;
+};
+
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-collapse.vue?raw');
+    const docSource = await import('./collapse.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    compCode.value = $prism.normalizeCode(compSource.default);
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
 </script>

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -1,0 +1,251 @@
+<template>
+    <div>
+        <h1>
+            Collapse
+        </h1>
+        <p>
+            Extended from <a
+                href="https://v3.primevue.org/panel/#toggleable"
+                target="_blank">
+                PrimeVue panel
+            </a>
+        </p>
+        <p>
+            Per our writing guidelines, please ensure the title is in
+            <a
+                href="https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case"
+                target="_blank">
+                Sentence case.
+            </a>
+        </p>
+
+        <div class="my-500">
+            <h2>
+                Default
+            </h2>
+            <p>
+                A normal EsCollapse component. Click it to toggle showing its contents!
+            </p>
+            <div class="px-500 pt-500">
+                <es-collapse>
+                    <template #title>
+                        <h2 class="mb-0">
+                            My title
+                        </h2>
+                    </template>
+                    <!-- eslint-disable max-len -->
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                        Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                        vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                        ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                        Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                        Donec eleifend elit quam.
+                    </p>
+                    <!-- eslint-enable max-len -->
+                </es-collapse>
+            </div>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Programmatic, with user override
+            </h2>
+            <p>
+                An EsCollapse component that takes a "visible" prop. Click the checkbox to toggle showing its
+                contents! If you click the collapse itself, the "visible" prop will no longer be honored.
+            </p>
+            <form class="mx-500 mt-500">
+                <label for="suggestedVisibleInput">
+                    <input
+                        id="suggestedVisibleInput"
+                        v-model="suggestedVisible"
+                        type="checkbox">
+                    Toggle collapse programmatically (will be honored until a manual expand or collapse)
+                </label>
+            </form>
+            <div class="p-500">
+                <es-collapse
+                    :visible="suggestedVisible"
+                    @shown="shownEvent"
+                    @toggled="toggledEvent">
+                    <template #title>
+                        <h2 class="mb-0">
+                            My title
+                        </h2>
+                    </template>
+                    <!-- eslint-disable max-len -->
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                        Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                        vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                        ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                        Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                        Donec eleifend elit quam.
+                    </p>
+                    <!-- eslint-enable max-len -->
+                </es-collapse>
+            </div>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Programmatic, with priority
+            </h2>
+            <p>
+                An EsCollapse component that takes a "visible" prop with "is-programmatic-until-user-input" true. Click
+                the checkbox to toggle showing its contents! Unlike the previous example, if you click the collapse
+                itself, the "visible" prop will continue to be honored.
+            </p>
+            <form class="mx-500 mt-500">
+                <label for="visible">
+                    <input
+                        id="visible"
+                        v-model="visible"
+                        type="checkbox">
+                    Toggle collapse programmatically (will always be honored)
+                </label>
+            </form>
+            <div class="p-500">
+                <es-collapse
+                    v-model="visible"
+                    :is-programmatic-until-user-input="false"
+                    @shown="shownEvent"
+                    @toggled="toggledEventInSuggestedVisibleExample">
+                    <template #title>
+                        <h2 class="mb-0">
+                            My title
+                        </h2>
+                    </template>
+                    <!-- eslint-disable max-len -->
+                    <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                        Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                        vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                        ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                        Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                        Donec eleifend elit quam.
+                    </p>
+                    <!-- eslint-enable max-len -->
+                </es-collapse>
+            </div>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                No border example
+            </h2>
+            <p>
+                To avoid a jumpy transition, remove margins from elements within the default slot
+            </p>
+            <es-collapse
+                id="noBorderExample"
+                class="m-500"
+                :border="false">
+                <template #title>
+                    <h2 class="mb-0">
+                        My title
+                    </h2>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p class="m-0">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                    Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                    vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                    ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                    Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                    Donec eleifend elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </es-collapse>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Extra spacing
+            </h2>
+            <es-collapse
+                id="extraStylingExample"
+                class="m-500 bg-yellow-100 py-100 px-150 rounded"
+                :border="false">
+                <template #title>
+                    <h2 class="mb-0">
+                        My title
+                    </h2>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p class="m-0">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex mi, ut suscipit libero condimentum id.
+                    Pellentesque eu diam vel nisi molestie porta eget sed odio. Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris
+                    vitae ante porttitor, consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+                    ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor mauris. Cras suscipit nibh nec nisi cursus ornare.
+                    Maecenas quis turpis sit amet sapien dapibus sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat.
+                    Donec eleifend elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </es-collapse>
+        </div>
+
+        <div class="mb-500">
+            <h2>
+                EsCollapse props
+            </h2>
+            <!--<ds-prop-table
+                :rows="propTableRows"
+                :widths="tableWidths" />-->
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'EsCollapseDocs',
+
+    data() {
+        return {
+            compCode: '',
+            docCode: '',
+            suggestedVisible: true,
+            visible: false,
+            propTableRows: [
+                [
+                    'visible',
+                    'false',
+                    'Suggested visibility state. Will be ignored if and when the user '
+                    + 'interacts with the collapse (unless "isProgrammaticUntilUserInput" is false).',
+                ],
+                [
+                    'isProgrammaticUntilUserInput',
+                    'true',
+                    'Priority for the "visible" prop. When false, "visible" will continue to affect the component '
+                    + 'even after the user interacts with the collapse.',
+                ],
+                [
+                    'border',
+                    'true',
+                    'Will hide/show borders',
+                ],
+            ],
+            tableWidths: {
+                md: ['4', '3', '5'],
+                lg: ['4', '3', '5'],
+            },
+        };
+    },
+    methods: {
+        shownEvent() {
+            // eslint-disable-next-line no-console
+            console.log('shown');
+        },
+        toggledEvent(newValue) {
+            // eslint-disable-next-line no-console
+            console.log(`toggled to ${newValue}`);
+        },
+        toggledEventInSuggestedVisibleExample(newValue) {
+            // eslint-disable-next-line no-console
+            console.log(`toggled to ${newValue}`);
+            this.visible = newValue;
+        },
+    },
+};
+</script>

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -7,7 +7,7 @@
             Extended from <a
                 href="https://v3.primevue.org/panel/#toggleable"
                 target="_blank">
-                PrimeVue panel
+                PrimeVue Panel
             </a>
         </p>
         <p>

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -190,9 +190,9 @@
             <h2>
                 EsCollapse props
             </h2>
-            <!--<ds-prop-table
+            <ds-prop-table
                 :rows="propTableRows"
-                :widths="tableWidths" />-->
+                :widths="tableWidths" />
         </div>
 
         <ds-doc-source

--- a/es-ds-docs/pages/molecules/index.vue
+++ b/es-ds-docs/pages/molecules/index.vue
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        molecules
+    </div>
+</template>

--- a/es-ds-docs/pages/molecules/index.vue
+++ b/es-ds-docs/pages/molecules/index.vue
@@ -1,5 +1,8 @@
 <template>
     <div>
-        molecules
+        <h1>
+            Molecules
+        </h1>
+        <ds-molecules-list />
     </div>
 </template>

--- a/es-ds-docs/plugins/prism.client.js
+++ b/es-ds-docs/plugins/prism.client.js
@@ -1,0 +1,70 @@
+import 'clipboard'; // For the copy to clipboard plugin
+import Prism from 'prismjs';
+import { nextTick } from 'vue';
+
+import 'prismjs/themes/prism-okaidia.css';
+import 'prismjs/components/prism-scss';
+import 'prismjs/components/prism-javascript';
+
+import 'prismjs/plugins/toolbar/prism-toolbar';
+import 'prismjs/plugins/toolbar/prism-toolbar.css';
+
+import 'prismjs/plugins/line-numbers/prism-line-numbers';
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css';
+
+import 'prismjs/plugins/line-highlight/prism-line-highlight';
+import 'prismjs/plugins/line-highlight/prism-line-highlight.css';
+
+import 'prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard';
+import 'prismjs/plugins/normalize-whitespace/prism-normalize-whitespace';
+import 'prismjs/plugins/autolinker/prism-autolinker';
+import 'prismjs/plugins/match-braces/prism-match-braces';
+import 'prismjs/plugins/highlight-keywords/prism-highlight-keywords';
+
+const SOURCE_LINK_PREFIX = 'https://github.com/EnergySage/es-ds/blob/main/';
+
+// Register custom view source button; seen on hover of code block
+Prism.plugins.toolbar.registerButton('source', {
+    text: 'View Source',
+    onClick(env) {
+        const linkSuffix = env.element.dataset?.source;
+        if (linkSuffix) {
+            window.open(`${SOURCE_LINK_PREFIX}${linkSuffix}`);
+        } else {
+            // eslint-disable-next-line no-alert
+            alert('No source Provided');
+        }
+    },
+});
+
+// Set defaults for normalizer to handle raw .vue files
+Prism.plugins.NormalizeWhitespace.setDefaults({
+    'remove-trailing': true,
+    'remove-indent': true,
+    'left-trim': true,
+    'right-trim': true,
+});
+
+export default defineNuxtPlugin(() => {
+    const normalizer = Prism.plugins.NormalizeWhitespace;
+
+    const prism = {
+        Prism,
+        normalizer,
+        normalizeCode: (code, lang = 'javascript') => {
+            const cleanCode = normalizer.normalize(code);
+
+            return Prism.highlight(cleanCode, Prism.languages[lang]);
+        },
+        highlight: () => {
+            nextTick(() => {
+                Prism.highlightAll();
+            });
+        },
+    };
+    return {
+        provide: {
+            prism
+        }
+    }
+});


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-1725

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Created components in `es-ds-components`
   - Created BContainer, BRow, and BCol
   - Created EsBreadcrumbs and EsCollapse to prove out examples of mapping ESDS 2.0 props API to PrimeVue components (also because the core docs site functionality needs them)
   - Was able to copy in IconChevronDown and IconChevronUp with no changes, to support EsCollapse and the `es-ds-docs` side nav, respectively
- Set up basic structure of `es-ds-docs` site
   - Installed PrimeVue and configured unstyled mode
   - Got the component/documentation source display working with prism
   - Proved out building the Colors page as an example of how we need to modify importing SASS variables in Vite
   - Copied over DsPropTable and associated DsResponsiveTable components

<img width="1415" alt="Screen Shot 2024-07-29 at 2 38 51 PM" src="https://github.com/user-attachments/assets/292b7c85-dc9a-4c9e-b91f-bee17967082b">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally with `make dev`

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Is this enough for people to get started building PrimeVue-based components?
- EsBreadcrumbs and EsCollapse have enough custom functionality (needed to preserve the props API from ESDS 2.0) that it's likely necessary to confine the pass-through styling to those specific components (as I have done) rather than specifying them globally - there may be cases where the PrimeVue component is solid enough that we want to specify the pass-through styles globally for that one, but we'll have to see. If we do, that'd likely be a separate example we'd want to call out on the docs page for that component.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
