### PR TITLE
feat: layout atom for es-ds 3.0

### DIFF
--- a/es-bs-base/scss/modules/breakpoints.module.scss
+++ b/es-bs-base/scss/modules/breakpoints.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+@use "sass:map";
+@use "../variables";
+
+:export {
+  xxl: map.get(variables.$grid-breakpoints, xxl);
+  xl: map.get(variables.$grid-breakpoints, xl);
+  lg: map.get(variables.$grid-breakpoints, lg);
+  md: map.get(variables.$grid-breakpoints, md);
+  sm: map.get(variables.$grid-breakpoints, sm);
+  xs: map.get(variables.$grid-breakpoints, xs);
+}

--- a/es-bs-base/scss/modules/max-widths.module.scss
+++ b/es-bs-base/scss/modules/max-widths.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable selector-pseudo-class-no-unknown, property-no-unknown */
+
+@use "sass:map";
+@use "../variables";
+
+:export {
+  xxl: map.get(variables.$container-max-widths, xxl);
+  xl: map.get(variables.$container-max-widths, xl);
+  lg: map.get(variables.$container-max-widths, lg);
+  md: map.get(variables.$container-max-widths, md);
+  sm: map.get(variables.$container-max-widths, sm);
+}

--- a/es-ds-docs/pages/atoms/layout.vue
+++ b/es-ds-docs/pages/atoms/layout.vue
@@ -4,260 +4,255 @@
             Layout
         </h1>
         <p>
-            Extended from 
-            <NuxtLink to="https://bootstrap-vue.org/docs/components/layout" target="_blank">
-                bootstrap-vue layout
-            </NuxtLink>
+            Based on
+            <nuxt-link to="https://bootstrap-vue.org/docs/components/layout" target="_blank">
+                Bootstrap Vue layout
+            </nuxt-link>
         </p>
         <h2 class="mt-200">
-            Responsive Breakpoints
+            Responsive breakpoints
         </h2>
         <p>
             At each breakpoint above extra small (xs), the content is constrained to the max width listed below.
         </p>
-        
         <ds-responsive-table>
             <ds-responsive-table-row
-                v-for="item in breakpointTableItems"
-                zebraStripes >
-                <ds-responsive-table-column md="1.5"
-                    v-for="field in breakpointTableFields">
+                v-for="field in breakpointTableFields"
+                zebraStripes>
+                <ds-responsive-table-column>
                     <template #name>
-
-                        <div 
-                            v-if="field.label == ``">
-                                &nbsp; 
-                        </div>
-                        <div v-else>
-                            {{ field.label }} 
-                        </div>
+                        &nbsp;
                     </template>
                     <template #value>
-                        <div 
-                            v-if="field.key == `label`">
-                                <strong>{{ item[field.key] }} </strong>
+                        <div>
+                            <strong>{{ field.label }} </strong>
                         </div>
-                        <div v-else>
-                            {{ item[field.key] }}
-                        </div>
+                    </template>
+                </ds-responsive-table-column>
+                <ds-responsive-table-column
+                    v-for="(item, index) in breakpointTableItems">
+                    <template #name>
+                        {{ breakpointTableLabels[index] }}
+                    </template>
+                    <template #value>
+                        {{ item[field.key] }}
                     </template>
                 </ds-responsive-table-column>
             </ds-responsive-table-row>
         </ds-responsive-table>
-
         <h2 class="mt-200">
-            Grid Overview
+            Grid overview
         </h2>
         <b-container>
             <b-row>
                 <b-col
                     cols="12"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     12 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="11"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     11 Columns
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="10"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     10 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     2 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="9"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     9 Columns
                 </b-col>
                 <b-col
                     cols="3"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     3 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="8"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     8 Columns
                 </b-col>
                 <b-col
                     cols="4"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     4 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="7"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     7 Columns
                 </b-col>
                 <b-col
                     cols="5"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     5 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="6"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     6 Columns
                 </b-col>
                 <b-col
                     cols="6"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     6 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="4"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     4 Columns
                 </b-col>
                 <b-col
                     cols="4"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     4 Columns
                 </b-col>
                 <b-col
                     cols="4"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     4 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="3"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     3 Columns
                 </b-col>
                 <b-col
                     cols="3"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     3 Columns
                 </b-col>
                 <b-col
                     cols="3"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     3 Columns
                 </b-col>
                 <b-col
                     cols="3"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     3 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="2"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     2 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     2 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     2 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     2 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     2 Columns
                 </b-col>
                 <b-col
                     cols="2"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     2 Columns
                 </b-col>
             </b-row>
             <b-row>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-light">
+                    class="bg-gray-400 text-center">
                     1
                 </b-col>
                 <b-col
                     cols="1"
-                    class="bg-gray-dark">
+                    class="bg-gray-700 text-center text-gray-400">
                     1
                 </b-col>
             </b-row>
@@ -271,33 +266,38 @@
 import sassBreakpoints from '@energysage/es-bs-base/scss/modules/breakpoints.module.scss';
 import sassMaxWidths from '@energysage/es-bs-base/scss/modules/max-widths.module.scss';
 
+
+const  breakpointTableLabels = [`Breakpoint`, `Max container width` ];
+
 const  breakpointTableFields = [
-                { key: 'label', label: `` },
-                { key: 'xs', label: 'Extra small (xs)' },
-                { key: 'sm', label: 'Small (sm)' },
-                { key: 'md', label: 'Medium (md)' },
-                { key: 'lg', label: 'Large (lg)' },
-                { key: 'xl', label: 'Extra large (xl)' },
-                { key: 'xxl', label: 'Extra extra large (xxl)' }];
-const breakpointTableItems = [{
-                    label: 'Breakpoint',
-                    xs: `< ${sassBreakpoints.sm}`,
-                    sm: `≥ ${sassBreakpoints.sm}`,
-                    md: `≥ ${sassBreakpoints.md}`,
-                    lg: `≥ ${sassBreakpoints.lg}`,
-                    xl: `≥ ${sassBreakpoints.xl}`,
-                    xxl: `≥ ${sassBreakpoints.xxl}`,
-                },
-                {
-                    label: 'Max container width',
-                    xs: 'None',
-                    sm: sassMaxWidths.sm,
-                    md: sassMaxWidths.md,
-                    lg: sassMaxWidths.lg,
-                    xl: sassMaxWidths.xl,
-                    xxl: sassMaxWidths.xxl,
-                }
-            ];
+    //{ key: 'label', label: `` },
+    { key: 'xs', label: 'Extra small (xs)' },
+    { key: 'sm', label: 'Small (sm)' },
+    { key: 'md', label: 'Medium (md)' },
+    { key: 'lg', label: 'Large (lg)' },
+    { key: 'xl', label: 'Extra large (xl)' },
+    { key: 'xxl', label: 'Extra extra large (xxl)' }
+];
+const breakpointTableItems = [
+    {
+        // label: 'Breakpoint',
+        xs: `< ${sassBreakpoints.sm}`,
+        sm: `≥ ${sassBreakpoints.sm}`,
+        md: `≥ ${sassBreakpoints.md}`,
+        lg: `≥ ${sassBreakpoints.lg}`,
+        xl: `≥ ${sassBreakpoints.xl}`,
+        xxl: `≥ ${sassBreakpoints.xxl}`,
+    },
+    {
+        // label: 'Max container width',
+        xs: 'None',
+        sm: sassMaxWidths.sm,
+        md: sassMaxWidths.md,
+        lg: sassMaxWidths.lg,
+        xl: sassMaxWidths.xl,
+        xxl: sassMaxWidths.xxl,
+    }
+];
 
 const { $prism } = useNuxtApp();
 const docCode = ref('');
@@ -311,18 +311,3 @@ if ($prism) {
 }
 </script>
 
-
-<style lang="scss" scoped>
-@use "@energysage/es-bs-base/scss/variables" as variables;
-
-.bg-gray-light {
-    background: variables.$gray-400;
-    text-align: center;
-}
-
-.bg-gray-dark {
-    background: variables.$gray-700;
-    text-align: center;
-    color: variables.$gray-400;
-}
-</style>

--- a/es-ds-docs/pages/atoms/layout.vue
+++ b/es-ds-docs/pages/atoms/layout.vue
@@ -1,5 +1,328 @@
 <template>
-    <div>
-        atoms - layout
+    <div width: 100%;>
+        <h1>
+            Layout
+        </h1>
+        <p>
+            Extended from 
+            <NuxtLink to="https://bootstrap-vue.org/docs/components/layout" target="_blank">
+                bootstrap-vue layout
+            </NuxtLink>
+        </p>
+        <h2 class="mt-200">
+            Responsive Breakpoints
+        </h2>
+        <p>
+            At each breakpoint above extra small (xs), the content is constrained to the max width listed below.
+        </p>
+        
+        <ds-responsive-table>
+            <ds-responsive-table-row
+                v-for="item in breakpointTableItems"
+                zebraStripes >
+                <ds-responsive-table-column md="1.5"
+                    v-for="field in breakpointTableFields">
+                    <template #name>
+
+                        <div 
+                            v-if="field.label == ``">
+                                &nbsp; 
+                        </div>
+                        <div v-else>
+                            {{ field.label }} 
+                        </div>
+                    </template>
+                    <template #value>
+                        <div 
+                            v-if="field.key == `label`">
+                                <strong>{{ item[field.key] }} </strong>
+                        </div>
+                        <div v-else>
+                            {{ item[field.key] }}
+                        </div>
+                    </template>
+                </ds-responsive-table-column>
+            </ds-responsive-table-row>
+        </ds-responsive-table>
+
+        <h2 class="mt-200">
+            Grid Overview
+        </h2>
+        <b-container>
+            <b-row>
+                <b-col
+                    cols="12"
+                    class="bg-gray-light">
+                    12 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="11"
+                    class="bg-gray-light">
+                    11 Columns
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="10"
+                    class="bg-gray-light">
+                    10 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-dark">
+                    2 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="9"
+                    class="bg-gray-light">
+                    9 Columns
+                </b-col>
+                <b-col
+                    cols="3"
+                    class="bg-gray-dark">
+                    3 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="8"
+                    class="bg-gray-light">
+                    8 Columns
+                </b-col>
+                <b-col
+                    cols="4"
+                    class="bg-gray-dark">
+                    4 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="7"
+                    class="bg-gray-light">
+                    7 Columns
+                </b-col>
+                <b-col
+                    cols="5"
+                    class="bg-gray-dark">
+                    5 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="6"
+                    class="bg-gray-light">
+                    6 Columns
+                </b-col>
+                <b-col
+                    cols="6"
+                    class="bg-gray-dark">
+                    6 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="4"
+                    class="bg-gray-light">
+                    4 Columns
+                </b-col>
+                <b-col
+                    cols="4"
+                    class="bg-gray-dark">
+                    4 Columns
+                </b-col>
+                <b-col
+                    cols="4"
+                    class="bg-gray-light">
+                    4 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="3"
+                    class="bg-gray-light">
+                    3 Columns
+                </b-col>
+                <b-col
+                    cols="3"
+                    class="bg-gray-dark">
+                    3 Columns
+                </b-col>
+                <b-col
+                    cols="3"
+                    class="bg-gray-light">
+                    3 Columns
+                </b-col>
+                <b-col
+                    cols="3"
+                    class="bg-gray-dark">
+                    3 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="2"
+                    class="bg-gray-light">
+                    2 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-dark">
+                    2 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-light">
+                    2 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-dark">
+                    2 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-light">
+                    2 Columns
+                </b-col>
+                <b-col
+                    cols="2"
+                    class="bg-gray-dark">
+                    2 Columns
+                </b-col>
+            </b-row>
+            <b-row>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-light">
+                    1
+                </b-col>
+                <b-col
+                    cols="1"
+                    class="bg-gray-dark">
+                    1
+                </b-col>
+            </b-row>
+        </b-container>
+        <ds-doc-source
+            :doc-code="docCode"
+            doc-source="es-ds-docs/atoms/layout.vue" />
     </div>
 </template>
+<script setup lang="ts">
+import sassBreakpoints from '@energysage/es-bs-base/scss/modules/breakpoints.module.scss';
+import sassMaxWidths from '@energysage/es-bs-base/scss/modules/max-widths.module.scss';
+
+const  breakpointTableFields = [
+                { key: 'label', label: `` },
+                { key: 'xs', label: 'Extra small (xs)' },
+                { key: 'sm', label: 'Small (sm)' },
+                { key: 'md', label: 'Medium (md)' },
+                { key: 'lg', label: 'Large (lg)' },
+                { key: 'xl', label: 'Extra large (xl)' },
+                { key: 'xxl', label: 'Extra extra large (xxl)' }];
+const breakpointTableItems = [{
+                    label: 'Breakpoint',
+                    xs: `< ${sassBreakpoints.sm}`,
+                    sm: `≥ ${sassBreakpoints.sm}`,
+                    md: `≥ ${sassBreakpoints.md}`,
+                    lg: `≥ ${sassBreakpoints.lg}`,
+                    xl: `≥ ${sassBreakpoints.xl}`,
+                    xxl: `≥ ${sassBreakpoints.xxl}`,
+                },
+                {
+                    label: 'Max container width',
+                    xs: 'None',
+                    sm: sassMaxWidths.sm,
+                    md: sassMaxWidths.md,
+                    lg: sassMaxWidths.lg,
+                    xl: sassMaxWidths.xl,
+                    xxl: sassMaxWidths.xxl,
+                }
+            ];
+
+const { $prism } = useNuxtApp();
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const docSource = await import('./layout.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>
+
+
+<style lang="scss" scoped>
+@use "@energysage/es-bs-base/scss/variables" as variables;
+
+.bg-gray-light {
+    background: variables.$gray-400;
+    text-align: center;
+}
+
+.bg-gray-dark {
+    background: variables.$gray-700;
+    text-align: center;
+    color: variables.$gray-400;
+}
+</style>

--- a/es-ds-docs/pages/atoms/layout.vue
+++ b/es-ds-docs/pages/atoms/layout.vue
@@ -1,5 +1,5 @@
 <template>
-    <div width: 100%;>
+    <div>
         <h1>
             Layout
         </h1>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
[CED-1734: Add the layout atom page](https://energysage.atlassian.net/browse/CED-1734) 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Created layout atom for es-ds 3.0 
- Created SCSS module for `breakpoints` and `max-widths`
- Refactored previous `b-table` into `ds-responsive-table`
- Changed font color for dark background for clarity

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally at http://localhost:8500/atoms/layout

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I have a type error that sometimes shows up. A potential fix is `item[field.key as keyof typeof item]` but I was wondering if there is a better fix. 
- I added a `&nbsp;` and `md="1.5"` to fix the table spacing, but I was wondering if there is a better solution. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
