### PR TITLE
feat: Add peek props to carousel and update numDots calculation

### DIFF
--- a/es-ds-components/components/es-carousel.vue
+++ b/es-ds-components/components/es-carousel.vue
@@ -35,6 +35,8 @@ interface IProps {
     items: Array<any>;
     numScroll?: number;
     numVisible?: number;
+    peekDesktop?: string;
+    peekMobile?: string;
     showArrows?: boolean;
     showDots?: boolean;
     slideGap?: number;
@@ -50,6 +52,8 @@ const props = withDefaults(defineProps<IProps>(), {
     items: () => [],
     numScroll: 1,
     numVisible: 1,
+    peekDesktop: '',
+    peekMobile: '',
     showArrows: true,
     showDots: true,
     slideGap: 16,
@@ -114,22 +118,34 @@ const dotsMarginTop = computed(() => `${props.controlGap / BASE_FONT_SIZE}rem`);
 
 // the number of dots visible at each breakpoint
 const numDotsXs = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleXs.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleXs.value) / numScrollXs.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 const numDotsSm = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleSm.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleSm.value) / numScrollSm.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 const numDotsMd = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleMd.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleMd.value) / numScrollMd.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 const numDotsLg = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleLg.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleLg.value) / numScrollLg.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 const numDotsXl = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleXl.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleXl.value) / numScrollXl.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 const numDotsXxl = computed(() =>
-    props.showDots ? Math.ceil(props.items.length / numVisibleXxl.value) : ARROW_SPACING_WHEN_NO_DOTS,
+    props.showDots
+        ? Math.ceil((props.items.length - numVisibleXxl.value) / numScrollXxl.value) + 1
+        : ARROW_SPACING_WHEN_NO_DOTS,
 );
 
 // calculate the arrow position from center based on the number of dots
@@ -292,7 +308,13 @@ onMounted(() => {
                 class: 'd-block',
             },
             itemsContent: {
-                class: 'w-100 overflow-hidden',
+                class: [
+                    'w-100 overflow-hidden',
+                    {
+                        'es-carousel-peek-desktop': peekDesktop,
+                        'es-carousel-peek-mobile': peekMobile,
+                    },
+                ],
             },
             itemsContainer: {
                 class: 'd-flex',
@@ -372,6 +394,18 @@ $num-dots-supported: 8;
 :deep(.es-carousel-container) {
     margin-left: v-bind(negativeMargin);
     margin-right: v-bind(negativeMargin);
+
+    > div.es-carousel-peek-desktop {
+        @include breakpoints.media-breakpoint-up(lg) {
+            padding-right: v-bind(peekDesktop);
+        }
+    }
+
+    > div.es-carousel-peek-mobile {
+        @include breakpoints.media-breakpoint-down(sm) {
+            padding-right: v-bind(peekMobile);
+        }
+    }
 }
 
 /* card sizing, based on num visible at each breakpoint */

--- a/es-ds-components/components/es-carousel.vue
+++ b/es-ds-components/components/es-carousel.vue
@@ -4,7 +4,6 @@
      - circular has quirky behavior when numVisible doesn't match numScroll
         - you can see this in the circular autoplay example
         - i'm not sure if this is fixable
-     - figure out peek behavior
      - prop to position the arrows at the bottom two corners of a full-width slide, like homepage
 */
 

--- a/es-ds-docs/pages/organisms/carousel.vue
+++ b/es-ds-docs/pages/organisms/carousel.vue
@@ -92,6 +92,18 @@ const propTableRows = [
         '1',
         'The number of items visible at any one time. This is also used as the default mobile value when using breakpoints.',
     ],
+    [
+        'peekDesktop',
+        'string',
+        '""',
+        'Padding added to the right of the carousel on desktop viewports to give the rightmost card a peek or cut-off. Ex: "100px"; "6rem".',
+    ],
+    [
+        'peekMobile',
+        'string',
+        '""',
+        'Same as peekDesktop but only applies to mobile viewports.  Both must be set if peek should be applied to all viewports.',
+    ],
     ['showArrows', 'Boolean', 'true', 'Whether to show the arrows below the carousel.'],
     ['showDots', 'Boolean', 'true', 'Whether to show the dots below the carousel.'],
     ['slideGap', 'Number', '16', 'The spacing, in pixels, between each carousel slide.'],
@@ -184,7 +196,8 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
             <h2>Customization</h2>
             <p class="mb-200">
                 This example shows the ability to customize the gap between slides, the gap between the slides and the
-                controls, and the size and color of the arrow button icons.
+                controls, 'peek' styling for cards on desktop and mobile, and the size and color of the arrow button
+                icons.
             </p>
             <es-carousel
                 arrow-size="lg"
@@ -198,6 +211,8 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
                 :items="basicExampleItems"
                 :show-dots="false"
                 :slide-gap="32"
+                peek-desktop="125px"
+                peek-mobile="75px"
                 variant="brand">
                 <template #item="{ item }">
                     <es-card class="text-center">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Relevant to https://energysage.atlassian.net/browse/CED-1974

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Added `peekDesktop` and `peekMobile` props to `EsCarousel` because they were part of the design for the carousel on `whole-home` page, but also has come up before as something we want to support for more carousels
- Tweaked the `numDots` logic to take into account `numScroll` - the arrow placement was wonky when `numScroll` was not the same as `numVisible`

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

- "Customization" example on docs page http://localhost:8500/organisms/carousel
- Adding and removing one or both peek props; changing `numScroll` and `numVisible` at different viewports to test dots

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

-

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
