### PR TITLE
fix: v-for handling in EsTabs and EsAccordion

### DIFF
--- a/es-ds-components/components/es-accordion-list.vue
+++ b/es-ds-components/components/es-accordion-list.vue
@@ -17,19 +17,27 @@ const props = withDefaults(defineProps<Props>(), {
 // eslint-disable-next-line vue/require-prop-types
 const model = defineModel();
 
-const children = useSlots().default?.() || [];
+// get the list of elements provided as children to the default slot
+const initialChildren = useSlots().default?.() || [];
+const children: any[] = [];
+initialChildren.forEach((child) => {
+    // unless this has a v-for element and we instead need to access its children
+    if (typeof child.type === 'symbol' && Array.isArray(child.children)) {
+        children.push(...child.children);
+    } else {
+        children.push(child);
+    }
+});
 
 const activeIndex = ref();
 
 watch(model, (newVal) => {
     if (newVal) {
-        // @ts-expect-error not sure
         activeIndex.value = children.findIndex((child) => child.props.id === newVal);
     }
 });
 
 const accordionTabs = children.map((child, index) => {
-    // @ts-expect-error not sure
     if (child.props.id === props.initialExpandedId || child.props.id === model.value) {
         activeIndex.value = index;
     }
@@ -38,7 +46,6 @@ const accordionTabs = children.map((child, index) => {
 
 const updateActiveIndex = (index: any) => {
     if (model.value) {
-        // @ts-expect-error not sure
         model.value = children[index]?.props.id || '';
     }
 };
@@ -99,7 +106,6 @@ const updateActiveIndex = (index: any) => {
                     role="heading"
                     aria-level="3"
                     :class="{ 'h3 mb-0': variant === 'minimal' }">
-                    <!-- @vue-expect-error -->
                     <component
                         :is="item"
                         v-for="item in tab.title()"
@@ -107,7 +113,6 @@ const updateActiveIndex = (index: any) => {
                 </span>
                 <icon-chevron-down class="es-accordion-icon flex-shrink-0 ml-200" />
             </template>
-            <!-- @vue-expect-error -->
             <component
                 :is="item"
                 v-for="item in tab.default()"

--- a/es-ds-components/components/es-tabs.vue
+++ b/es-ds-components/components/es-tabs.vue
@@ -6,7 +6,16 @@ import TabView from 'primevue/tabview';
 const model = defineModel<number>();
 
 // get the list of elements provided as children to the default slot
-const panels = useSlots().default?.() || [];
+const initialChildren = useSlots().default?.() || [];
+const panels: any[] = [];
+initialChildren.forEach((child) => {
+    // unless this has a v-for element and we instead need to access its children
+    if (typeof child.type === 'symbol' && Array.isArray(child.children)) {
+        panels.push(...child.children);
+    } else {
+        panels.push(child);
+    }
+});
 
 // keep track of the active tab index
 //  - from above, if v-model is used
@@ -36,7 +45,6 @@ const updateActiveIndex = (index: number) => {
             panelContainer: 'tab-content',
         }"
         @update:active-index="updateActiveIndex">
-        <!-- @vue-expect-error -->
         <tab-panel
             v-for="(panel, index) in panels"
             :key="index"
@@ -60,7 +68,6 @@ const updateActiveIndex = (index: number) => {
                     ],
                 }),
             }">
-            <!-- @vue-expect-error -->
             <component
                 :is="item"
                 v-for="(item, idx) in panel.children.default()"

--- a/es-ds-docs/pages/molecules/accordion.vue
+++ b/es-ds-docs/pages/molecules/accordion.vue
@@ -1,6 +1,21 @@
 <script setup lang="ts">
 const programmaticExpandedId = ref('programmatic-question-1');
 
+const accordionIterativeItems = [
+    {
+        id: 1,
+        title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit?',
+        content:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing. Mi tempus imperdiet nulla malesuada pellentesque elit.',
+    },
+    {
+        id: 2,
+        title: 'Faucibus purus in massa tempor nec feugiat?',
+        content:
+            'Faucibus purus in massa tempor nec feugiat. In hac habitasse platea dictumst. Leo duis ut diam quam nulla porttitor. Diam vel quam elementum pulvinar etiam non quam. Elementum curabitur vitae nunc sed velit dignissim. Velit sed ullamcorper morbi tincidunt ornare. Sed cras ornare arcu dui vivamus arcu felis bibendum. Vel pharetra vel turpis nunc eget lorem.',
+    },
+];
+
 const accordionListProps = [
     [
         'allowMultipleExpand',
@@ -378,6 +393,22 @@ onMounted(async () => {
                         cursus vitae congue mauris rhoncus aenean vel elit. In aliquam sem fringilla ut morbi
                         tincidunt. Semper auctor neque vitae tempus quam pellentesque nec. Sit amet nisl purus in
                         mollis nunc sed id semper.
+                    </p>
+                </es-accordion>
+            </es-accordion-list>
+        </div>
+
+        <div class="mb-450">
+            <h2>Using v-for</h2>
+            <p>Example using v-for to construct the children <code>es-accordion</code> elements.</p>
+            <es-accordion-list :initial-expanded-id="`iterative-item-${accordionIterativeItems[0].id}`">
+                <es-accordion
+                    v-for="item in accordionIterativeItems"
+                    :id="`iterative-item-${item.id}`"
+                    :key="item.id">
+                    <template #title> {{ item.title }}</template>
+                    <p>
+                        {{ item.content }}
                     </p>
                 </es-accordion>
             </es-accordion-list>

--- a/es-ds-docs/pages/molecules/tabs.vue
+++ b/es-ds-docs/pages/molecules/tabs.vue
@@ -16,6 +16,11 @@ onMounted(async () => {
         $prism.highlight();
     }
 });
+
+const tabs = [
+    { id: 1, title: 'Item one', content: 'Content one' },
+    { id: 2, title: 'Item two', content: 'Content two' },
+];
 </script>
 
 <template>
@@ -52,6 +57,19 @@ onMounted(async () => {
                 </es-tab>
                 <es-tab title="Item four">
                     <p>Content four</p>
+                </es-tab>
+            </es-tabs>
+        </div>
+
+        <div class="my-500">
+            <h2>Using v-for</h2>
+            <p>Example using v-for to construct the children <code>es-tab</code> elements.</p>
+            <es-tabs>
+                <es-tab
+                    v-for="tab in tabs"
+                    :key="tab.id"
+                    :title="tab.title">
+                    <p>{{ tab.content }}</p>
                 </es-tab>
             </es-tabs>
         </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Unblocks https://energysage.atlassian.net/browse/CED-1983 and https://energysage.atlassian.net/browse/CED-1986

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

With the current implementation of Tabs and Accordion, you'll get errors when trying to use a `v-for` to iterate through child elements (`es-tab` and `es-accordion`), which is what many of the downstream usages do.  When we're accessing the children using useSlots() the `v-for` element shows up as one child, but we need its children in turn, so this is just doing some replacement in that case. 

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

Tested with the examples on both docs pages; also tested adding a hardcoded child alongside the `v-for` in both examples

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- This feels a bit hacky, definitely open to suggestions if there are other methods to try!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I have documented testing approach
