### PR TITLE
fix: popover hover functionality and arrow alignment

### DIFF
--- a/es-ds-components/components/es-popover.vue
+++ b/es-ds-components/components/es-popover.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { OverlayPanelState } from 'primevue/overlaypanel';
 import OverlayPanel from 'primevue/overlaypanel';
 
 const props = defineProps({
@@ -35,7 +36,7 @@ const showPanel = (event: Event) => {
     if (event.type !== 'mouseover') {
         triggeredBy.value = event.type;
     } else {
-        const overlayVisible = (op.value as any)?.visible as boolean | undefined;
+        const overlayVisible = (op.value as unknown as OverlayPanelState)?.visible;
         if (!overlayVisible) {
             triggeredBy.value = event.type;
         }

--- a/es-ds-components/components/es-popover.vue
+++ b/es-ds-components/components/es-popover.vue
@@ -48,6 +48,8 @@ const addHoverListener = () => {
     const targetElement = document.getElementById(props.target);
     const overlayElement = (op.value as any)?.container as HTMLElement | undefined;
     overlayElement?.addEventListener('mouseleave', () => {
+        // Add a 0.25s delay before closing the panel to ensure the user
+        // can hover over the target element before the panel closes
         setTimeout(() => {
             if (targetElement && !targetElement.matches(':hover') && triggeredBy.value === 'mouseover') {
                 closePanel();
@@ -65,6 +67,8 @@ onMounted(() => {
 
             if (trigger === 'mouseover') {
                 targetElement.addEventListener('mouseleave', () => {
+                    // Add a 0.25s delay before closing the panel to ensure the user
+                    // can hover over the popover body before it closes
                     setTimeout(() => {
                         if (triggeredBy.value === 'mouseover' && !(op.value as any)?.container?.matches(':hover')) {
                             closePanel();

--- a/es-ds-docs/pages/molecules/popover.vue
+++ b/es-ds-docs/pages/molecules/popover.vue
@@ -211,6 +211,93 @@ onMounted(async () => {
                     </es-popover>
                 </div>
             </div>
+            <div class="my-500">
+                <h2>Hover trigger</h2>
+                <div>
+                    <!-- eslint-disable vuejs-accessibility/label-has-for -->
+                    <label>
+                        With title
+                        <a
+                            id="hoverTitleTarget"
+                            class="p-0 text-gray-700 cursor-pointer-hover"
+                            tabindex="0">
+                            <icon-info
+                                width="16px"
+                                height="16px" />
+                        </a>
+                    </label>
+                    <es-popover
+                        target="hoverTitleTarget"
+                        variant="dark"
+                        triggers="hover focus">
+                        <template #title> My title </template>
+                        <p class="mb-0">
+                            Install solar panels through this program and get $250 cash back.
+                            <a
+                                class="mt-50 d-block cursor-pointer-hover"
+                                href="https://communitysolar.energysage.com/"
+                                target="_blank"
+                                >Learn more</a
+                            >
+                        </p>
+                    </es-popover>
+                </div>
+                <div>
+                    <label>
+                        No title
+                        <a
+                            id="hoverNoTitleTarget"
+                            class="p-0 text-gray-700 cursor-pointer-hover"
+                            tabindex="0">
+                            <icon-info
+                                width="16px"
+                                height="16px" />
+                        </a>
+                    </label>
+                    <es-popover
+                        target="hoverNoTitleTarget"
+                        variant="dark"
+                        triggers="hover focus">
+                        <p class="mb-0">
+                            Install solar panels through this program and get $250 cash back.
+                            <a
+                                class="mt-50 d-block cursor-pointer-hover"
+                                href="https://communitysolar.energysage.com/"
+                                target="_blank"
+                                >Learn more</a
+                            >
+                        </p>
+                    </es-popover>
+                </div>
+                <div>
+                    <label>
+                        With button
+                        <a
+                            id="hoverButtonTarget"
+                            class="p-0 text-gray-700 cursor-pointer-hover"
+                            tabindex="0">
+                            <icon-info
+                                width="16px"
+                                height="16px" />
+                        </a>
+                    </label>
+                    <es-popover
+                        target="hoverButtonTarget"
+                        variant="dark"
+                        triggers="hover focus">
+                        <template #title> My title </template>
+                        <p class="mb-0">
+                            Install solar panels through this program and get $250 cash back.
+                            <es-button
+                                size="sm"
+                                class="mt-100 d-block"
+                                variant="dark-bg">
+                                Small button
+                            </es-button>
+                        </p>
+                    </es-popover>
+                </div>
+            </div>
             <div class="mb-500">
                 <h2>EsPopover props</h2>
                 <ds-prop-table

--- a/es-ds-styles/scss/_popover.scss
+++ b/es-ds-styles/scss/_popover.scss
@@ -2,6 +2,7 @@
 @use "functions";
 @use "mixins/border-radius";
 @use "mixins/box-shadow";
+@use "mixins/breakpoints";
 @use "mixins/reset-text";
 @use "variables";
 @use "vendor/rfs";
@@ -76,6 +77,10 @@
       bottom: -(variables.$popover-arrow-height) - variables.$popover-border-width + 0.1rem;
       left: 0;
       clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+ 
+      @include breakpoints.media-breakpoint-down("xs") {
+          left: calc(var(--overlayArrowLeft) - 0.75rem);     
+      }      
 
       &::after {
         bottom: variables.$popover-border-width;
@@ -100,6 +105,10 @@
       top: -(variables.$popover-arrow-height) - variables.$popover-border-width + 0.1rem;
       left: 0;
       clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
+
+      @include breakpoints.media-breakpoint-down("xs") {
+        left: calc(var(--overlayArrowLeft) - 0.75rem);
+      }      
 
       &::after {
         top: variables.$popover-border-width;

--- a/es-ds-styles/scss/_popover.scss
+++ b/es-ds-styles/scss/_popover.scss
@@ -79,7 +79,7 @@
       clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
  
       @include breakpoints.media-breakpoint-down("xs") {
-          left: calc(var(--overlayArrowLeft) - 0.75rem);     
+        left: calc(var(--overlayArrowLeft) - 0.75rem);     
       }      
 
       &::after {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Updated `es-popover` so that when it is triggered by `hover`, it will be dismissed (after a 0.25s timeout) when neither the target nor the popover are being hovered over
- Updated docs to add examples of popovers triggered by `hover`
- Updated `arrow` styles for popover so that arrow is correctly aligned with target on xs viewports (previously was aligned all the way left)

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on docs page:
  - Hovering over icon or popover body keeps the popover visible
  - Hovering over icon -> mouseout closes the popover
  - Hovering over popover body -> mouseout closes the popover
  - Clicking on the icon shows the popover, and the popover stays open until a click outside
  - Tab through to focus on the icon opens the popover until a click outside
- Also tested that arrow points to the correct target across viewports

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- I tested this with `hover focus` and `hover click` triggers and got the expected results, but are there other triggers to worry about that might not play well with the hover?
- Any way around having to set the popover hover listener on every `show`?
- Are there best practices for choosing a timeout value? I just picked an arbitrary number to ensure that the popover stays open when the hover is moved from the target to the popover body
- Any other possible simplifications, since tracking whether either the popover body or target are being hovered over added complexity

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have updated any applicable documentation.
