### PR TITLE
feat: added EsTabs wrapper component for PrimeVue TabView

### DIFF
--- a/es-ds-components/components/es-tab.vue
+++ b/es-ds-components/components/es-tab.vue
@@ -1,0 +1,6 @@
+<template>
+    <!--
+    While this file needs to exist to keep Nuxt happy, it doesn't actually do anything.
+    Instances of es-tab are placed inside es-tabs, and es-tabs handles their display.
+    -->
+</template>

--- a/es-ds-components/components/es-tabs.vue
+++ b/es-ds-components/components/es-tabs.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import TabPanel from 'primevue/tabpanel';
+import TabView from 'primevue/tabview';
+
+// allow use of v-model on this component
+const model = defineModel();
+
+// get the list of elements provided as children to the default slot
+const panels = useSlots().default?.() || [];
+
+// keep track of the active tab index
+//  - from above, if v-model is used
+//  - from below, if the tab component receives a click
+const activeIndex = ref(0);
+
+// watch the v-model for changes and update the active index if it does change
+watch(model, (newVal) => {
+    activeIndex.value = newVal;
+});
+
+// called from the TabView when the user clicks a tab to make it active
+const updateActiveIndex = (index) => {
+    model.value = index;
+};
+</script>
+
+<template>
+    <tab-view
+        :active-index="activeIndex"
+        @update:active-index="updateActiveIndex"
+        :pt="{
+            root: 'tabs es-tabs',
+            nav: 'list-unstyled nav position-relative',
+            tab: 'nav-link',
+            inkbar: 'inkbar position-absolute',
+            panelContainer: 'tab-content'
+        }">
+        <tab-panel
+            v-for="(panel, index) in panels"
+            :key="index"
+            :header="panel.props.title"
+            :pt="{
+                header: 'nav-item',
+                headerAction: ({ context }) => ({
+                    class: [
+                        'nav-link',
+                        {
+                            'active active-tab font-weight-bolder': context.active,
+                        },
+                    ],
+                }),
+                content: ({ context }) => ({
+                    class: [
+                        'tab-pane mt-100',
+                        {
+                            'active': context.active
+                        }
+                    ]
+                })
+            }">
+            <component v-for="item in panel.children.default()" :is="item" />
+        </tab-panel>
+    </tab-view>
+</template>

--- a/es-ds-components/nuxt.config.ts
+++ b/es-ds-components/nuxt.config.ts
@@ -63,6 +63,8 @@ export default defineNuxtConfig({
                 "primevue/progressbar",
                 "primevue/radiobutton",
                 "primevue/rating",
+                "primevue/tabpanel",
+                "primevue/tabview",
             ]
         }
     }

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -76,6 +76,11 @@
             </ds-link>
         </li>
         <li>
+            <ds-link to="/molecules/tabs">
+                Tabs
+            </ds-link>
+        </li>
+        <li>
             <ds-link to="/molecules/form-input">
                 Text input
             </ds-link>

--- a/es-ds-docs/pages/molecules/tabs.vue
+++ b/es-ds-docs/pages/molecules/tabs.vue
@@ -1,0 +1,150 @@
+<script setup>
+const tabIndexProgrammatic = ref(0);
+
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-tabs.vue?raw');
+    const docSource = await import('./tabs.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    compCode.value = $prism.normalizeCode(compSource.default);
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+</script>
+
+<template>
+    <div>
+        <h1>
+            Tabs
+        </h1>
+        <p>
+            Extended from <a
+                href="https://v3.primevue.org/tabview/"
+                target="_blank">
+                PrimeVue TabView
+            </a>
+        </p>
+        <p>
+            Per our writing guidelines, please ensure the title is in
+            <a
+                href="https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case"
+                target="_blank">
+                Sentence case.
+            </a>
+        </p>
+
+        <div class="my-500">
+            <h2>
+                Basic example
+            </h2>
+            <es-tabs>
+                <es-tab title="Item one">
+                    <p>
+                        Content one
+                    </p>
+                </es-tab>
+                <es-tab title="Item two">
+                    <p>
+                        Content two
+                    </p>
+                </es-tab>
+                <es-tab title="Item three">
+                    <p>
+                        Content three
+                    </p>
+                </es-tab>
+                <es-tab title="Item four">
+                    <p>
+                        Content four
+                    </p>
+                </es-tab>
+            </es-tabs>
+        </div>
+
+        <div class="my-500">
+            <h2>
+                Using v-model
+            </h2>
+            <p>
+                If you need to select tabs programmatically or trigger a UI change elsewhere when a
+                tab is selected, you can use the <code>v-model</code> directive to bind the
+                active index to a data value.
+            </p>
+            <div class="mb-100">
+                <es-button
+                    class="mb-50 mr-50"
+                    :disabled="tabIndexProgrammatic === 0"
+                    @click="tabIndexProgrammatic = 0">
+                    Select tab one
+                </es-button>
+                <es-button
+                    class="mb-50 mr-50"
+                    :disabled="tabIndexProgrammatic === 1"
+                    @click="tabIndexProgrammatic = 1">
+                    Select tab two
+                </es-button>
+                <es-button
+                    class="mb-50"
+                    :disabled="tabIndexProgrammatic === 2"
+                    @click="tabIndexProgrammatic = 2">
+                    Select tab three
+                </es-button>
+            </div>
+            <b-row>
+                <b-col
+                    cols="12"
+                    lg="8">
+                    <es-tabs
+                        v-model="tabIndexProgrammatic"
+                        class="mb-200">
+                        <es-tab title="Item one">
+                            <p>
+                                Content one
+                            </p>
+                        </es-tab>
+                        <es-tab title="Item two">
+                            <p>
+                                Content two
+                            </p>
+                        </es-tab>
+                        <es-tab title="Item three">
+                            <p>
+                                Content three
+                            </p>
+                        </es-tab>
+                    </es-tabs>
+                </b-col>
+                <b-col
+                    cols="12"
+                    lg="4">
+                    <div
+                        v-if="tabIndexProgrammatic === 0"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 1
+                    </div>
+                    <div
+                        v-if="tabIndexProgrammatic === 1"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 2
+                    </div>
+                    <div
+                        v-if="tabIndexProgrammatic === 2"
+                        class="bg-gray-300 p-200 rounded-lg text-center">
+                        Content associated with tab 3
+                    </div>
+                </b-col>
+            </b-row>
+        </div>
+
+        <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/components/es-tabs.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/tabs.vue" />
+    </div>
+</template>

--- a/es-ds-styles/scss/vue/components/_tabs.scss
+++ b/es-ds-styles/scss/vue/components/_tabs.scss
@@ -3,19 +3,19 @@
 
 .es-tabs {
   .nav {
-      border-bottom: var(--border-bottom);
-      border-color: v.$gray-300;
+      border-bottom: 1px solid v.$gray-300;
   }
 
   .nav-item {
-      margin-bottom: 0;
+      margin: 0 2rem 0 0;
   }
 
   .nav-link {
       color: v.$gray-900;
+      cursor: pointer;
       font-weight: v.$font-weight-normal;
-      margin: 0 2rem -2px;
       padding: 0.25rem 0 0.5rem 0;
+      user-select: none;
 
       &:first-child {
           margin-left: 0;
@@ -29,8 +29,6 @@
   }
 
   .active-tab {
-      border-bottom: 2px solid;
-      border-color: v.$blue-500;
       color: v.$blue-500;
       pointer-events: none;
 
@@ -38,5 +36,11 @@
       &:focus {
           color: v.$blue-500;
       }
+  }
+
+  .inkbar {
+    border-bottom: 2px solid v.$blue-500;
+    bottom: -2px;
+    transition: 250ms cubic-bezier(0.35, 0, 0.25, 1);
   }
 }


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1757

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added EsTabs and EsTab component - had to follow the EsAccordionList pattern of referencing children in the slot directly
- Added Tabs docs page
- Customized tabs styling to work with PrimeVue's TabView
- Tabs now have a nice animation on the active inkbar

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on the docs page

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
