### PR TITLE
feat: globally style PrimeVue radio buttons

### DIFF
--- a/es-bs-base/scss/_custom-forms.scss
+++ b/es-bs-base/scss/_custom-forms.scss
@@ -28,24 +28,22 @@
   margin-right: variables.$custom-control-spacer-x;
 }
 
-.custom-control-wrapper {
-  .custom-control-input {
-    position: absolute;
-    left: 0;
-    z-index: -1; // Put the input behind the label so it doesn't overlay text
-    width: variables.$custom-control-indicator-size;
-    height: (variables.$font-size-base * variables.$line-height-base + variables.$custom-control-indicator-size) * .5;
-    opacity: 0;
-  }
+.custom-control-input {
+  position: absolute;
+  left: 0;
+  z-index: -1; // Put the input behind the label so it doesn't overlay text
+  width: variables.$custom-control-indicator-size;
+  height: (variables.$font-size-base * variables.$line-height-base + variables.$custom-control-indicator-size) * .5;
+  opacity: 0;
 
-  &:has(.custom-control-input:checked) ~ .custom-control-label::before {
+  &:checked ~ .custom-control-label::before, &:has(.custom-radio-input:checked) ~ .custom-control-label::before {
     color: variables.$custom-control-indicator-checked-color;
     border-color: variables.$custom-control-indicator-checked-border-color;
     @include gradients.gradient-bg(variables.$custom-control-indicator-checked-bg);
     @include box-shadow.box-shadow(variables.$custom-control-indicator-checked-box-shadow);
   }
 
-  &:has(.custom-control-input:focus) ~ .custom-control-label::before {
+  &:focus ~ .custom-control-label::before, &:has(.custom-radio-input:focus) ~ .custom-control-label::before {
     // the mixin is not used here to make sure there is feedback
     @if variables.$enable-shadows {
       box-shadow: variables.$input-box-shadow, variables.$custom-control-indicator-focus-box-shadow;
@@ -54,16 +52,16 @@
     }
   }
 
-  &:has(.custom-control-input:focus):not(:has(.custom-control-input:checked)) ~ .custom-control-label::before {
+  &:focus:not(:checked) ~ .custom-control-label::before, &:has(.custom-radio-input:focus):not(:has(.custom-radio-input:checked)) ~ .custom-control-label::before {
     border-color: variables.$custom-control-indicator-focus-border-color;
   }
 
-  &:not(:has(.custom-control-input:disabled)):not(:has(.custom-control-input:focus)) ~ .custom-control-label:hover::before {
+  &:not(:disabled):not(:focus) ~ .custom-control-label:hover::before, &:not(:has(.custom-radio-input:disabled)):not(:has(.custom-radio-input:focus)) ~ .custom-control-label:hover::before {
     // the mixin is not used here to make sure there is feedback
     box-shadow: variables.$custom-control-indicator-hover-box-shadow;
   }
 
-  &:not(:has(.custom-control-input:disabled)):active ~ .custom-control-label::before {
+  &:not(:disabled):active ~ .custom-control-label::before, &:not(:has(.custom-radio-input:disabled)):active ~ .custom-control-label::before {
     color: variables.$custom-control-indicator-active-color;
     background-color: variables.$custom-control-indicator-active-bg;
     border-color: variables.$custom-control-indicator-active-border-color;
@@ -73,7 +71,8 @@
 
   // Use [disabled] and :disabled to work around https://github.com/twbs/bootstrap/issues/28247
   &[disabled],
-  &:has(.custom-control-input:disabled) {
+  &:disabled,
+  &:has(.custom-radio-input:disabled) {
     ~ .custom-control-label {
       color: variables.$custom-control-label-disabled-color;
 
@@ -182,7 +181,7 @@
     border-radius: variables.$custom-radio-indicator-border-radius;
   }
 
-  .custom-control-wrapper:has(.custom-control-input:checked) ~ .custom-control-label {
+  .custom-control-input:has(.custom-radio-input:checked) ~ .custom-control-label {
     &::before {
       background-color: variables.$custom-control-indicator-bg;
     }
@@ -191,7 +190,7 @@
     }
   }
 
-  .custom-control-wrapper:has(.custom-control-input:disabled:checked) ~ .custom-control-label {
+  .custom-control-input:has(.custom-radio-input:disabled:checked) ~ .custom-control-label {
     &::before {
       @include gradients.gradient-bg(variables.$custom-control-indicator-checked-disabled-bg);
     }

--- a/es-bs-base/scss/_custom-forms.scss
+++ b/es-bs-base/scss/_custom-forms.scss
@@ -56,7 +56,7 @@
     border-color: variables.$custom-control-indicator-focus-border-color;
   }
 
-  &:not(:disabled):not(:focus) ~ .custom-control-label:hover::before, &:not(:has(.custom-radio-input:disabled)):not(:has(.custom-radio-input:focus)) ~ .custom-control-label:hover::before {
+  &:not(:disabled):not(:focus):not(:has(.custom-radio-input:disabled)):not(:has(.custom-radio-input:focus)) ~ .custom-control-label:hover::before {
     // the mixin is not used here to make sure there is feedback
     box-shadow: variables.$custom-control-indicator-hover-box-shadow;
   }

--- a/es-bs-base/scss/_custom-forms.scss
+++ b/es-bs-base/scss/_custom-forms.scss
@@ -28,22 +28,24 @@
   margin-right: variables.$custom-control-spacer-x;
 }
 
-.custom-control-input {
-  position: absolute;
-  left: 0;
-  z-index: -1; // Put the input behind the label so it doesn't overlay text
-  width: variables.$custom-control-indicator-size;
-  height: (variables.$font-size-base * variables.$line-height-base + variables.$custom-control-indicator-size) * .5;
-  opacity: 0;
+.custom-control-wrapper {
+  .custom-control-input {
+    position: absolute;
+    left: 0;
+    z-index: -1; // Put the input behind the label so it doesn't overlay text
+    width: variables.$custom-control-indicator-size;
+    height: (variables.$font-size-base * variables.$line-height-base + variables.$custom-control-indicator-size) * .5;
+    opacity: 0;
+  }
 
-  &:checked ~ .custom-control-label::before {
+  &:has(.custom-control-input:checked) ~ .custom-control-label::before {
     color: variables.$custom-control-indicator-checked-color;
     border-color: variables.$custom-control-indicator-checked-border-color;
     @include gradients.gradient-bg(variables.$custom-control-indicator-checked-bg);
     @include box-shadow.box-shadow(variables.$custom-control-indicator-checked-box-shadow);
   }
 
-  &:focus ~ .custom-control-label::before {
+  &:has(.custom-control-input:focus) ~ .custom-control-label::before {
     // the mixin is not used here to make sure there is feedback
     @if variables.$enable-shadows {
       box-shadow: variables.$input-box-shadow, variables.$custom-control-indicator-focus-box-shadow;
@@ -52,16 +54,16 @@
     }
   }
 
-  &:focus:not(:checked) ~ .custom-control-label::before {
+  &:has(.custom-control-input:focus):not(:has(.custom-control-input:checked)) ~ .custom-control-label::before {
     border-color: variables.$custom-control-indicator-focus-border-color;
   }
 
-  &:not(:disabled):not(:focus) ~ .custom-control-label:hover::before {
+  &:not(:has(.custom-control-input:disabled)):not(:has(.custom-control-input:focus)) ~ .custom-control-label:hover::before {
     // the mixin is not used here to make sure there is feedback
     box-shadow: variables.$custom-control-indicator-hover-box-shadow;
   }
 
-  &:not(:disabled):active ~ .custom-control-label::before {
+  &:not(:has(.custom-control-input:disabled)):active ~ .custom-control-label::before {
     color: variables.$custom-control-indicator-active-color;
     background-color: variables.$custom-control-indicator-active-bg;
     border-color: variables.$custom-control-indicator-active-border-color;
@@ -71,7 +73,7 @@
 
   // Use [disabled] and :disabled to work around https://github.com/twbs/bootstrap/issues/28247
   &[disabled],
-  &:disabled {
+  &:has(.custom-control-input:disabled) {
     ~ .custom-control-label {
       color: variables.$custom-control-label-disabled-color;
 
@@ -180,21 +182,21 @@
     border-radius: variables.$custom-radio-indicator-border-radius;
   }
 
-  .custom-control-input:checked ~ .custom-control-label {
+  .custom-control-wrapper:has(.custom-control-input:checked) ~ .custom-control-label {
     &::before {
       background-color: variables.$custom-control-indicator-bg;
     }
     &::after {
-      background-image: functions.escape-svg(variables.$custom-radio-indicator-icon-checked);
+      background-image: functions.escape-svg(variables.$custom-radio-indicator-icon-checked) !important;
     }
   }
 
-  .custom-control-input:disabled:checked ~ .custom-control-label {
+  .custom-control-wrapper:has(.custom-control-input:disabled:checked) ~ .custom-control-label {
     &::before {
       @include gradients.gradient-bg(variables.$custom-control-indicator-checked-disabled-bg);
     }
     &::after {
-      background-image: functions.escape-svg(variables.$custom-radio-indicator-icon-checked-disabled);
+      background-image: functions.escape-svg(variables.$custom-radio-indicator-icon-checked-disabled) !important;
     }
   }
 }

--- a/es-ds-components/components/es-radio-button.vue
+++ b/es-ds-components/components/es-radio-button.vue
@@ -1,0 +1,62 @@
+<template>
+    <div :class="`custom-control custom-radio custom-control${props.inline ? '-inline' : ''}`">
+        <radio-button
+            class="custom-control-input"
+            input-class="custom-radio-input"
+            v-model="localValue"
+            :disabled="disabled"
+            :input-id="`${value}-${groupName}`"
+            :name="groupName"
+            :value="value" />
+        <label :for="`${value}-${groupName}`" class="custom-control-label">{{ displayName }}</label>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
+    displayName: {
+        type: String,
+        required: true,
+        default: "",
+    },
+    groupName: {
+        type: String,
+        required: false,
+        default: "",
+    },
+    inline: {
+        type: Boolean,
+        default: false,
+    },
+    modelValue: {
+        type: String,
+        required: true,
+        default: "",
+    },
+    value: {
+        type: String,
+        required: true,
+        default: "",
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const localValue = ref(props.modelValue);
+
+// Watch for changes to the local value and emit them
+watch(localValue, (newValue) => {
+    emit('update:modelValue', newValue);
+});
+
+// Watch for prop changes and update the local value
+watch(() => props.modelValue, (newValue) => {
+    localValue.value = newValue;
+});
+
+</script>

--- a/es-ds-components/components/es-radio-button.vue
+++ b/es-ds-components/components/es-radio-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="`custom-control custom-radio custom-control${props.inline ? '-inline' : ''}`">
+    <div :class="`custom-control custom-radio custom-control${inline ? '-inline' : ''}`">
         <radio-button
             class="custom-control-input"
             input-class="custom-radio-input"

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -10,5 +10,10 @@
                 Collapse
             </ds-link>
         </li>
+        <li>
+            <ds-link to="/molecules/radio-button">
+                Radio button
+            </ds-link>
+        </li>
     </ul>
 </template>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -18,18 +18,13 @@
             <p>
                 Please choose your favorite fruit.
             </p>
-            <div>
-                <div v-for="fruit in fruits" class="custom-control custom-control-inline custom-radio">
-                    <radio-button
-                        class="custom-control-input"
-                        input-class="custom-radio-input"
-                        v-model="selectedFruit"
-                        :input-id="`${fruit.key}-inline`"
-                        name="inline"
-                        :value="fruit.key" />
-                    <label :for="`${fruit.key}-inline`" class="custom-control-label">{{ fruit.name }}</label>
-                </div>
-            </div>
+            <es-radio-button
+                v-for="fruit in fruits"
+                v-model="selectedFruit"
+                :display-name="fruit.name"
+                group-name="inline"
+                :value="fruit.key"
+                inline />
         </div>
 
         <div class="my-500">
@@ -39,18 +34,12 @@
             <p>
                 Please choose your favorite fruit.
             </p>
-            <div>
-                <div v-for="fruit in fruits" class="custom-control custom-radio">
-                    <radio-button
-                        class="custom-control-input"
-                        input-class="custom-radio-input"
-                        v-model="selectedFruit"
-                        :input-id="`${fruit.key}-stacked`"
-                        name="stacked"
-                        :value="fruit.key" />
-                    <label :for="`${fruit.key}-stacked`" class="custom-control-label">{{ fruit.name }}</label>
-                </div>
-            </div>
+            <es-radio-button
+                v-for="fruit in fruits"
+                v-model="selectedFruit"
+                :display-name="fruit.name"
+                group-name="stacked"
+                :value="fruit.key" />
         </div>
 
         <div class="my-500">
@@ -60,22 +49,27 @@
             <p>
                 Please choose your favorite fruit.
             </p>
-            <div>
-                <div v-for="fruit in fruits" class="custom-control custom-radio">
-                    <radio-button
-                        disabled
-                        class="custom-control-input"
-                        input-class="custom-radio-input"
-                        v-model="selectedFruit"
-                        :input-id="`${fruit.key}-disabled`"
-                        name="disabled"
-                        :value="fruit.key" />
-                    <label :for="`${fruit.key}-disabled`" class="custom-control-label">{{ fruit.name }}</label>
-                </div>
-            </div>
+            <es-radio-button
+                v-for="fruit in fruits"
+                v-model="selectedFruit"
+                :display-name="fruit.name"
+                group-name="disabled"
+                :value="fruit.key"
+                disabled />
+        </div>
+
+        <div class="mb-500">
+            <h2>
+                EsCollapse props
+            </h2>
+            <ds-prop-table
+                :rows="propTableRows"
+                :widths="tableWidths" />
         </div>
 
         <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/src/lib-components/es-radio-button.vue"
             :doc-code="docCode"
             doc-source="es-ds-docs/pages/molecules/radio-button.vue" />
     </div>
@@ -92,14 +86,56 @@ const fruits = ref([
 ]);
 
 const { $prism } = useNuxtApp();
+const compCode = ref('');
 const docCode = ref("");
 
 if ($prism) {
     /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-radio-button.vue?raw');
     const docSource = await import("./radio-button.vue?raw");
     /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
 
+    compCode.value = $prism.normalizeCode(compSource.default);
     docCode.value = $prism.normalizeCode(docSource.default);
     $prism.highlight();
 }
+
+const propTableRows = [
+    [
+        'disabled',
+        'false',
+        'When present, it specifies that the radio button should be disabled.',
+    ],
+    [
+        'inline',
+        'false',
+        'When present, it specifies that the radio buttons should be displayed inline.',
+    ],
+    [
+        'v-model',
+        'n/a',
+        'Required. The v-model directive binds the radio button to a data property.',
+    ],
+    [
+        'display-name',
+        'n/a',
+        'Required. The text to display next to the radio button.',
+    ],
+    [
+        'value',
+        'n/a',
+        'Required. The value to be used by v-model.',
+    ],
+    [
+        'group-name',
+        "''",
+        'Descriptive name of the radio button group. Optional but should be used if multiple groups '
+        + 'use the same v-model.',
+    ],
+];
+
+const tableWidths = {
+    md: ['4', '3', '5'],
+    lg: ['4', '3', '5'],
+};
 </script>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -16,22 +16,18 @@
                 Inline
             </h2>
             <div>
-                <div class="flex flex-wrap gap-3">
-                    <div class="custom-control custom-control-inline custom-radio">
-                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
-                        <label class="custom-control-label" for="fruit1">Apple</label>
-                    </div>
-                    <div class="custom-control custom-control-inline custom-radio">
-                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
-                        <label class="custom-control-label" for="fruit2">Banana</label>
-                    </div>
-                    <div class="custom-control custom-control-inline custom-radio">
-                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
-                        <label class="custom-control-label" for="fruit3">Cherry</label>
-                    </div>
+                <div class="custom-control custom-control-inline custom-radio">
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit1" value="apple" />
+                    <label for="fruit1" class="custom-control-label">Apple</label>
                 </div>
-
-                {{ fruit }}
+                <div class="custom-control custom-control-inline custom-radio">
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit2" value="banana" />
+                    <label for="fruit2" class="custom-control-label">Banana</label>
+                </div>
+                <div class="custom-control custom-control-inline custom-radio">
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit3" value="cherry" />
+                    <label for="fruit3" class="custom-control-label">Cherry</label>
+                </div>
             </div>
         </div>
 
@@ -41,15 +37,15 @@
             </h2>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit1" value="apple" />
                     <label class="custom-control-label" for="fruit1">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit2" value="banana" />
                     <label class="custom-control-label" for="fruit2">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit3" value="cherry" />
                     <label class="custom-control-label" for="fruit3">Cherry</label>
                 </div>
             </div>
@@ -61,15 +57,15 @@
             </h2>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton disabled class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit1" value="apple" />
                     <label class="custom-control-label" for="fruit1">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton disabled class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit2" value="banana" />
                     <label class="custom-control-label" for="fruit2">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" disabled v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
+                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit3" value="cherry" />
                     <label class="custom-control-label" for="fruit3">Cherry</label>
                 </div>
             </div>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -15,6 +15,9 @@
             <h2>
                 Inline
             </h2>
+            <p>
+                Please choose your favorite fruit.
+            </p>
             <div>
                 <div class="custom-control custom-control-inline custom-radio">
                     <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit1" value="apple" />
@@ -35,18 +38,21 @@
             <h2>
                 Stacked
             </h2>
+            <p>
+                Please choose your favorite fruit.
+            </p>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit1" value="apple" />
-                    <label class="custom-control-label" for="fruit1">Apple</label>
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit4" value="apple" />
+                    <label class="custom-control-label" for="fruit4">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit2" value="banana" />
-                    <label class="custom-control-label" for="fruit2">Banana</label>
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit5" value="banana" />
+                    <label class="custom-control-label" for="fruit5">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit3" value="cherry" />
-                    <label class="custom-control-label" for="fruit3">Cherry</label>
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit6" value="cherry" />
+                    <label class="custom-control-label" for="fruit6">Cherry</label>
                 </div>
             </div>
         </div>
@@ -55,18 +61,21 @@
             <h2>
                 Disabled
             </h2>
+            <p>
+                Please choose your favorite fruit.
+            </p>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit1" value="apple" />
-                    <label class="custom-control-label" for="fruit1">Apple</label>
+                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit7" value="apple" />
+                    <label class="custom-control-label" for="fruit7">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit2" value="banana" />
-                    <label class="custom-control-label" for="fruit2">Banana</label>
+                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit8" value="banana" />
+                    <label class="custom-control-label" for="fruit8">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit3" value="cherry" />
-                    <label class="custom-control-label" for="fruit3">Cherry</label>
+                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit9" value="cherry" />
+                    <label class="custom-control-label" for="fruit9">Cherry</label>
                 </div>
             </div>
         </div>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -1,0 +1,100 @@
+<template>
+    <div>
+        <h1>
+            Radio button
+        </h1>
+        <p class="mb-500">
+            Uses <a
+                href="https://v3.primevue.org/radiobutton/"
+                target="_blank">
+                PrimeVue RadioButton
+            </a>
+        </p>
+
+        <div class="my-500">
+            <h2>
+                Inline
+            </h2>
+            <div>
+                <div class="flex flex-wrap gap-3">
+                    <div class="custom-control custom-control-inline custom-radio">
+                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
+                        <label class="custom-control-label" for="fruit1">Apple</label>
+                    </div>
+                    <div class="custom-control custom-control-inline custom-radio">
+                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
+                        <label class="custom-control-label" for="fruit2">Banana</label>
+                    </div>
+                    <div class="custom-control custom-control-inline custom-radio">
+                        <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
+                        <label class="custom-control-label" for="fruit3">Cherry</label>
+                    </div>
+                </div>
+
+                {{ fruit }}
+            </div>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Stacked
+            </h2>
+            <div>
+                <div class="custom-control custom-radio">
+                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
+                    <label class="custom-control-label" for="fruit1">Apple</label>
+                </div>
+                <div class="custom-control custom-radio">
+                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
+                    <label class="custom-control-label" for="fruit2">Banana</label>
+                </div>
+                <div class="custom-control custom-radio">
+                    <RadioButton class="custom-control-input" v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
+                    <label class="custom-control-label" for="fruit3">Cherry</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Disabled
+            </h2>
+            <div>
+                <div class="custom-control custom-radio">
+                    <RadioButton disabled class="custom-control-input" v-model="fruit" inputId="fruit1" name="fruit" value="apple" />
+                    <label class="custom-control-label" for="fruit1">Apple</label>
+                </div>
+                <div class="custom-control custom-radio">
+                    <RadioButton disabled class="custom-control-input" v-model="fruit" inputId="fruit2" name="fruit" value="banana" />
+                    <label class="custom-control-label" for="fruit2">Banana</label>
+                </div>
+                <div class="custom-control custom-radio">
+                    <RadioButton class="custom-control-input" disabled v-model="fruit" inputId="fruit3" name="fruit" value="cherry" />
+                    <label class="custom-control-label" for="fruit3">Cherry</label>
+                </div>
+            </div>
+        </div>
+
+        <ds-doc-source
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/radio-button.vue" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const fruit = ref('');
+
+const { $prism } = useNuxtApp();
+const docCode = ref("");
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const docSource = await import("./radio-button.vue?raw");
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -20,13 +20,13 @@
             </p>
             <div>
                 <div v-for="fruit in fruits" class="custom-control custom-control-inline custom-radio">
-                    <RadioButton
+                    <radio-button
                         class="custom-control-input"
-                        inputClass="custom-radio-input"
+                        input-class="custom-radio-input"
                         v-model="selectedFruit"
-                        :inputId="`${fruit.key}-inline`"
+                        :input-id="`${fruit.key}-inline`"
                         name="inline"
-                        :value="fruit.name" />
+                        :value="fruit.key" />
                     <label :for="`${fruit.key}-inline`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
@@ -41,13 +41,13 @@
             </p>
             <div>
                 <div v-for="fruit in fruits" class="custom-control custom-radio">
-                    <RadioButton
+                    <radio-button
                         class="custom-control-input"
-                        inputClass="custom-radio-input"
+                        input-class="custom-radio-input"
                         v-model="selectedFruit"
-                        :inputId="`${fruit.key}-stacked`"
+                        :input-id="`${fruit.key}-stacked`"
                         name="stacked"
-                        :value="fruit.name" />
+                        :value="fruit.key" />
                     <label :for="`${fruit.key}-stacked`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
@@ -62,14 +62,14 @@
             </p>
             <div>
                 <div v-for="fruit in fruits" class="custom-control custom-radio">
-                    <RadioButton
+                    <radio-button
                         disabled
                         class="custom-control-input"
-                        inputClass="custom-radio-input"
+                        input-class="custom-radio-input"
                         v-model="selectedFruit"
-                        :inputId="`${fruit.key}-disabled`"
+                        :input-id="`${fruit.key}-disabled`"
                         name="disabled"
-                        :value="fruit.name" />
+                        :value="fruit.key" />
                     <label :for="`${fruit.key}-disabled`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
@@ -84,7 +84,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-const selectedFruit = ref('');
+const selectedFruit = ref('banana');
 const fruits = ref([
     { name: 'Apple', key: 'apple' },
     { name: 'Banana', key: 'banana' },

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -17,15 +17,15 @@
             </h2>
             <div>
                 <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit1" value="apple" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit1" value="apple" />
                     <label for="fruit1" class="custom-control-label">Apple</label>
                 </div>
                 <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit2" value="banana" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit2" value="banana" />
                     <label for="fruit2" class="custom-control-label">Banana</label>
                 </div>
                 <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit3" value="cherry" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit3" value="cherry" />
                     <label for="fruit3" class="custom-control-label">Cherry</label>
                 </div>
             </div>
@@ -37,15 +37,15 @@
             </h2>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit1" value="apple" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit1" value="apple" />
                     <label class="custom-control-label" for="fruit1">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit2" value="banana" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit2" value="banana" />
                     <label class="custom-control-label" for="fruit2">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" v-model="fruit" inputId="fruit3" value="cherry" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit3" value="cherry" />
                     <label class="custom-control-label" for="fruit3">Cherry</label>
                 </div>
             </div>
@@ -57,15 +57,15 @@
             </h2>
             <div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit1" value="apple" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit1" value="apple" />
                     <label class="custom-control-label" for="fruit1">Apple</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit2" value="banana" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit2" value="banana" />
                     <label class="custom-control-label" for="fruit2">Banana</label>
                 </div>
                 <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-wrapper" inputClass="custom-control-input" disabled v-model="fruit" inputId="fruit3" value="cherry" />
+                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" disabled v-model="fruit" inputId="fruit3" value="cherry" />
                     <label class="custom-control-label" for="fruit3">Cherry</label>
                 </div>
             </div>

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -86,9 +86,9 @@ import { ref } from 'vue';
 
 const selectedFruit = ref('');
 const fruits = ref([
-    { name: 'Apple', key: 'A' },
-    { name: 'Banana', key: 'M' },
-    { name: 'Cherry', key: 'P' },
+    { name: 'Apple', key: 'apple' },
+    { name: 'Banana', key: 'banana' },
+    { name: 'Cherry', key: 'cherry' },
 ]);
 
 const { $prism } = useNuxtApp();

--- a/es-ds-docs/pages/molecules/radio-button.vue
+++ b/es-ds-docs/pages/molecules/radio-button.vue
@@ -19,17 +19,15 @@
                 Please choose your favorite fruit.
             </p>
             <div>
-                <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit1" value="apple" />
-                    <label for="fruit1" class="custom-control-label">Apple</label>
-                </div>
-                <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit2" value="banana" />
-                    <label for="fruit2" class="custom-control-label">Banana</label>
-                </div>
-                <div class="custom-control custom-control-inline custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit3" value="cherry" />
-                    <label for="fruit3" class="custom-control-label">Cherry</label>
+                <div v-for="fruit in fruits" class="custom-control custom-control-inline custom-radio">
+                    <RadioButton
+                        class="custom-control-input"
+                        inputClass="custom-radio-input"
+                        v-model="selectedFruit"
+                        :inputId="`${fruit.key}-inline`"
+                        name="inline"
+                        :value="fruit.name" />
+                    <label :for="`${fruit.key}-inline`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
         </div>
@@ -42,17 +40,15 @@
                 Please choose your favorite fruit.
             </p>
             <div>
-                <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit4" value="apple" />
-                    <label class="custom-control-label" for="fruit4">Apple</label>
-                </div>
-                <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit5" value="banana" />
-                    <label class="custom-control-label" for="fruit5">Banana</label>
-                </div>
-                <div class="custom-control custom-radio">
-                    <RadioButton class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit6" value="cherry" />
-                    <label class="custom-control-label" for="fruit6">Cherry</label>
+                <div v-for="fruit in fruits" class="custom-control custom-radio">
+                    <RadioButton
+                        class="custom-control-input"
+                        inputClass="custom-radio-input"
+                        v-model="selectedFruit"
+                        :inputId="`${fruit.key}-stacked`"
+                        name="stacked"
+                        :value="fruit.name" />
+                    <label :for="`${fruit.key}-stacked`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
         </div>
@@ -65,17 +61,16 @@
                 Please choose your favorite fruit.
             </p>
             <div>
-                <div class="custom-control custom-radio">
-                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit7" value="apple" />
-                    <label class="custom-control-label" for="fruit7">Apple</label>
-                </div>
-                <div class="custom-control custom-radio">
-                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit8" value="banana" />
-                    <label class="custom-control-label" for="fruit8">Banana</label>
-                </div>
-                <div class="custom-control custom-radio">
-                    <RadioButton disabled class="custom-control-input" inputClass="custom-radio-input" v-model="fruit" inputId="fruit9" value="cherry" />
-                    <label class="custom-control-label" for="fruit9">Cherry</label>
+                <div v-for="fruit in fruits" class="custom-control custom-radio">
+                    <RadioButton
+                        disabled
+                        class="custom-control-input"
+                        inputClass="custom-radio-input"
+                        v-model="selectedFruit"
+                        :inputId="`${fruit.key}-disabled`"
+                        name="disabled"
+                        :value="fruit.name" />
+                    <label :for="`${fruit.key}-disabled`" class="custom-control-label">{{ fruit.name }}</label>
                 </div>
             </div>
         </div>
@@ -89,7 +84,12 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-const fruit = ref('');
+const selectedFruit = ref('');
+const fruits = ref([
+    { name: 'Apple', key: 'A' },
+    { name: 'Banana', key: 'M' },
+    { name: 'Cherry', key: 'P' },
+]);
 
 const { $prism } = useNuxtApp();
 const docCode = ref("");


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1753

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Globally styles PrimeVue radio buttons to match the [custom styling done for viz id on BFormGroup and BFormRadioGroup radio buttons](https://design.energysage.dev/molecules/radio-button) and created a “Radio button” molecule docs page 

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested inline, stacked, and disabled radio button groups with focus and hover states locally at http://localhost:8500/molecules/radio-button

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I attempted to avoid regressions by adding new classes, is the resulting css too complicated? In addition, `has` is a relatively [new css feature](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) and may not be supported by older devices or browsers.
- `PrimeVue RadioButton` is a tad finicky and will not work if any props vary from the example, should a component `EsRadioButton` be created to deal with the classes and props necessary to get `PrimeVue RadioButton` working as expected?
- Should `ariaLabel` be added?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
