### PR TITLE
feat: add EsFormTextarea v3

### DIFF
--- a/es-ds-components/components/es-form-textarea.vue
+++ b/es-ds-components/components/es-form-textarea.vue
@@ -29,14 +29,6 @@ const props = defineProps({
         required: true,
     },
     /**
-     * modelValue
-     */
-    modelValue: {
-        type: String,
-        required: true,
-        default: '',
-    },
-    /**
      * state
      */
     state: {
@@ -44,20 +36,7 @@ const props = defineProps({
         default: null,
     },
 });
-
-const emit = defineEmits(['update:modelValue']);
-const localValue = ref(props.modelValue);
-// Watch for changes to the local value and emit them
-watch(localValue, (newValue) => {
-    emit('update:modelValue', newValue);
-});
-// Watch for prop changes and update the local value
-watch(
-    () => props.modelValue,
-    (newValue) => {
-        localValue.value = newValue;
-    },
-);
+const model = defineModel<string>();
 
 const slots = useSlots();
 
@@ -69,15 +48,15 @@ const hasError = () => !!slots.errorMessage;
 <template>
     <div
         class="input-wrapper justify-content-end"
-        :required="required">
+        :required="props.required">
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
-            :for="id"
+            :for="props.id"
             class="label justify-content-start">
             <slot name="label" />
 
             <span
-                v-if="required"
+                v-if="props.required"
                 class="text-danger">
                 *
             </span>
@@ -85,27 +64,28 @@ const hasError = () => !!slots.errorMessage;
 
         <div class="input-holder">
             <textarea
-                :id="id"
-                v-model="localValue"
+                :id="props.id"
+                v-model="model"
+                v-bind="$attrs"
                 class="es-form-textarea w-100 form-control"
-                :class="{ 'is-invalid': state === false }"
-                :disabled="disabled"
-                :invalid="state === false" />
+                :class="{ 'is-invalid': props.state === false }"
+                :disabled="props.disabled"
+                :invalid="props.state === false" />
             <small
-                v-if="hasMessage() && ((!hasSuccess() && state) || state == null)"
+                v-if="hasMessage() && ((!hasSuccess() && props.state) || props.state == null)"
                 class="text-muted">
                 <slot name="message" />
             </small>
             <small
-                v-if="state === false && (hasError() || required)"
+                v-if="props.state === false && (hasError() || props.required)"
                 class="text-danger">
                 <slot
                     v-if="hasError()"
                     name="errorMessage" />
-                <template v-else-if="required"> This field is required. </template>
+                <template v-else-if="props.required"> This field is required. </template>
             </small>
             <small
-                v-if="state && hasSuccess()"
+                v-if="props.state && hasSuccess()"
                 class="text-success">
                 <slot name="successMessage" />
             </small>
@@ -125,7 +105,6 @@ const hasError = () => !!slots.errorMessage;
     border: 0;
 }
 
-// TODO: Move to es-bs-base
 .is-invalid {
     color: variables.$danger;
 }

--- a/es-ds-components/components/es-form-textarea.vue
+++ b/es-ds-components/components/es-form-textarea.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import Textarea from 'primevue/textarea';
+
+// Prevents attributes from being applied to first <div>
+// v-bind="$attr" is on the input instead
+defineOptions({
+    inheritAttrs: false,
+});
+
+const props = defineProps({
+    /**
+     * Required
+     */
+    required: {
+        type: Boolean,
+        default: false,
+    },
+    /**
+     * Disabled
+     */
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
+    /**
+     * ID
+     * required
+     */
+    id: {
+        type: String,
+        required: true,
+    },
+    /**
+     * modelValue
+     */
+    modelValue: {
+        type: String,
+        required: true,
+        default: "",
+    },
+    /**
+     * state
+     */
+    state: {
+        type: [Boolean, null],
+        default: null,
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const localValue = ref(props.modelValue);
+// Watch for changes to the local value and emit them
+watch(localValue, (newValue) => {
+    emit('update:modelValue', newValue);
+});
+// Watch for prop changes and update the local value
+watch(() => props.modelValue, (newValue) => {
+    localValue.value = newValue;
+});
+
+const slots = useSlots();
+
+const hasSuccess = () => !!slots.successMessage;
+const hasMessage = () => !!slots.message;
+const hasError = () => !!slots.errorMessage;
+</script>
+
+<template>
+    <div
+        class="input-wrapper justify-content-end"
+        :required="required">
+        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+        <label
+            :for="id"
+            class="label justify-content-start">
+            <slot name="label" />
+
+            <span
+                v-if="required"
+                class="text-danger">
+                *
+            </span>
+        </label>
+
+        <div class="input-holder">
+            <Textarea
+                class="es-form-textarea w-100 form-control"
+                :class="{ 'is-invalid': state === false }"
+                v-model="localValue"
+                :id="id"
+                :disabled="disabled"
+                :invalid="state === false" />
+            <small
+                v-if="hasMessage() && ((!hasSuccess() && state) || state == null)"
+                class="text-muted">
+                <slot name="message" />
+            </small>
+            <small
+                v-if="state === false && (hasError() || required)"
+                class="text-danger">
+                <slot
+                    v-if="hasError()"
+                    name="errorMessage" />
+                <template v-else-if="required"> This field is required. </template>
+            </small>
+            <small
+                v-if="state && hasSuccess()"
+                class="text-success">
+                <slot name="successMessage" />
+            </small>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables' as variables;
+
+.es-form-textarea {
+    min-height: 8.125rem;
+}
+
+.es-form-textarea:disabled,
+.es-form-textarea[readonly] {
+    border: 0;
+}
+
+// TODO: Move to es-bs-base
+.is-invalid {
+    color: variables.$danger;
+}
+
+.form-inline .input-wrapper {
+    display: flex;
+    flex: 0 0 100%;
+
+    label {
+        flex: 0 0 30%;
+    }
+
+    .input-holder {
+        flex: 0 0 70%;
+    }
+}
+</style>

--- a/es-ds-components/components/es-form-textarea.vue
+++ b/es-ds-components/components/es-form-textarea.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import Textarea from 'primevue/textarea';
 
 // Prevents attributes from being applied to first <div>
 // v-bind="$attr" is on the input instead
@@ -83,7 +82,7 @@ const hasError = () => !!slots.errorMessage;
         </label>
 
         <div class="input-holder">
-            <Textarea
+            <textarea
                 class="es-form-textarea w-100 form-control"
                 :class="{ 'is-invalid': state === false }"
                 v-model="localValue"

--- a/es-ds-components/components/es-form-textarea.vue
+++ b/es-ds-components/components/es-form-textarea.vue
@@ -5,7 +5,7 @@ defineOptions({
     inheritAttrs: false,
 });
 
-const props = defineProps({
+defineProps({
     /**
      * Required
      */
@@ -48,15 +48,15 @@ const hasError = () => !!slots.errorMessage;
 <template>
     <div
         class="input-wrapper justify-content-end"
-        :required="props.required">
+        :required="required">
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
         <label
-            :for="props.id"
+            :for="id"
             class="label justify-content-start">
             <slot name="label" />
 
             <span
-                v-if="props.required"
+                v-if="required"
                 class="text-danger">
                 *
             </span>
@@ -64,28 +64,28 @@ const hasError = () => !!slots.errorMessage;
 
         <div class="input-holder">
             <textarea
-                :id="props.id"
+                :id="id"
                 v-model="model"
                 v-bind="$attrs"
                 class="es-form-textarea w-100 form-control"
-                :class="{ 'is-invalid': props.state === false }"
-                :disabled="props.disabled"
-                :invalid="props.state === false" />
+                :class="{ 'is-invalid': state === false }"
+                :disabled="disabled"
+                :invalid="state === false" />
             <small
-                v-if="hasMessage() && ((!hasSuccess() && props.state) || props.state == null)"
+                v-if="hasMessage() && ((!hasSuccess() && state) || state == null)"
                 class="text-muted">
                 <slot name="message" />
             </small>
             <small
-                v-if="props.state === false && (hasError() || props.required)"
+                v-if="state === false && (hasError() || required)"
                 class="text-danger">
                 <slot
                     v-if="hasError()"
                     name="errorMessage" />
-                <template v-else-if="props.required"> This field is required. </template>
+                <template v-else-if="required"> This field is required. </template>
             </small>
             <small
-                v-if="props.state && hasSuccess()"
+                v-if="state && hasSuccess()"
                 class="text-success">
                 <slot name="successMessage" />
             </small>

--- a/es-ds-components/components/es-form-textarea.vue
+++ b/es-ds-components/components/es-form-textarea.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-
 // Prevents attributes from being applied to first <div>
 // v-bind="$attr" is on the input instead
 defineOptions({
@@ -35,7 +34,7 @@ const props = defineProps({
     modelValue: {
         type: String,
         required: true,
-        default: "",
+        default: '',
     },
     /**
      * state
@@ -53,9 +52,12 @@ watch(localValue, (newValue) => {
     emit('update:modelValue', newValue);
 });
 // Watch for prop changes and update the local value
-watch(() => props.modelValue, (newValue) => {
-    localValue.value = newValue;
-});
+watch(
+    () => props.modelValue,
+    (newValue) => {
+        localValue.value = newValue;
+    },
+);
 
 const slots = useSlots();
 
@@ -83,10 +85,10 @@ const hasError = () => !!slots.errorMessage;
 
         <div class="input-holder">
             <textarea
+                :id="id"
+                v-model="localValue"
                 class="es-form-textarea w-100 form-control"
                 :class="{ 'is-invalid': state === false }"
-                v-model="localValue"
-                :id="id"
                 :disabled="disabled"
                 :invalid="state === false" />
             <small

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -34,6 +34,9 @@
             <ds-link to="/molecules/form-message"> Form message </ds-link>
         </li>
         <li>
+            <ds-link to="/molecules/form-textarea"> Form textarea </ds-link>
+        </li>
+        <li>
             <ds-link to="/molecules/modal"> Modal </ds-link>
         </li>
         <li>

--- a/es-ds-docs/components/ds-molecules-list.vue
+++ b/es-ds-docs/components/ds-molecules-list.vue
@@ -34,9 +34,6 @@
             <ds-link to="/molecules/form-message"> Form message </ds-link>
         </li>
         <li>
-            <ds-link to="/molecules/form-textarea"> Form textarea </ds-link>
-        </li>
-        <li>
             <ds-link to="/molecules/modal"> Modal </ds-link>
         </li>
         <li>
@@ -62,6 +59,9 @@
         </li>
         <li>
             <ds-link to="/molecules/tabs"> Tabs </ds-link>
+        </li>
+        <li>
+            <ds-link to="/molecules/form-textarea"> Textarea </ds-link>
         </li>
         <li>
             <ds-link to="/molecules/text-input"> Text input </ds-link>

--- a/es-ds-docs/pages/molecules/form-textarea.vue
+++ b/es-ds-docs/pages/molecules/form-textarea.vue
@@ -1,6 +1,6 @@
 <script setup>
 const docTextarea = ref('');
-const successValue = 'My experience was great!';
+const successValue = ref('My experience was great!');
 
 const { $prism } = useNuxtApp();
 const compCode = ref('');

--- a/es-ds-docs/pages/molecules/form-textarea.vue
+++ b/es-ds-docs/pages/molecules/form-textarea.vue
@@ -6,16 +6,17 @@ const { $prism } = useNuxtApp();
 const compCode = ref('');
 const docCode = ref('');
 
-if ($prism) {
-    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
-    const compSource = await import('@energysage/es-ds-components/components/es-form-textarea.vue?raw');
-    const docSource = await import('./form-textarea.vue?raw');
-    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+onMounted(async () => {
+    if ($prism) {
+        const compSource = await import('@energysage/es-ds-components/components/es-form-textarea.vue?raw');
+        // eslint-disable-next-line import/no-self-import
+        const docSource = await import('./form-textarea.vue?raw');
 
-    compCode.value = $prism.normalizeCode(compSource.default);
-    docCode.value = $prism.normalizeCode(docSource.default);
-    $prism.highlight();
-}
+        compCode.value = $prism.normalizeCode(compSource.default);
+        docCode.value = $prism.normalizeCode(docSource.default);
+        $prism.highlight();
+    }
+});
 
 const propTableRows = [
     ['id', 'String', 'n/a', 'Required. The id of the input.'],
@@ -158,7 +159,7 @@ const propTableRows = [
 
         <ds-doc-source
             :comp-code="compCode"
-            comp-source="es-ds-components/src/lib-components/es-form-textarea.vue"
+            comp-source="es-ds-components/components/es-form-textarea.vue"
             :doc-code="docCode"
             doc-source="es-ds-docs/pages/molecules/form-textarea.vue" />
     </div>

--- a/es-ds-docs/pages/molecules/form-textarea.vue
+++ b/es-ds-docs/pages/molecules/form-textarea.vue
@@ -1,0 +1,165 @@
+<script setup>
+const docTextarea = ref('');
+const successValue = 'My experience was great!';
+
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+
+if ($prism) {
+    /* eslint-disable import/no-webpack-loader-syntax, import/no-self-import */
+    const compSource = await import('@energysage/es-ds-components/components/es-form-textarea.vue?raw');
+    const docSource = await import('./form-textarea.vue?raw');
+    /* eslint-enable import/no-webpack-loader-syntax, import/no-self-import */
+
+    compCode.value = $prism.normalizeCode(compSource.default);
+    docCode.value = $prism.normalizeCode(docSource.default);
+    $prism.highlight();
+}
+
+const propTableRows = [
+    ['id', 'String', 'n/a', 'Required. The id of the input.'],
+    ['v-model', 'String', 'n/a', 'Required. The v-model directive binds the input to a data property.'],
+    ['disabled', 'Boolean', 'false', 'Specifies that the input should be disabled.'],
+    ['required', 'Boolean', 'false', 'Specifies that the input is required.'],
+    [
+        'state',
+        'Boolean',
+        'null',
+        'Specifies the validity of the input. Can be true (success), false (error), or null (default).',
+    ],
+];
+</script>
+
+<template>
+    <div>
+        <h1>Textarea</h1>
+        <p>
+            When using a form textarea, please ensure that the label style is
+            <nuxt-link
+                href="https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case"
+                target="_blank">
+                Sentence case.
+            </nuxt-link>
+        </p>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Basic example</h2>
+                <es-form-textarea
+                    id="basic-example"
+                    v-model="docTextarea">
+                    <template #label> Notes </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Required</h2>
+                <es-form-textarea
+                    id="required-example"
+                    v-model="docTextarea"
+                    required>
+                    <template #label> Notes </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Error state</h2>
+                <es-form-textarea
+                    id="error-example"
+                    v-model="docTextarea"
+                    required
+                    :state="false">
+                    <template #label> Notes </template>
+                    <template #errorMessage> This field is required. </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Success state</h2>
+                <es-form-textarea
+                    id="success-example"
+                    v-model="successValue"
+                    required
+                    :state="true">
+                    <template #label> Notes </template>
+                    <template #errorMessage> This field is required. </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Success state with message</h2>
+                <es-form-textarea
+                    id="success-message-example"
+                    v-model="successValue"
+                    required
+                    :state="true">
+                    <template #label> Notes </template>
+                    <template #message> Please enter your notes. </template>
+                    <template #errorMessage> This field is required. </template>
+                    <template #successMessage> Your notes have been entered successfully. </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Disabled state</h2>
+                <es-form-textarea
+                    id="disabled-example"
+                    v-model="docTextarea"
+                    disabled>
+                    <template #label> Notes </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <b-row class="my-500">
+            <b-col
+                cols="12"
+                lg="6">
+                <h2>Context message</h2>
+                <es-form-textarea
+                    id="context-message-example"
+                    v-model="docTextarea"
+                    required>
+                    <template #label> Notes </template>
+                    <template #message> Please enter your notes. </template>
+                    <template #errorMessage> This field is required. </template>
+                    <template #successMessage> Your notes have been entered successfully. </template>
+                </es-form-textarea>
+            </b-col>
+        </b-row>
+
+        <div class="mb-500">
+            <h2>EsFormTextarea props</h2>
+            <ds-prop-table :rows="propTableRows" />
+        </div>
+
+        <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/src/lib-components/es-form-textarea.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/form-textarea.vue" />
+    </div>
+</template>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1758

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Adds molecule `EsFormTextarea` based off of [existing implementation](https://design.energysage.dev/molecules/es-form-textarea/) that uses HTML element `textarea`. I initially tried using [PrimeVue's](https://v3.primevue.org/textarea/) `Textarea` component but the unstyled mode is essentially the same as `textarea`.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested locally at http://localhost:8500/molecules/form-textarea ensuring the entered value propagates across all input fields, excluding the success state fields which have their own message

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- A few things to note:
- I tried `v-bind="$attrs"` but ended up using `modelValue` when that worked with neither `Textarea` nor `textarea`
- hover, active, and focus pseudo-classes match existing implementation rather than ESDS 2.0 design
- border width matches design, not existing implementation (existing: .556px, ESDS 2.0 design: 1px)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
