### PR TITLE
feat: EsProgress molecule for es-ds 3.0

### DIFF
--- a/es-ds-components/components/es-progress.vue
+++ b/es-ds-components/components/es-progress.vue
@@ -1,0 +1,36 @@
+<template>
+    <ProgressBar
+        aria-describedby="es-progress"
+        class="bg-gray-200 rounded-0"
+        :pt="progressBarPt"
+        :showValue="showValue"
+        :value="value"
+        v-bind="$attrs">
+    </ProgressBar>
+</template>
+<script setup lang="ts">
+import ProgressBar from 'primevue/progressbar';
+const props = defineProps({
+    value: {
+        type: Number,
+        required: true,
+    },
+    height: {
+        type: String,
+        default: '0.3125rem',
+    },
+    showValue: {
+        type: Boolean,
+        default: false,
+    },
+});
+const progressBarPt = {
+    value: {
+                class: 'EsProgressValue progress-bar',
+                style: {
+                    height: props.height,
+                    borderRadius: props.value === 100 ? '0' : '0 0.125rem 0.125rem 0',
+                },
+            },
+};
+</script>

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -15,5 +15,10 @@
                 Radio button
             </ds-link>
         </li>
+        <li>
+            <ds-link to="/molecules/progress">
+                Progress
+            </ds-link>
+        </li>
     </ul>
 </template>

--- a/es-ds-docs/pages/molecules/progress.vue
+++ b/es-ds-docs/pages/molecules/progress.vue
@@ -1,0 +1,83 @@
+<template>
+    <div>
+        <h1>
+            Progress
+        </h1>
+        <p class="pb-200">
+            Extended from <nuxt-link
+                href="https://v3.primevue.org/progressbar/"
+                target="_blank">
+                primevue progress
+            </nuxt-link>
+        </p>
+        <h2>
+            Three Steps
+        </h2>
+        <div class="mb-100">
+            <es-progress :value="0" />
+        </div>
+        <div class="mb-100">
+            <es-progress :value="33" />
+        </div>
+        <div class="mb-100">
+            <es-progress :value="67" />
+        </div>
+        <div class="mb-100">
+            <es-progress :value="100" />
+        </div>
+        <h2>
+            Animated Transition
+        </h2>
+        <div class="mb-100">
+            <es-progress :value="value" />
+        </div>
+        <div class="mb-100">
+            <es-button
+                class="px-50"
+                size="sm"
+                @click="value = Math.max(value - 20, 0)">
+                <icon-minus
+                    height="16px"
+                    width="16px" />
+                <span class="sr-only">Remove</span>
+                20%
+            </es-button>
+            <es-button
+                class="px-50"
+                size="sm"
+                @click="value = Math.min(value + 20, 100)">
+                <icon-plus
+                    height="16px"
+                    width="16px" />
+                <span class="sr-only">Add</span>
+                20%
+            </es-button>
+        </div>
+        <p class="mb-300">
+            value: {{ value }}
+        </p>
+       <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/src/lib-components/es-progress.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/es-progress.vue" />
+    </div>
+</template>
+
+<script setup lang='ts'>
+const value = ref(20);
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-progress.vue?raw');
+    const docSource = await import('./progress.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    compCode.value = $prism.normalizeCode(compSource.default);
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-1750

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Created progress molecule for es-ds 3.0
- Created es-progress component based on es-ds 2.0 - used pass through to fix style issues
- Added progress link to ds-molecules-list.vue

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested the changes on http://localhost:8500/molecules/progress

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I moved `progressBarPt` to the `script` to better handle the pass-through logic and keep the template clean. Does that work?
- I am waiting on approval of [PR](https://github.com/EnergySage/es-ds/pull/1473) to incorporate es-button for "Animated Transition", does that work?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
