### PR TITLE
fix: added EsLazyYoutube to play video on single click

### DIFF
--- a/es-vue-base/src/lib-components/EsVideo.vue
+++ b/es-vue-base/src/lib-components/EsVideo.vue
@@ -134,19 +134,10 @@ export default ({
     width: 100% !important;
 }
 
-.y-video__button {
-    padding-bottom: 0 !important;
-}
-
 .y-video__media {
-    //position: relative !important;
     height: 800px !important;
     padding-bottom: 0 !important;
     width: 800px !important;
-}
-.movie_player {
-    padding-bottom: 0 !important;
-    //object-fit: cover !important;
 }
 
 .html5-video-player {

--- a/es-vue-base/src/lib-components/EsVideo.vue
+++ b/es-vue-base/src/lib-components/EsVideo.vue
@@ -1,15 +1,21 @@
 <template>
-    <div>
-        <b-embed
+    <div class="EsLazyYoutube">
+        <es-card
             v-if="showVideo"
-            allowfullscreen
-            aspect="16by9"
-            :src="autoplayUrl"
-            :title="altText"
-            type="iframe" />
+            class="EsLazyYoutube-button bg-transparent overflow-hidden p-0 position-relative w-100"
+            variant="interactive">
+            <LazyYoutubeVideo
+                allowfullscreen
+                ref="lazyYoutube"
+                autoplay="true"
+                class="pb-0 EsLazyYoutube-restrict w-100 h-100"
+                :style="videoStyles"
+                :src="autoplayUrl"
+                :title="altText" />
+        </es-card>
         <es-card
             v-else
-            class="EsVideo-button bg-transparent overflow-hidden p-0 position-relative w-100"
+            class="EsLazyYoutube-button bg-transparent overflow-hidden p-0 position-relative w-100"
             variant="interactive"
             @click="showVideo = true">
             <slot
@@ -19,10 +25,10 @@
                 v-else-if="coverImageUrl"
                 :alt="altText"
                 sizes="md:530px sm:275px"
-                class="EsVideo-image d-block w-100"
+                class="EsLazyYoutube-image d-block w-100"
                 :src="coverImageUrl" />
             <icon-video-play
-                class="EsVideo-icon position-absolute"
+                class="EsLazyYoutube-icon position-absolute"
                 width="74px"
                 height="54px" />
         </es-card>
@@ -30,17 +36,19 @@
 </template>
 
 <script lang="js">
-import { BImg, BEmbed } from 'bootstrap-vue';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import LazyYoutubeVideo from 'vue-lazy-youtube-video';
+import { BImg } from 'bootstrap-vue';
 import EsCard from './EsCard.vue';
 import IconVideoPlay from '../lib-icons/icon-video-play.vue';
 
 export default ({
-    name: 'EsVideo',
+    name: 'EsLazyYoutube',
     components: {
         BImg,
-        BEmbed,
         EsCard,
         IconVideoPlay,
+        LazyYoutubeVideo,
     },
     props: {
         altText: {
@@ -72,22 +80,85 @@ export default ({
             // but requires that the video owner upload non-auto-generated captions
             return `${pieces[0]}?rel=0&autoplay=1&cc_load_policy=1&cc_lang_pref=en`;
         },
+        videoStyles() {
+            return {
+                position: 'relative',
+                paddingBottom: '0 !important',
+                height: '100%',
+                width: '100%',
+            };
+        },
     },
+    // eslint-disable-next-line max-len, no-param-reassign
+    watch: { showVideo(val) { if (val) { this.$nextTick(() => { const videoInner = this.$refs.lazyYoutube.$el.querySelector('.y-video__inner'); if (videoInner) { videoInner.style.paddingBottom = '0'; const observer = new MutationObserver((mutations) => { mutations.forEach((mutation) => { if (mutation.attributeName === 'style') { mutation.target.style.paddingBottom = '0'; } }); }); observer.observe(videoInner, { attributes: true }); } }); } } },
 });
 </script>
 
 <style lang="scss" scoped>
-.EsVideo {
-    &-button,
-    &-image {
-        height: auto;
+.EsLazyYoutube {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    &-button {
+        height: 100%;
+        padding-bottom: 0 !important;
+        position: relative;
+        width: 100%;
     }
 
     &-icon {
         left: 50%;
+        padding-bottom: 0 !important;
         top: 50%;
         transform: translateX(-50%) translateY(-50%);
         z-index: 2;
     }
+    &-image,
+    &-restrict
+    &-iframe,
+    iframe
+    {
+        height: 100% !important;
+        left: 0 !important;
+        //object-fit: cover !important;
+        padding-bottom: 0 !important;
+        position: relative !important;
+        top: 0 !important;
+        width: 100% !important;
+    }
 }
+.y-video__inner {
+    height: 100% !important;
+    position: relative !important;
+    padding-bottom: 0 !important;
+    width: 100% !important;
+}
+
+.y-video__button {
+    padding-bottom: 0 !important;
+}
+
+.y-video__media {
+    //position: relative !important;
+    height: 800px !important;
+    padding-bottom: 0 !important;
+    width: 800px !important;
+}
+.movie_player {
+    padding-bottom: 0 !important;
+    //object-fit: cover !important;
+}
+
+.html5-video-player {
+    height: 800px !important;
+    padding-bottom: 0 !important;
+    width: 800px !important;
+}
+
+.movie_player {
+    height: 800px !important;
+    padding-bottom: 0 !important;
+    width: 800px !important;
+}
+
 </style>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-1628

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added [LazyYoutubeVideo](https://www.npmjs.com/package/vue-lazy-youtube-video?activeTab=readme) to enable video play on a single click. 

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested the changes on http://localhost:8500/molecules/es-video

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

#### Pending
- Fix the height and width of the video in the `es-card`. 


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach