### PR TITLE
feat: updated default layout to match normal max width; created fullWidthComponent layout for edge cases

### DIFF
--- a/es-ds-docs/layouts/default.vue
+++ b/es-ds-docs/layouts/default.vue
@@ -1,24 +1,22 @@
 <template>
-    <div>
-        <div class="d-flex justify-content-center">
-            <div class="ds-side-nav d-none d-xl-block flex-shrink-0 p-100">
-                <ds-link-list />
-            </div>
-            <b-container class="pt-xl-100 mx-0">
-                <b-row class="mb-100">
-                    <b-col cols="12">
+    <div class="d-flex justify-content-center">
+        <b-container class="pt-100 mx-0">
+            <b-row>
+                <b-col class="d-none d-xl-block" xl="3">
+                    <div class="ds-side-nav flex-shrink-0">
+                        <ds-link-list />
+                    </div>
+                </b-col>
+                <b-col xl="9">
+                    <div class="mb-100">
                         <es-breadcrumbs :items="breadcrumbs" />
-                    </b-col>
-                </b-row>
-                <b-row>
-                    <b-col
-                        class="mb-300"
-                        cols="12">
+                    </div>
+                    <div class="mb-300">
                         <slot />
-                    </b-col>
-                </b-row>
-            </b-container>
-        </div>
+                    </div>
+                </b-col>
+            </b-row>
+        </b-container>
     </div>
 </template>
 

--- a/es-ds-docs/layouts/fullWidthComponent.vue
+++ b/es-ds-docs/layouts/fullWidthComponent.vue
@@ -1,0 +1,53 @@
+<template>
+    <!--
+        use this layout only for components that are meant to appear at full page width,
+        and therefore need more horizontal space than 9 columns on large desktop
+        to showcase what it will look like on a real page
+    -->
+    <div>
+        <div class="d-flex justify-content-center">
+            <div class="ds-side-nav d-none d-xl-block flex-shrink-0 p-100">
+                <ds-link-list />
+            </div>
+            <b-container class="pt-xl-100 mx-0">
+                <b-row class="mb-100">
+                    <b-col cols="12">
+                        <es-breadcrumbs :items="breadcrumbs" />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col
+                        class="mb-300"
+                        cols="12">
+                        <slot />
+                    </b-col>
+                </b-row>
+            </b-container>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const route = useRoute();
+
+const breadcrumbs = computed(() => {
+    let pathSoFar = '';
+    const paths = route.path.split('/');
+
+    // Set removes dupes from path
+    return [...new Set(paths)].map((path) => {
+        pathSoFar += path ? `/${path}` : '';
+
+        let text = 'Home';
+        // Convert to CamelCase to be in line with component naming
+        if (path) {
+            text = path.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+            text = text[0].toUpperCase() + text.slice(1);
+        }
+        return {
+            text,
+            to: pathSoFar || '/',
+        };
+    });
+});
+</script>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- In order to better be a showcase and example for all EnergySage teams on how our layout and max-width container works, most pages on the design system site should adhere to our own max width container conventions
- When I originally added the side nav at larger breakpoints, I deliberately broke it out of the container so that the organisms that are intended to render at full width (e.g. CTA banner, support card) are able to be previewed in a manner like how they're supposed to appear on a page - however there are a limited number of these edge cases such that this behavior should not be the default layout - I've restored the default layout to a normal max width container and preserved the container breakout of the side nav in the fullWidthComponent layout for use when we build those organism pages
- Also fixed top padding on mobile

### Before
<img width="1423" alt="Screen Shot 2024-08-29 at 3 04 47 PM" src="https://github.com/user-attachments/assets/33dba21a-4dfd-4f26-8dbb-3ed50c8ebcbc">

### After
<img width="1419" alt="Screen Shot 2024-08-29 at 3 04 59 PM" src="https://github.com/user-attachments/assets/4bbd187f-cda3-4859-b3b8-dd8a572e0fb7">

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
