### PR TITLE
feat: expanded functionality for EsCarousel

### DIFF
--- a/es-ds-components/components/es-carousel.vue
+++ b/es-ds-components/components/es-carousel.vue
@@ -170,7 +170,7 @@ onMounted(() => {
     <carousel
         :key="key"
         :autoplay-interval="autoplayInterval"
-        :circular="isMounted ? props.circular : false"
+        :circular="isMounted && props.circular"
         :num-scroll="props.numScroll"
         :num-visible="props.numVisible"
         :responsive-options="responsiveOptions"

--- a/es-ds-components/components/es-carousel.vue
+++ b/es-ds-components/components/es-carousel.vue
@@ -1,50 +1,125 @@
 <script setup lang="ts">
+/*
+    TODO:
+     - why is mobile so messed up with paging
+     - why does mobile first show item 12 and then switch to item 1
+*/
+
 import Carousel from 'primevue/carousel';
+import sassBreakpoints from '@energysage/es-ds-styles/scss/modules/breakpoints.module.scss';
+import type { EsCarouselBreakpointsInterface } from '../types';
 
-const responsiveOptions = ref([
-    {
-        // xl: 1200px
-        breakpoint: '1199px',
-        numVisible: 4,
-        numScroll: 1,
-    },
-    {
-        // lg: 992px
-        breakpoint: '991px',
-        numVisible: 3,
-        numScroll: 1,
-    },
-    {
-        // md: 768px
-        breakpoint: '767px',
-        numVisible: 2,
-        numScroll: 1,
-    },
-    {
-        // sm: 576px
-        breakpoint: '575px',
-        numVisible: 1,
-        numScroll: 1,
-    },
-]);
-
-const props = defineProps({
-    autoscroll: {
-        type: Boolean,
-        default: false,
-    },
-    dots: {
-        type: Boolean,
-        default: true,
-    },
-    items: {
-        type: Array,
-        default: () => [],
-        required: true,
-    },
+interface IProps {
+    autoPlay?: boolean;
+    autoPlayInterval?: number;
+    breakpoints?: EsCarouselBreakpointsInterface;
+    circular?: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    items: Array<any>;
+    numScroll?: number;
+    numVisible?: number;
+    showArrows?: boolean;
+    showDots?: boolean;
+}
+const props = withDefaults(defineProps<IProps>(), {
+    autoPlay: false,
+    autoPlayInterval: 2000,
+    breakpoints: () => ({}),
+    circular: true,
+    items: () => [],
+    numScroll: 1,
+    numVisible: 1,
+    showArrows: true,
+    showDots: true,
 });
 
-const autoplayInterval = ref(props.autoscroll ? 3000 : 0);
+const emit = defineEmits<{
+    update: [value: number];
+}>();
+
+// get the breakpoint pixel numbers from the SASS variables in es-ds-styles
+const parseSassBreakpoint = (breakpoint: string) => parseInt(breakpoint.replace('px', ''), 10);
+const BREAKPOINTS = {
+    SM: parseSassBreakpoint(sassBreakpoints.sm),
+    MD: parseSassBreakpoint(sassBreakpoints.md),
+    LG: parseSassBreakpoint(sassBreakpoints.lg),
+    XL: parseSassBreakpoint(sassBreakpoints.xl),
+    XXL: parseSassBreakpoint(sassBreakpoints.xxl),
+};
+
+// lower breakpoint values propagate to higher breakpoints unless overridden
+const numVisibleXs = computed(() => props.numVisible);
+const numVisibleSm = computed(() => props.breakpoints?.sm?.numVisible || numVisibleXs.value);
+const numVisibleMd = computed(() => props.breakpoints?.md?.numVisible || numVisibleSm.value);
+const numVisibleLg = computed(() => props.breakpoints?.lg?.numVisible || numVisibleMd.value);
+const numVisibleXl = computed(() => props.breakpoints?.xl?.numVisible || numVisibleLg.value);
+const numVisibleXxl = computed(() => props.breakpoints?.xxl?.numVisible || numVisibleXl.value);
+
+// lower breakpoint values propagate to higher breakpoints unless overridden
+const numScrollXs = computed(() => props.numScroll);
+const numScrollSm = computed(() => props.breakpoints?.sm?.numScroll || numScrollXs.value);
+const numScrollMd = computed(() => props.breakpoints?.md?.numScroll || numScrollSm.value);
+const numScrollLg = computed(() => props.breakpoints?.lg?.numScroll || numScrollMd.value);
+const numScrollXl = computed(() => props.breakpoints?.xl?.numScroll || numScrollLg.value);
+const numScrollXxl = computed(() => props.breakpoints?.xxl?.numScroll || numScrollXl.value);
+
+// in order to enable full-width carousels with one item
+// but also ensure there is some space between items when more than one is visible
+// only apply horizontal padding to carousel items on breakpoints where more than one item is visible
+const DEFAULT_PADDING = '0.5rem';
+const paddingXs = computed(() => (numVisibleXs.value === 1 ? '0' : DEFAULT_PADDING));
+const paddingSm = computed(() => (numVisibleSm.value === 1 ? '0' : DEFAULT_PADDING));
+const paddingMd = computed(() => (numVisibleMd.value === 1 ? '0' : DEFAULT_PADDING));
+const paddingLg = computed(() => (numVisibleLg.value === 1 ? '0' : DEFAULT_PADDING));
+const paddingXl = computed(() => (numVisibleXl.value === 1 ? '0' : DEFAULT_PADDING));
+const paddingXxl = computed(() => (numVisibleXxl.value === 1 ? '0' : DEFAULT_PADDING));
+
+const responsiveOptions = computed(() => {
+    // if no special breakpoints are defined, don't pass in any responsive options
+    if (!Object.keys(props.breakpoints).length) {
+        return undefined;
+    }
+
+    return [
+        // XXL breakpoint
+        {
+            // max width of XXL is infinite, so let's use 9999px
+            breakpoint: '9999px',
+            numScroll: numScrollXxl.value,
+            numVisible: numVisibleXxl.value,
+        },
+        // XL breakpoint
+        {
+            // max width of XL is XXL minus one
+            breakpoint: `${BREAKPOINTS.XXL - 1}px`,
+            numScroll: numScrollXl.value,
+            numVisible: numVisibleXl.value,
+        },
+        // LG breakpoint
+        {
+            // max width of LG is XL minus one
+            breakpoint: `${BREAKPOINTS.XL - 1}px`,
+            numScroll: numScrollLg.value,
+            numVisible: numVisibleLg.value,
+        },
+        // MD breakpoint
+        {
+            // max width of MD is LG minus one
+            breakpoint: `${BREAKPOINTS.LG - 1}px`,
+            numScroll: numScrollMd.value,
+            numVisible: numVisibleMd.value,
+        },
+        // SM breakpoint
+        {
+            // max width of SM is MD minus one
+            breakpoint: `${BREAKPOINTS.MD - 1}px`,
+            numScroll: numScrollSm.value,
+            numVisible: numVisibleSm.value,
+        },
+    ];
+});
+
+const autoplayInterval = ref(props.autoPlay ? props.autoPlayInterval : 0);
 const key = ref('');
 
 const stopAutoplay = () => {
@@ -69,20 +144,22 @@ onMounted(() => {
     <carousel
         :key="key"
         :autoplay-interval="autoplayInterval"
-        circular
-        :num-visible="4"
+        :circular="props.circular"
+        :num-scroll="props.numScroll"
+        :num-visible="props.numVisible"
         :responsive-options="responsiveOptions"
-        :show-indicators="dots"
-        :value="items"
+        :show-indicators="props.showDots"
+        :show-navigators="props.showArrows"
+        :value="props.items"
         :pt="{
             container: {
                 class: 'd-flex',
             },
             indicator: {
-                class: 'dot',
+                class: 'es-carousel-dot',
             },
             indicators: {
-                class: 'd-flex justify-content-center',
+                class: 'es-carousel-dots d-flex justify-content-center mt-100',
                 style: 'gap: 12px;',
             },
             itemsContent: {
@@ -92,22 +169,29 @@ onMounted(() => {
                 class: 'd-flex',
             },
             item: {
-                class: 'p-carousel-item p-1',
+                class: 'es-carousel-item',
             },
             itemCloned: {
-                class: 'p-carousel-item p-1',
+                class: 'es-carousel-item',
             },
             previousButton: {
-                style: 'border: unset; background: unset; color: #64748b;',
+                class: 'es-carousel-arrow es-carousel-prev-arrow btn btn-outline-primary px-sm-50',
             },
             nextButton: {
-                style: 'border: unset; background: unset; color: #64748b;',
+                class: 'es-carousel-arrow es-carousel-next-arrow btn btn-outline-primary px-sm-50',
             },
-        }">
+        }"
+        @update:page="(value: number) => emit('update', value)">
         <template #item="item">
             <slot
                 name="item"
                 :item="item.data" />
+        </template>
+        <template #previousicon>
+            <icon-chevron-left />
+        </template>
+        <template #nexticon>
+            <icon-chevron-right />
         </template>
     </carousel>
 </template>
@@ -116,29 +200,64 @@ onMounted(() => {
 @use '@energysage/es-ds-styles/scss/variables' as variables;
 @use '@energysage/es-ds-styles/scss/mixins/breakpoints' as breakpoints;
 
-:deep(.p-carousel-item) {
-    flex: 1 0 100%;
+:deep(.es-carousel-item) {
+    flex: 1 0 calc(100% / v-bind(numVisibleXs));
+    padding: 0 v-bind(paddingXs);
 }
 
 @include breakpoints.media-breakpoint-up(sm) {
-    :deep(.p-carousel-item) {
-        flex: 1 0 calc(100% / 2);
+    :deep(.es-carousel-item) {
+        flex: 1 0 calc(100% / v-bind(numVisibleSm));
+        padding: 0 v-bind(paddingSm);
     }
 }
 
 @include breakpoints.media-breakpoint-up(md) {
-    :deep(.p-carousel-item) {
-        flex: 1 0 calc(100% / 3);
+    :deep(.es-carousel-item) {
+        flex: 1 0 calc(100% / v-bind(numVisibleMd));
+        padding: 0 v-bind(paddingMd);
     }
 }
 
 @include breakpoints.media-breakpoint-up(lg) {
-    :deep(.p-carousel-item) {
-        flex: 1 0 calc(100% / 4);
+    :deep(.es-carousel-item) {
+        flex: 1 0 calc(100% / v-bind(numVisibleLg));
+        padding: 0 v-bind(paddingLg);
     }
 }
 
-:deep(.dot) {
+@include breakpoints.media-breakpoint-up(xl) {
+    :deep(.es-carousel-item) {
+        flex: 1 0 calc(100% / v-bind(numVisibleXl));
+        padding: 0 v-bind(paddingXl);
+    }
+}
+
+@include breakpoints.media-breakpoint-up(xxl) {
+    :deep(.es-carousel-item) {
+        flex: 1 0 calc(100% / v-bind(numVisibleXxl));
+        padding: 0 v-bind(paddingXxl);
+    }
+}
+
+:deep(.es-carousel-arrow) {
+    background: unset;
+    border: unset;
+    box-shadow: none;
+    color: variables.$gray-900;
+    height: auto;
+
+    &:hover {
+        color: variables.$gray-700;
+    }
+    &:not(:disabled):not(.disabled):active {
+        background: unset;
+        box-shadow: none;
+        color: variables.$gray-700;
+    }
+}
+
+:deep(.es-carousel-dot) {
     list-style-type: none;
 
     &[data-p-highlight='true'] button {

--- a/es-ds-components/nuxt.config.ts
+++ b/es-ds-components/nuxt.config.ts
@@ -18,6 +18,11 @@ export default defineNuxtConfig({
         },
     },
 
+    // Configure how Nuxt auto-imports composables into your application.
+    imports: {
+        dirs: ['composables', 'types'],
+    },
+
     modules: [
         // https://google-fonts.nuxtjs.org/getting-started/setup
         '@nuxtjs/google-fonts',

--- a/es-ds-components/types/es-carousel.ts
+++ b/es-ds-components/types/es-carousel.ts
@@ -1,0 +1,12 @@
+export interface EsCarouselBreakpointInterface {
+    numScroll?: number;
+    numVisible: number;
+}
+
+export interface EsCarouselBreakpointsInterface {
+    sm?: EsCarouselBreakpointInterface;
+    md?: EsCarouselBreakpointInterface;
+    lg?: EsCarouselBreakpointInterface;
+    xl?: EsCarouselBreakpointInterface;
+    xxl?: EsCarouselBreakpointInterface;
+}

--- a/es-ds-components/types/index.ts
+++ b/es-ds-components/types/index.ts
@@ -1,0 +1,1 @@
+export type * from './es-carousel';

--- a/es-ds-docs/pages/organisms/carousel.vue
+++ b/es-ds-docs/pages/organisms/carousel.vue
@@ -1,41 +1,23 @@
 <script setup lang="ts">
-const items = ref([
-    {
-        image_url: 'https://loremflickr.com/200/200?random=1',
-        breed: 'Manx',
-        age: 'Kitten',
-        url: 'https://www.petfinder.com/search/cats-for-adoption/',
-        subtitle: 'Adopt me!',
-    },
-    {
-        image_url: 'https://loremflickr.com/200/200?random=2',
-        breed: 'Maine Coon',
-        age: 'Kitten',
-        url: 'https://www.petfinder.com/search/cats-for-adoption/',
-        subtitle: 'Adopt me!',
-    },
-    {
-        image_url: 'https://loremflickr.com/200/200?random=3',
-        breed: 'Ragamuffin',
-        age: 'Adult',
-        url: 'https://www.petfinder.com/search/cats-for-adoption/',
-        subtitle: 'Adopt me!',
-    },
-    {
-        image_url: 'https://loremflickr.com/200/200?random=4',
-        breed: 'Ragdoll',
-        age: 'Senior',
-        url: 'https://www.petfinder.com/search/cats-for-adoption/',
-        subtitle: 'Adopt me!',
-    },
-    {
-        image_url: 'https://loremflickr.com/200/200?random=5',
-        breed: 'Sphynx',
-        age: 'Senior',
-        url: 'https://www.petfinder.com/search/cats-for-adoption/',
-        subtitle: 'Adopt me!',
-    },
-]);
+const SAMPLE_IMAGES = [
+    'https://a-us.storyblok.com/f/1006159/810x471/e9dfa73446/renewable-energy-credits.jpg?cv=1729091549197',
+    'https://a-us.storyblok.com/f/1006159/810x471/e9724bfe3d/how-many-solar-panels-can-i-fit-on-my-roof-1.jpg?cv=1729089091200',
+    'https://a-us.storyblok.com/f/1006159/810x471/9d70141e04/how-many-solar-batteries-do-i-need.jpg?cv=1729027236346',
+    'https://a-us.storyblok.com/f/1006159/810x471/f719b5918c/types-of-solar-panels.jpg?cv=1729027121520',
+    'https://a-us.storyblok.com/f/1006159/810x471/2a88e73a6b/heat-pump-vs-oil.jpg?cv=1729171528536',
+    'https://a-us.storyblok.com/f/1006159/810x471/d48ae4605e/des-1116-csm.jpg?cv=1729694782046',
+    'https://a-us.storyblok.com/f/1006159/810x471/ca3650d4f7/hybrid-heat-pumps.jpg?cv=1730192379642',
+    'https://a-us.storyblok.com/f/1006159/810x473/319bb5c48e/ev-charger-tax-credit-2024.jpg?cv=1729025549687',
+    'https://a-us.storyblok.com/f/1006159/810x471/e19919aa39/heatpump_minisplits.jpg?cv=1729022439533',
+    'https://a-us.storyblok.com/f/1006159/810x473/730730f571/solar-patio-cover.jpg?cv=1728483201600',
+    'https://a-us.storyblok.com/f/1006159/810x473/dfbc056218/alternative-to-solar-panels.jpg?cv=1728482849234',
+    'https://a-us.storyblok.com/f/1006159/810x473/a3a6b6d667/adding-solar-panels.jpg?cv=1728482273086',
+];
+
+const basicExampleItems = SAMPLE_IMAGES.map((image, index) => ({
+    heading: `Item ${index + 1}`,
+    url: image,
+}));
 
 const { $prism } = useNuxtApp();
 const compCode = ref('');
@@ -55,130 +37,132 @@ onMounted(async () => {
 
 const propTableRows = [
     [
-        'autoscroll',
+        'autoPlay',
         'Boolean',
         'false',
-        'Whether to automatically scroll the carousel. When true, the carousel will scroll every 3 seconds.',
+        'If true, the carousel will automatically go to the next page after a set interval, determined by autoPlayInterval. The autoplay functionality can be stopped by pressing the Esc key.',
     ],
-    ['dots', 'Boolean', 'true', 'Whether to show the dots at the bottom of the carousel.'],
+    [
+        'autoPlayInterval',
+        'Number',
+        '2000',
+        'If autoPlay is true, this determines the number of milliseconds between transitions.',
+    ],
+    [
+        'breakpoints',
+        'Object',
+        '{}',
+        'Allows you to specify how many items should be shown and how many items should scroll at each breakpoint. This object has optional keys of sm, md, lg, xl, and xxl. If a breakpoint is omitted, the values from the next-lowest defined breakpoint will be used. Each key points to an object where you can set numScroll (optional) and numVisible (required).',
+    ],
+    [
+        'circular',
+        'Boolean',
+        'true',
+        'Whether the carousel should stop paging at either end or start over from the beginning.',
+    ],
     [
         'items',
         'Array',
         '[]',
         'Required. The items to display in the carousel. Use the template #item to style the items.',
     ],
+    [
+        'numScroll',
+        'Number',
+        '1',
+        'The number of items to scroll on each page transition. This is also used as the default mobile value when using breakpoints.',
+    ],
+    [
+        'numVisible',
+        'Number',
+        '1',
+        'The number of items visible at any one time. This is also used as the default mobile value when using breakpoints.',
+    ],
+    ['showArrows', 'Boolean', 'true', 'Whether to show the arrows on either side of the carousel.'],
+    ['showDots', 'Boolean', 'true', 'Whether to show the dots at the bottom of the carousel.'],
 ];
+
+const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible page of the carousel changes.']];
 </script>
 
 <template>
     <div>
         <h1>Carousel</h1>
         <p class="mb-500">
-            Uses
+            Extended from
             <a
                 href="https://v3.primevue.org/carousel/"
                 target="_blank">
                 PrimeVue Carousel
             </a>
         </p>
-        <h2>No dots</h2>
 
         <div class="my-500">
+            <h2>Basic example</h2>
+            <p class="mb-200">
+                This example shows a responsive carousel with twelve items, rendered as cards with an image and
+                subtitle. Mobile sees one card at a time, which then increases to two, three, and four as the viewport
+                width increases.
+            </p>
             <es-carousel
-                :items="items"
-                :dots="false">
+                :breakpoints="{
+                    sm: {
+                        numScroll: 2,
+                        numVisible: 2,
+                    },
+                    lg: {
+                        numScroll: 3,
+                        numVisible: 3,
+                    },
+                    xxl: {
+                        numScroll: 4,
+                        numVisible: 4,
+                    },
+                }"
+                :items="basicExampleItems"
+                @update="(value) => console.log('it is now value', value)">
                 <template #item="{ item }">
-                    <es-card
-                        class="d-flex flex-column bg-soft-blue h-100"
-                        :href="item.url"
-                        variant="interactive">
+                    <es-card class="text-center">
                         <nuxt-img
-                            v-if="item.image_url"
-                            alt=""
-                            class="w-100 rounded product-image"
-                            loading="lazy"
-                            :src="item.image_url" />
-                        <h3 class="flex-grow-1 font-size-300 mb-50 text-blue-900">{{ item.model_name }}</h3>
-                        <div>
-                            <p
-                                v-if="item.age"
-                                class="mb-100 mb-lg-50 text-blue-900">
-                                {{ item.age }}
-                            </p>
-                            <p
-                                v-if="item.subtitle"
-                                class="mb-0 text-black font-size-50">
-                                {{ item.subtitle }}
-                            </p>
-                        </div>
+                            class="mb-50 w-100"
+                            :src="item.url" />
+                        <p class="font-weight-semibold mb-0">
+                            {{ item.heading }}
+                        </p>
                     </es-card>
                 </template>
             </es-carousel>
         </div>
 
-        <h2>With dots</h2>
-
         <div class="my-500">
-            <es-carousel :items="items">
-                <template #item="{ item }">
-                    <es-card
-                        class="d-flex flex-column bg-soft-blue h-100"
-                        :href="item.url"
-                        variant="interactive">
-                        <img
-                            v-if="item.image_url"
-                            alt=""
-                            class="w-100 rounded product-image"
-                            loading="lazy"
-                            :src="item.image_url" />
-                        <h3 class="flex-grow-1 font-size-300 mb-50 text-blue-900">{{ item.model_name }}</h3>
-                        <div>
-                            <p
-                                v-if="item.age"
-                                class="mb-100 mb-lg-50 text-blue-900">
-                                {{ item.age }}
-                            </p>
-                            <p
-                                v-if="item.subtitle"
-                                class="mb-0 text-black font-size-50">
-                                {{ item.subtitle }}
-                            </p>
-                        </div>
-                    </es-card>
-                </template>
-            </es-carousel>
-        </div>
-
-        <h2>With autoscroll</h2>
-
-        <div class="my-500">
+            <h2>Autoplay with hidden arrows and dots</h2>
+            <p class="mb-200">
+                This example shows the same twelve items, but with autoplay turned on and the arrows and dots hidden.
+            </p>
             <es-carousel
-                :items="items"
-                autoscroll>
+                auto-play
+                :breakpoints="{
+                    sm: {
+                        numVisible: 2,
+                    },
+                    lg: {
+                        numVisible: 3,
+                    },
+                    xxl: {
+                        numVisible: 4,
+                    },
+                }"
+                :items="basicExampleItems"
+                :show-arrows="false"
+                :show-dots="false">
                 <template #item="{ item }">
-                    <es-card
-                        class="d-flex flex-column bg-soft-blue h-100"
-                        :href="item.url"
-                        variant="interactive">
-                        <img
-                            v-if="item.image_url"
-                            alt=""
-                            class="w-100 rounded product-image"
-                            loading="lazy"
-                            :src="item.image_url" />
-                        <h3 class="flex-grow-1 font-size-300 mb-50 text-blue-900">{{ item.model_name }}</h3>
-                        <div>
-                            <p
-                                v-if="item.age"
-                                class="mb-100 mb-lg-50 text-blue-900">
-                                {{ item.age }}
-                            </p>
-                            <p
-                                v-if="item.subtitle"
-                                class="mb-0 text-black font-size-50">
-                                {{ item.subtitle }}
-                            </p>
-                        </div>
+                    <es-card class="text-center">
+                        <nuxt-img
+                            class="mb-50 w-100"
+                            :src="item.url" />
+                        <p class="font-weight-semibold mb-0">
+                            {{ item.heading }}
+                        </p>
                     </es-card>
                 </template>
             </es-carousel>
@@ -187,6 +171,16 @@ const propTableRows = [
         <div class="mb-500">
             <h2>EsCarousel props</h2>
             <ds-prop-table :rows="propTableRows" />
+        </div>
+
+        <div class="mb-500">
+            <h2>EsCarousel events</h2>
+            <ds-prop-table
+                :columns="['Name', 'Parameters', 'Description']"
+                :rows="eventTableRows"
+                :widths="{
+                    md: ['3', '4', '5'],
+                }" />
         </div>
 
         <ds-doc-source

--- a/es-ds-docs/pages/organisms/carousel.vue
+++ b/es-ds-docs/pages/organisms/carousel.vue
@@ -119,8 +119,7 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
                         numVisible: 4,
                     },
                 }"
-                :items="basicExampleItems"
-                @update="(value) => console.log('it is now value', value)">
+                :items="basicExampleItems">
                 <template #item="{ item }">
                     <es-card class="text-center">
                         <nuxt-img
@@ -135,9 +134,57 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
         </div>
 
         <div class="my-500">
-            <h2>Autoplay with hidden arrows and dots</h2>
+            <h2>Circular example</h2>
+            <p>
+                This example shows the same responsive carousel but with circular behavior turned on, meaning the user
+                can continue paging in one direction forever and the items from the beginning of the list will be
+                repeated once the end of the list is reached.
+            </p>
             <p class="mb-200">
-                This example shows the same twelve items, but with autoplay turned on and the arrows and dots hidden.
+                Unless paging is done in a rapid-fire succession (the carousel needs a split second to add more hidden
+                items after a page transition completes), the next set of items will always appear to come from the
+                same direction as all previous items, even when circling back to the beginning of the list.
+            </p>
+            <es-carousel
+                :breakpoints="{
+                    sm: {
+                        numScroll: 2,
+                        numVisible: 2,
+                    },
+                    lg: {
+                        numScroll: 3,
+                        numVisible: 3,
+                    },
+                    xxl: {
+                        numScroll: 4,
+                        numVisible: 4,
+                    },
+                }"
+                circular
+                :items="basicExampleItems">
+                <template #item="{ item }">
+                    <es-card class="text-center">
+                        <nuxt-img
+                            class="mb-50 w-100"
+                            :src="item.url" />
+                        <p class="font-weight-semibold mb-0">
+                            {{ item.heading }}
+                        </p>
+                    </es-card>
+                </template>
+            </es-carousel>
+        </div>
+
+        <div class="my-500">
+            <h2>Circular autoplay with hidden arrows and dots</h2>
+            <p>
+                This example shows the same twelve items, but with autoplay turned on, circular behavior enabled, and
+                the arrows and dots hidden.
+            </p>
+            <p class="mb-200">
+                Pressing the Esc key will stop the autoplay. This is an accessibility feature for screen readers,
+                because the contents of each new slide brought into view by autoplay are automatically read aloud, no
+                matter where the user is on the page.
             </p>
             <es-carousel
                 auto-play
@@ -152,6 +199,7 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
                         numVisible: 4,
                     },
                 }"
+                circular
                 :items="basicExampleItems"
                 :show-arrows="false"
                 :show-dots="false">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-1900

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- EsCarousel now takes `numVisible`, `numScroll`, and `breakpoints` props to customize the number of slides shown per breakpoint and number of slides that scroll on each paging event
- The `breakpoints` is set up in a way that makes sense with our breakpoints and how we use them in components like EsCol, for example, rather than conforming to PrimeVue Carousel's odd reversed max-width approach
- Renamed `autoscroll` prop to `autoPlay` and added `autoPlayInterval` prop
- Renamed `dots` prop to `showDots` and added `showArrows` prop
- Added `circular` prop
   - Fixed an SSR issue with `circular` behavior where the wrong item would be briefly displayed as the first item on page load, then hydration would correct it
- ESDS is now exporting types (for EsCarousel's `breakpoints` prop)
- On the docs page, since I'm very nervous about relying on a third-party CDN for example images, switched to using images from Storyblok prod we'll likely never delete and used a more generic card design instead of something with such specific styling
- _Known issue:_ responsive carousels briefly show mobile amount of dots on desktop, until hydration
   - this is preexisting and since none of the homepage carousels have this issue, i left solving it out of scope for now

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally with ESDS docs site
- Also tested on es-cms-pages homepage with the logo carousel and the hero carousel

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
