### PR TITLE
feat: use v-bind in the style section

### DIFF
--- a/es-ds-components/components/es-slider.vue
+++ b/es-ds-components/components/es-slider.vue
@@ -55,9 +55,6 @@ const props = defineProps({
 // allow use of v-model on this component
 const model = defineModel<number | number[]>();
 model.value = props.startingValue;
-function handleSliderUpdate(newVal: number | number[]) {
-    model.value = newVal;
-}
 </script>
 
 <template>
@@ -80,7 +77,7 @@ function handleSliderUpdate(newVal: number | number[]) {
                     class: 'slider-handle',
                 }
             }"
-            @update:model-value="handleSliderUpdate" />
+        />
 
         <div class="d-flex flex-row justify-content-between">
             <span>{{ labelFormatter(min) }}</span>

--- a/es-ds-components/components/es-slider.vue
+++ b/es-ds-components/components/es-slider.vue
@@ -47,15 +47,17 @@ const props = defineProps({
     labelFormatter: {
         type: Function,
         required: false,
-        default: (val) => val,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        default: (val: any) => val,
     },
 });
 
 // allow use of v-model on this component
-const model = defineModel<number>();
-
-// set starting value
+const model = defineModel<number | number[]>();
 model.value = props.startingValue;
+function handleSliderUpdate(newVal: number | number[]) {
+    model.value = newVal;
+}
 </script>
 
 <template>
@@ -76,8 +78,9 @@ model.value = props.startingValue;
                 },
                 handle: {
                     class: 'slider-handle',
-                },
-            }" />
+                }
+            }"
+            @update:model-value="handleSliderUpdate" />
 
         <div class="d-flex flex-row justify-content-between">
             <span>{{ labelFormatter(min) }}</span>
@@ -126,7 +129,7 @@ model.value = props.startingValue;
     bottom: 27px;
     box-shadow: 0 1px 6px 0 rgba(34, 38, 51, 0.25);
     color: variables.$white;
-    content: attr(aria-valuenow);
+    content: v-bind("`'${model}'`");
     display: flex;
     font-weight: variables.$font-weight-boldest;
     height: 52px;

--- a/es-ds-components/components/es-slider.vue
+++ b/es-ds-components/components/es-slider.vue
@@ -126,7 +126,7 @@ model.value = props.startingValue;
     bottom: 27px;
     box-shadow: 0 1px 6px 0 rgba(34, 38, 51, 0.25);
     color: variables.$white;
-    content: v-bind("`'${model}'`");
+    content: v-bind("`'${labelFormatter(model)}'`");
     display: flex;
     font-weight: variables.$font-weight-boldest;
     height: 52px;

--- a/es-ds-docs/pages/molecules/slider.vue
+++ b/es-ds-docs/pages/molecules/slider.vue
@@ -1,5 +1,6 @@
 <script setup>
-const model = ref(null);
+const startValue = 150;
+const sliderVal = ref(startValue);
 const min = ref(0);
 const max = ref(1000);
 const step = ref(50);
@@ -46,13 +47,16 @@ onMounted(async () => {
 
         <div class="my-500">
             <es-slider
-                v-model="model"
+                v-model="sliderVal"
                 :min="min"
                 :max="max"
                 :step="step"
-                :starting-value="150"
+                :starting-value="startValue"
                 :aria-label="ariaLabel"
                 :label-formatter="(val) => `$${val}`" />
+            <pre>
+                sliderVal: {{ sliderVal }}
+            </pre>
         </div>
 
         <div class="mb-500">


### PR DESCRIPTION
DONT merge, just for reference.

Not really in the scope for [CED-1755](https://energysage.atlassian.net/browse/CED-1755), but I think `startingValue` should be made optional, and the default value set to the `v-model` value. It feels slightly odd to set a non-reactive startValue as well as bind to a reactive value via `v-model`.

[CED-1755]: https://energysage.atlassian.net/browse/CED-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ