### PR TITLE
fix: update EsCollapse to use aria-labbeledby for accessibility

### DIFF
--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -53,7 +53,7 @@ const onClick = ({ value }: { value: boolean }) => {
     <panel
         :collapsed="!expanded"
         :header="''"
-        :toggle-button-props="{ 'aria-labelledby': 'collapse-header'}"
+        :toggle-button-props="{ 'aria-labelledby': 'collapse-header' }"
         :pt="{
             header: 'd-flex flex-column justify-content-center position-relative py-100',
             icons: 'h-100 position-absolute w-100',

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -52,7 +52,8 @@ const onClick = ({ value }: { value: boolean }) => {
 <template>
     <panel
         :collapsed="!expanded"
-        :header="expanded ? 'click to collapse content' : 'click to expand content'"
+        :header="''"
+        :toggle-button-props="{ 'aria-labelledby': 'collapse-header'}"
         :pt="{
             header: 'd-flex flex-column justify-content-center position-relative py-100',
             icons: 'h-100 position-absolute w-100',
@@ -74,7 +75,9 @@ const onClick = ({ value }: { value: boolean }) => {
         toggleable
         @toggle="onClick">
         <template #header>
-            <slot name="title" />
+            <div id="collapse-header">
+                <slot name="title" />
+            </div>
         </template>
         <template #togglericon>
             <icon-chevron-down />

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -52,7 +52,6 @@ const onClick = ({ value }: { value: boolean }) => {
 <template>
     <panel
         :collapsed="!expanded"
-        :header="''"
         :toggle-button-props="{ 'aria-labelledby': 'collapse-header' }"
         :pt="{
             header: 'd-flex flex-column justify-content-center position-relative py-100',

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import Panel from 'primevue/panel';
-import { useId } from '#imports';
 
 const emit = defineEmits(['toggled', 'userClick']);
 

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import Panel from 'primevue/panel';
+import { useId } from '#imports';
+
 
 const emit = defineEmits(['toggled', 'userClick']);
 
@@ -20,6 +22,7 @@ const props = defineProps({
 });
 
 const userDeterminedState: Ref<boolean | null> = ref(null);
+const uniqueId = useId();
 
 // directly determines the expanded/collapsed state of the panel
 const expanded = computed(() => {
@@ -52,7 +55,7 @@ const onClick = ({ value }: { value: boolean }) => {
 <template>
     <panel
         :collapsed="!expanded"
-        :toggle-button-props="{ 'aria-labelledby': 'collapse-header' }"
+        :toggle-button-props="{ 'aria-labelledby': uniqueId }"
         :pt="{
             header: 'd-flex flex-column justify-content-center position-relative py-100',
             icons: 'h-100 position-absolute w-100',
@@ -74,7 +77,7 @@ const onClick = ({ value }: { value: boolean }) => {
         toggleable
         @toggle="onClick">
         <template #header>
-            <div id="collapse-header">
+            <div :id="uniqueId">
                 <slot name="title" />
             </div>
         </template>

--- a/es-ds-components/components/es-collapse.vue
+++ b/es-ds-components/components/es-collapse.vue
@@ -2,7 +2,6 @@
 import Panel from 'primevue/panel';
 import { useId } from '#imports';
 
-
 const emit = defineEmits(['toggled', 'userClick']);
 
 const model = defineModel<boolean>();


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://energysage.atlassian.net/browse/CED-2203?atlOrigin=eyJpIjoiMWI5Njg5ZTkyNzM5NDAzYzk5NmZiN2E2NzYyODMwOTkiLCJwIjoiaiJ9

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Previously, screen readers announced an incorrect header for the EsCollapse toggle. This change updates EsCollapse to use aria-labelledby on the header slot, so that the correct text is announced.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->

Tested locally at http://localhost:8500/molecules/collapse. The tab key focuses the toggle button and pressing Enter expands and collapses the panel. I also used VoiceOver on macOS so the toggle button now announces the correct header text through aria-labelledby. Images of using tab key to focus the toggle button and pressing enter, as well as using VoiceOver, is attached.

<img width="1504" alt="Screenshot 2025-04-15 at 4 10 24 PM" src="https://github.com/user-attachments/assets/5b4e7031-409a-42a6-95c9-f9dff7146caa" />
<img width="1512" alt="Screenshot 2025-04-15 at 4 10 57 PM" src="https://github.com/user-attachments/assets/0d3a1782-bb7b-4d99-a55c-2063b66f1cb7" />

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

general

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
