### PR TITLE
fix: header style for EsCollapse

### DIFF
--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -54,7 +54,7 @@ const onClick = ({ value }: { value: boolean }) => {
         :collapsed="!expanded"
         :header="expanded ? 'click to collapse content' : 'click to expand content'"
         :pt="{
-            header: 'align-items-center d-flex justify-content-between position-relative py-100',
+            header: 'd-flex flex-column justify-content-center position-relative py-100',
             icons: 'h-100 position-absolute w-100',
             root: border ? 'border-bottom border-top' : '',
             toggler: {

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -91,6 +91,29 @@ onMounted(async () => {
         </div>
 
         <div class="my-500">
+            <h2>Default, with multi-line header</h2>
+            <p>A normal EsCollapse component with a multi-line header. Click it to toggle showing its contents!</p>
+            <es-collapse>
+                <template #title>
+                    <h2 class="eyebrow">My eyebrow</h2>
+                    <h3 class="mb-0">My title</h3>
+                </template>
+                <!-- eslint-disable max-len -->
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
+                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
+                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
+                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
+                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
+                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
+                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
+                    elit quam.
+                </p>
+                <!-- eslint-enable max-len -->
+            </es-collapse>
+        </div>
+
+        <div class="my-500">
             <h2>Programmatic, with user override</h2>
             <p>
                 An EsCollapse component that takes a "visible" prop. Click the checkbox to toggle showing its contents!

--- a/es-ds-docs/pages/molecules/collapse.vue
+++ b/es-ds-docs/pages/molecules/collapse.vue
@@ -31,6 +31,16 @@ const toggledEventInSuggestedVisibleExample = (newValue: boolean) => {
     visible.value = newValue;
 };
 
+const loremIpsumText =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex ' +
+    'mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio. ' +
+    'Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor, ' +
+    'consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient ' +
+    'montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor ' +
+    'mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus ' +
+    'sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend ' +
+    'elit quam.';
+
 const { $prism } = useNuxtApp();
 const compCode = ref('');
 const docCode = ref('');
@@ -73,20 +83,11 @@ onMounted(async () => {
             <p>A normal EsCollapse component. Click it to toggle showing its contents!</p>
             <es-collapse>
                 <template #title>
-                    <h2 class="mb-0">My title</h2>
+                    <h3 class="mb-0">My title</h3>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 
@@ -95,21 +96,12 @@ onMounted(async () => {
             <p>A normal EsCollapse component with a multi-line header. Click it to toggle showing its contents!</p>
             <es-collapse>
                 <template #title>
-                    <h2 class="eyebrow">My eyebrow</h2>
-                    <h3 class="mb-0">My title</h3>
+                    <h3 class="eyebrow">My eyebrow</h3>
+                    <h4 class="mb-0">My title</h4>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 
@@ -131,20 +123,11 @@ onMounted(async () => {
                 @shown="shownEvent"
                 @toggled="toggledEvent">
                 <template #title>
-                    <h2 class="mb-0">My title</h2>
+                    <h3 class="mb-0">My title</h3>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 
@@ -168,20 +151,11 @@ onMounted(async () => {
                 @shown="shownEvent"
                 @toggled="toggledEventInSuggestedVisibleExample">
                 <template #title>
-                    <h2 class="mb-0">My title</h2>
+                    <h3 class="mb-0">My title</h3>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 
@@ -192,20 +166,11 @@ onMounted(async () => {
                 id="noBorderExample"
                 :border="false">
                 <template #title>
-                    <h2 class="mb-0">My title</h2>
+                    <h3 class="mb-0">My title</h3>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p class="m-0">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 
@@ -216,20 +181,11 @@ onMounted(async () => {
                 class="bg-yellow-100 py-100 px-150 rounded"
                 :border="false">
                 <template #title>
-                    <h2 class="mb-0">My title</h2>
+                    <h3 class="mb-0">My title</h3>
                 </template>
-                <!-- eslint-disable max-len -->
                 <p class="m-0">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi in aliquam ex. Nullam vestibulum ex
-                    mi, ut suscipit libero condimentum id. Pellentesque eu diam vel nisi molestie porta eget sed odio.
-                    Quisque congue risus id metus facilisis, non imperdiet libero rutrum. Mauris vitae ante porttitor,
-                    consectetur purus faucibus, euismod ex. Orci varius natoque penatibus et magnis dis parturient
-                    montes, nascetur ridiculus mus. Nulla ullamcorper elit sed viverra finibus. Mauris vitae tortor
-                    mauris. Cras suscipit nibh nec nisi cursus ornare. Maecenas quis turpis sit amet sapien dapibus
-                    sollicitudin viverra eu justo. Vivamus posuere metus sit amet purus tempus volutpat. Donec eleifend
-                    elit quam.
+                    {{ loremIpsumText }}
                 </p>
-                <!-- eslint-enable max-len -->
             </es-collapse>
         </div>
 


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-2207

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

It was discovered that when `EsCollapse` has both an eyebrow and heading in the title, the format was wrong (as seen below). This was because when `EsCollapse` was upgraded from using `b-collapse` and switched to using PrimeVue's `panel`, the `div` surrounding the #title slot was removed. This was fixed by changing the header style to remove the `align-items-center justify-content-between` styles and add in `justify-content-center` for centering the icon. This also cleans up the documentation code and adds a multi-line header example.
<img width="624" alt="Screenshot 2025-03-05 at 5 28 29 PM" src="https://github.com/user-attachments/assets/3fc0525c-d318-4629-92ce-ad1a82a65033" />

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested locally on http://localhost:8500/molecules/collapse, confirming the multi-line header example works and the existing examples still work as expected

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [x] automated check with the WAVE browser extension
  - [x] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have included any Storyblok component schema updates.
- [x] I have updated any applicable documentation.
