### PR TITLE
fix: left-aligned the contextMessage per Asheeta's design

### DIFF
--- a/es-ds-components/components/es-zip-code-form.vue
+++ b/es-ds-components/components/es-zip-code-form.vue
@@ -111,7 +111,7 @@ const handleSubmit = () => {
         <div class="d-flex flex-column">
             <p
                 v-if="contextMessage"
-                class="mb-25 font-size-75">
+                class="mb-50 font-size-75 text-left">
                 {{ contextMessage }}
             </p>
             <form


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://energysage.atlassian.net/browse/CED-2115?atlOrigin=eyJpIjoiY2NiZDA2MDg1NjU0NGVkMmJiNjUzYzcwMDdhZjRhMWYiLCJwIjoiaiJ9

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


Previously, it was the case that because the overall hero module has a text-center on it, this text-center was also being applied to the contextMessage - which should always be left-aligned per [Asheeta's design](https://energysage.atlassian.net/browse/CED-2115?atlOrigin=eyJpIjoiY2NiZDA2MDg1NjU0NGVkMmJiNjUzYzcwMDdhZjRhMWYiLCJwIjoiaiJ9) on the ticket. The code changes here include the explicit left-alignment of the contextMessage in the EsZipCodeForm, such that no matter the context it's placed in, this contextMessage is always left-aligned. Additionally, per Asheeta's request, I've increased spacing in between the contextMessage and the zip code text field.


### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

Locally tested on es-cms-pages via storyblok. Attached are images of the page on both desktop and mobile, confirming the fix. 

<img width="1374" alt="Screenshot 2025-02-25 at 2 40 30 PM" src="https://github.com/user-attachments/assets/0ac8c250-8cb4-4906-8b9a-62cf45d5ce6e" />
[
<img width="1375" alt="Screenshot 2025-02-25 at 2 40 38 PM" src="https://github.com/user-attachments/assets/794ad15f-cbe7-42d2-9221-e4cc29c78f45" />
](url)
#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

@ericdouglaspratt  @lgeggleston general

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have included any Storyblok component schema updates.
- [ ] I have updated any applicable documentation.
