### PR TITLE
feat: corners atom for es-ds 3.0

### DIFF
--- a/es-bs-base/scss/modules/border-radius-components.module.scss
+++ b/es-bs-base/scss/modules/border-radius-components.module.scss
@@ -1,0 +1,17 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "../variables";
+
+:export {
+  accordion: variables.$accordion-border-radius;
+  badge: variables.$badge-border-radius;
+  button: variables.$btn-border-radius;
+  card: variables.$card-border-radius;
+  data-table: variables.$table-border-radius;
+  form-message: variables.$alert-border-radius;
+  modal: variables.$modal-content-border-radius;
+  pagination: variables.$pagination-border-radius;
+  popover: variables.$popover-border-radius;
+  textarea: variables.$input-border-radius;
+  text-input: variables.$input-border-radius;
+  verification-code: variables.$verification-code-border-radius;
+}

--- a/es-bs-base/scss/modules/border-radius.module.scss
+++ b/es-bs-base/scss/modules/border-radius.module.scss
@@ -1,0 +1,10 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "../variables";
+
+:export {
+  xs: variables.$border-radius-xs;
+  sm: variables.$border-radius-sm;
+  md: variables.$border-radius;
+  lg: variables.$border-radius-lg;
+}

--- a/es-ds-docs/pages/atoms/corners.vue
+++ b/es-ds-docs/pages/atoms/corners.vue
@@ -1,5 +1,130 @@
 <template>
     <div>
-        atoms - corners
+        <h1>Corners</h1>
+        <p>
+            Below are the four corner radius sizes used throughout the design system. Each size lists a few examples of
+            components that make use of that size. Use the utility classes listed below (e.g. <code>rounded</code>) to
+            add the desired corner radius to your UI elements.
+        </p>
+
+        <b-row class="my-500">
+            <b-col
+                v-for="item in borderRadius"
+                :key="item.name"
+                class="mb-200"
+                cols="6"
+                lg="3">
+                <div
+                    class="bg-soft-blue h-100 px-100 px-lg-200 py-200 py-lg-300 text-center text-dark-blue"
+                    :class="item.class">
+                    <p class="font-size-300 mb-25">
+                        {{ `${item.name} / ${item.sizePx}px` }}
+                    </p>
+                    <p>
+                        <code class="text-body">
+                            {{ item.class }}
+                        </code>
+                    </p>
+                    <p class="font-size-sm mb-0">
+                        <ul class="component-list list-unstyled mb-0">
+                            <li class="d-inline-block">
+                                Used by
+                            </li>
+                            <li
+                                v-for="component in item.components"
+                                :key="component.name"
+                                class="d-inline-block">
+                                <ds-link :to="component.url">
+                                    {{ component.name }}
+                                </ds-link>
+                            </li>
+                        </ul>
+                    </p>
+                </div>
+            </b-col>
+        </b-row>
+
+        <ds-doc-source :doc-code="docCode" doc-source="es-ds-docs/atoms/corners.vue" />
     </div>
 </template>
+
+<script setup lang="ts">
+import sassBorderRadius from "@energysage/es-bs-base/scss/modules/border-radius.module.scss";
+import sassBorderRadiusComponents from "@energysage/es-bs-base/scss/modules/border-radius-components.module.scss";
+
+import { computed } from "vue";
+
+const BASE_FONT_SIZE_PX = 16;
+
+const COMPONENT_NAME_URLS = {
+    /*
+    accordion: '/molecules/es-accordion',
+    badge: '/molecules/es-badge',
+    button: '/molecules/es-button',
+    card: '/molecules/es-card',
+    'data-table': '/molecules/es-data-table',
+    'form-message': '/molecules/es-form-msg',
+    modal: '/molecules/es-modal',
+    pagination: '/molecules/es-pagination',
+    popover: '/molecules/es-popover',
+    textarea: '/molecules/es-form-textarea',
+    'text-input': '/molecules/es-form-input',
+    'verification-code': '/molecules/es-verification-code',
+    */
+};
+
+const borderRadius = computed(() => {
+    const sizeMap = Object.entries(sassBorderRadius).reduce((result, [name, sizeRem]) => {
+        // eslint-disable-next-line no-param-reassign
+        result[sizeRem] = {
+            name,
+            components: [],
+        };
+        return result;
+    }, {});
+
+    Object.entries(sassBorderRadiusComponents).forEach(([component, sizeRem]) => {
+        if (sizeMap[sizeRem]?.components?.push) {
+            sizeMap[sizeRem].components.push(component);
+        }
+    });
+
+    return Object.entries(sassBorderRadius).map(([name, sizeRem]) => {
+        const sizePx = parseFloat(sizeRem.replace("rem", "")) * BASE_FONT_SIZE_PX;
+        return {
+            class: name === "md" ? "rounded" : `rounded-${name}`,
+            components: sizeMap[sizeRem].components.map((simpleName) => ({
+                name: `${simpleName[0].toUpperCase()}${simpleName.substring(1).replace("-", " ")}`,
+                url: COMPONENT_NAME_URLS[simpleName],
+            })),
+            name,
+            sizePx,
+            sizeRem,
+        };
+    });
+});
+
+const { $prism } = useNuxtApp();
+const docCode = ref("");
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const docSource = await import("./color.vue?raw");
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>
+
+<style lang="scss" scoped>
+.component-list {
+    li:not(:first-child):not(:last-child) {
+        margin-right: 0.25rem;
+
+        &::after {
+            content: ",";
+        }
+    }
+}
+</style>

--- a/es-ds-docs/pages/atoms/corners.vue
+++ b/es-ds-docs/pages/atoms/corners.vue
@@ -28,7 +28,7 @@
                     <p class="font-size-sm mb-0">
                         <ul class="component-list list-unstyled mb-0">
                             <li class="d-inline-block">
-                                Used by
+                                Used by&nbsp;
                             </li>
                             <li
                                 v-for="component in item.components"
@@ -57,7 +57,7 @@ import { computed } from "vue";
 const BASE_FONT_SIZE_PX = 16;
 
 const COMPONENT_NAME_URLS = {
-    /*
+    /* TODO: uncomment once these molecules exist
     accordion: '/molecules/es-accordion',
     badge: '/molecules/es-badge',
     button: '/molecules/es-button',
@@ -109,7 +109,7 @@ const docCode = ref("");
 
 if ($prism) {
     /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-    const docSource = await import("./color.vue?raw");
+    const docSource = await import("./corners.vue?raw");
     /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
     docCode.value = $prism.normalizeCode(docSource.default);


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[CED-1732: Add the Corners atoms page](https://energysage.atlassian.net/browse/CED-1732)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Created corners atom for es-ds 3.0
- Created SCSS modules for `border-radius` and `border-radius-components`
- Followed example of atom `color.vue` for Prism code

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- Test locally at http://localhost:8500/atoms/corners

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I'm working on resolving several similar TypeScript errors inside the `borderRadius` computed property. I'm not sure what's causing them.

```txt
- Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.\n  No index signature with a parameter of type 'string' was found on type '{}'.
- Parameter 'simpleName' implicitly has an 'any' type.
```

- I'm confused about why the XL breakpoint seems to kick in at 1080px instead of 1200px, and why the container becomes flexible again. That's not specific to this ticket.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
