### PR TITLE
fix: accordion initial expand with multiple expand

### DIFF
--- a/es-ds-components/components/es-accordion-list.vue
+++ b/es-ds-components/components/es-accordion-list.vue
@@ -14,8 +14,7 @@ const props = withDefaults(defineProps<Props>(), {
     variant: 'default',
 });
 
-// eslint-disable-next-line vue/require-prop-types
-const model = defineModel();
+const model = defineModel<string>();
 
 // get the list of elements provided as children to the default slot
 const initialChildren = useSlots().default?.() || [];
@@ -29,7 +28,9 @@ initialChildren.forEach((child) => {
     }
 });
 
-const activeIndex = ref();
+type ActiveChildren = null | number | number[];
+
+const activeIndex: Ref<ActiveChildren> = ref(null);
 
 watch(model, (newVal) => {
     if (newVal) {
@@ -39,19 +40,30 @@ watch(model, (newVal) => {
 
 const accordionTabs = children.map((child, index) => {
     if (child.props.id === props.initialExpandedId || child.props.id === model.value) {
-        activeIndex.value = index;
+        if (props.allowMultipleExpand) {
+            activeIndex.value = [index];
+        } else {
+            activeIndex.value = index;
+        }
     }
     return child.children;
 });
 
-const updateActiveIndex = (index: any) => {
+const updateActiveIndex = (index: ActiveChildren) => {
     if (model.value) {
-        model.value = children[index]?.props.id || '';
+        if (typeof index === 'number') {
+            model.value = children[index]?.props.id || '';
+        } else if (index === null) {
+            model.value = '';
+        }
+        // There's another case where index will be an array. In that case, v-model is unsupported as specified
+        // in the documentation, so no update is made
     }
 };
 </script>
 
 <template>
+    <!-- @vue-expect-error PrimeVue's type information is wrong -->
     <accordion
         :multiple="allowMultipleExpand"
         :active-index="activeIndex"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-2041

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fix issue with `es-accordion` where if you allow multiple expand and set an initial expanded ID, the initial expanded one will not actually be initially expanded. This was due to incorrect type handling.
- I was not able to reproduce the issue of it needing two clicks on mobile, either on my computer or phone

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- On the [docs page](http://localhost:8500/molecules/accordion), you can see that the Multiple Expand example now actually has the first one expanded as requested
- Tested that the component still works in PageAccordionV2 in es-cms-pages (using `npm link`) at https://app.storyblok.com/#/me/spaces/1006156/stories/0/0/94177/blok/ed7a592a-773c-4fc9-afa5-51554dcb73f5#fe1280e3-08d9-4c47-8e0a-5f02647aa03e

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have documented testing approach
