### PR TITLE
feat: fix EsCard bug that forces all root-relative URLs to be an internal navigation

### DIFF
--- a/es-ds-components/components/es-card.vue
+++ b/es-ds-components/components/es-card.vue
@@ -35,8 +35,14 @@ const actualVariant = computed(() => {
 });
 const defaultTag = computed(() => {
     // if an href is provided and no alternate link tag was provided (e.g. nuxt-link),
-    // force the tag to be a nuxt-link, no matter the variant
+    // force the tag to be an anchor tag, no matter the variant
     if (props.href && props.tag === 'div') {
+        return 'a';
+    }
+
+    // if a 'to' destination is provided and no alternate link tag was provided (e.g. nuxt-link),
+    // force the tag to be a nuxt-link, no matter the variant
+    if (props.to && props.tag === 'div') {
         return 'nuxt-link';
     }
 
@@ -57,7 +63,8 @@ const defaultTag = computed(() => {
         :is="defaultTag == 'nuxt-link' ? NuxtLink : defaultTag"
         class="es-card"
         :class="actualVariant"
-        :to="to ? to : href"
+        :href="href"
+        :to="to"
         v-bind="$attrs">
         <slot />
     </component>

--- a/es-ds-docs/pages/molecules/card.vue
+++ b/es-ds-docs/pages/molecules/card.vue
@@ -145,6 +145,27 @@ onMounted(async () => {
                     <ds-responsive-table-column :md="columnWidths.md[0]">
                         <template #name> Name </template>
                         <template #value>
+                            <code>to</code>
+                        </template>
+                    </ds-responsive-table-column>
+                    <ds-responsive-table-column :md="columnWidths.md[1]">
+                        <template #name> Default </template>
+                        <template #value>
+                            <code>undefined</code>
+                        </template>
+                    </ds-responsive-table-column>
+                    <ds-responsive-table-column :md="columnWidths.md[2]">
+                        <template #name> Description </template>
+                        <template #value>
+                            If card is intended to be an internal link within a Nuxt application, the URL destination
+                            should be passed in here.
+                        </template>
+                    </ds-responsive-table-column>
+                </ds-responsive-table-row>
+                <ds-responsive-table-row>
+                    <ds-responsive-table-column :md="columnWidths.md[0]">
+                        <template #name> Name </template>
+                        <template #value>
                             <code>variant</code>
                         </template>
                     </ds-responsive-table-column>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-2283

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- In a downstream Nuxt app, when passing a root-relative URL like `/about-us/company/` as the `href` to EsCard, it will use a `<nuxt-link>` by default, which assumes that root-relative URLs are part of the same application and attempts to navigate to it using internal navigation when clicked, rather than loading the full document - this means the link is broken and doesn't load the desired page, just a blank page
- This was breaking links downstream - found while testing https://github.com/EnergySage/es-cms-pages/pull/994 on int at https://int.www.energysage.dev/authors/ (scroll to bottom and click the About Us card)

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally at http://localhost:8500/molecules/card to ensure the examples all still worked
- Tested locally by linking to Pages and observing the correct behavior

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have included any Storyblok component schema updates.
- [ ] I have updated any applicable documentation.
