### PR TITLE
feat: es-form-textarea with validation

### DIFF
--- a/es-ds-docs/pages/examples/form-field-validation.vue
+++ b/es-ds-docs/pages/examples/form-field-validation.vue
@@ -5,7 +5,7 @@ const state = reactive({
         password: '',
         phone: '',
         maskedPhoneNumber: '',
-        // notes: '',
+        notes: '',
     },
 });
 
@@ -19,9 +19,9 @@ const rules = {
             [vuelidateKeys.REQUIRED]: vuelidateRequired,
             [vuelidateKeys.EMAIL]: vuelidateEmail,
         },
-        // notes: {
-        //     [vuelidateKeys.REQUIRED]: vuelidateRequired,
-        // },
+        notes: {
+            [vuelidateKeys.REQUIRED]: vuelidateRequired,
+        },
         password: {
             [vuelidateKeys.REQUIRED]: vuelidateRequired,
             [vuelidateKeys.MIN_LENGTH]: vuelidateMinLength(8),
@@ -167,18 +167,16 @@ onMounted(async () => {
                         <template #label> Masked phone number </template>
                         <template #errorMessage> Please enter a valid phone number. </template>
                     </es-form-input>
-                    <!--                    <es-form-textarea-->
-                    <!--                        id="notes"-->
-                    <!--                        v-model="form.notes"-->
-                    <!--                        :disabled="isSubmitInProgress"-->
-                    <!--                        :state="validateState('form.notes')"-->
-                    <!--                        required-->
-                    <!--                        @change="touchOnChange('form.notes')"-->
-                    <!--                        @blur="$v.form.notes.$touch">-->
-                    <!--                        <template #label>-->
-                    <!--                            Notes-->
-                    <!--                        </template>-->
-                    <!--                    </es-form-textarea-->
+                    <es-form-textarea
+                        id="notes"
+                        v-model="state.form.notes"
+                        :disabled="isSubmitInProgress"
+                        :state="validateState('form.notes')"
+                        required
+                        @change="touchOnChange('form.notes')"
+                        @blur="v$.form.notes.$touch">
+                        <template #label> Notes </template>
+                    </es-form-textarea>
                     <div class="d-flex flex-grow-1 justify-content-end mt-200">
                         <es-button
                             type="submit"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-1829

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Uncomment `<es-form-textarea>` in form-field-validation example to be used with validation.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested locally at http://localhost:8500/examples/form-field-validation

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
