### PR TITLE
fix: es-tabs when comments are children  

### DIFF
--- a/es-ds-components/components/es-tabs.vue
+++ b/es-ds-components/components/es-tabs.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import TabPanel from 'primevue/tabpanel';
 import TabView from 'primevue/tabview';
+import { Comment } from 'vue';
 
 // allow use of v-model on this component
 const model = defineModel<number>();
 
-// get the list of elements provided as children to the default slot
-const initialChildren = useSlots().default?.() || [];
+// get the list of elements provided as children to the default slot - filtering out comments
+const rawChildren = useSlots().default?.() || [];
+const initialChildren = rawChildren.filter((child) => child.type !== Comment);
+
 const panels: any[] = [];
 initialChildren.forEach((child) => {
     // unless this has a v-for element and we instead need to access its children


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CORE-6387

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- filter out the comments from the initialChildren that are extracted from the slot 

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on docs page:
  - confirmed existing functionality did not change
  - checked that passing an es-tab with a v-if="false" can still render 
  - checked that adding in comments into the slots still allows the component to render  

used the following in the docs page to test on main branch vs. this one 
```
            <es-tabs>
                <es-tab title="Item one">
                    <p>Content one</p>
                </es-tab>
                <es-tab title="Item two">
                    <p>Content two</p>
                </es-tab>
                <es-tab title="Item three">
                    <p>Content three</p>
                </es-tab>
                <!--  -->
                <es-tab 
                    v-if="false"
                    title="Item four">
                    <p>Content four</p>
                </es-tab>
            </es-tabs>
```
#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Any better/cleaner ways to filter out the unnecessary children here? 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have updated any applicable documentation.
