### PR TITLE
fix: resolve EsNavBarLink before using in dynamic component

### DIFF
--- a/es-ds-components/components/es-nav-bar-top-level-menu.vue
+++ b/es-ds-components/components/es-nav-bar-top-level-menu.vue
@@ -51,6 +51,9 @@ export default {
         checkboxId() {
             return `menu-${this.name}`;
         },
+        resolvedEsNavBarLink() {
+            return resolveComponent('es-nav-bar-link');
+        },
     },
 };
 </script>
@@ -76,7 +79,7 @@ export default {
             <!-- mobile link and fly-out menu trigger -->
             <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
             <component
-                :is="link ? 'es-nav-bar-link' : 'label'"
+                :is="link ? resolvedEsNavBarLink : 'label'"
                 class="nav-link d-flex d-lg-none align-items-center w-100 h-100 px-0 py-lg-100 px-100 font-weight-bold justify-content-between"
                 :class="{ 'dropdown-label': !link }"
                 :for="link ? undefined : checkboxId"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[CED-2206: Solar calculator link in mobile nav doesn't work](https://energysage.atlassian.net/browse/CED-2206)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolve `EsNavBarLink` before using it in dynamic component. This is explained in the helpful [Definitive Nuxt 3 Upgrade Guide](https://energysage.atlassian.net/wiki/spaces/FG/pages/1273561099/The+definitive+Nuxt+3+upgrade+guide#Dynamic-components).

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

I tested this by viewing the design system navbar locally at http://localhost:8500/organisms/nav-bar and resizing the viewport to a mobile width. After this change the Solar Calculator item became a usable link and the element changed from `<es-nav-bar-link>` to `<a>`.

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

-

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have included any Storyblok component schema updates.
- [ ] I have updated any applicable documentation.
