### PR TITLE
feat: simplify EsPopover layout and allow text to go full width

### DIFF
--- a/es-ds-components/components/es-popover.vue
+++ b/es-ds-components/components/es-popover.vue
@@ -42,7 +42,7 @@ const emit = defineEmits(['update:show']);
                 :collision-padding="collisionPadding"
                 :side="side">
                 <popover-close
-                    class="es-popover-close align-items-center d-flex justify-content-center float-right mb-50 ml-50"
+                    class="es-popover-close align-items-center d-flex justify-content-center float-right mb-50 ml-50 position-relative"
                     :class="{ 'es-popover-close--light': variant === 'light' }">
                     <span class="sr-only">Close</span>
                     <icon-x
@@ -129,6 +129,9 @@ const emit = defineEmits(['update:show']);
     color: variables.$white;
     height: 28px;
     padding: 0;
+    /* better align top of close button with text */
+    right: -0.125rem;
+    top: -0.125rem;
     width: 28px;
 }
 

--- a/es-ds-components/components/es-popover.vue
+++ b/es-ds-components/components/es-popover.vue
@@ -42,7 +42,7 @@ const emit = defineEmits(['update:show']);
                 :collision-padding="collisionPadding"
                 :side="side">
                 <popover-close
-                    class="es-popover-close position-absolute"
+                    class="es-popover-close align-items-center d-flex justify-content-center float-right mb-50 ml-50"
                     :class="{ 'es-popover-close--light': variant === 'light' }">
                     <span class="sr-only">Close</span>
                     <icon-x
@@ -55,9 +55,8 @@ const emit = defineEmits(['update:show']);
                     :height="12"
                     rounded
                     :width="22" />
-                <div class="pr-300">
-                    <slot />
-                </div>
+                <slot />
+                <!-- the cta slot is kept for backwards compatibility but is deprecated -->
                 <slot name="cta" />
             </popover-content>
         </popover-portal>
@@ -129,9 +128,7 @@ const emit = defineEmits(['update:show']);
     border: none;
     color: variables.$white;
     height: 28px;
-    right: 1rem;
     padding: 0;
-    top: 0.75rem;
     width: 28px;
 }
 

--- a/es-ds-docs/pages/molecules/popover.vue
+++ b/es-ds-docs/pages/molecules/popover.vue
@@ -35,14 +35,7 @@ const propTableWidths = {
     md: ['3', '2', '2', '5'],
 };
 
-const slotTableRows = [
-    ['trigger', 'n/a', 'Required. The icon and/or content to put inside the trigger button.'],
-    [
-        'cta',
-        'n/a',
-        'Optional. Use to enable a link or button to appear at the bottom of the popover content and take up the full width of the popover.',
-    ],
-];
+const slotTableRows = [['trigger', 'n/a', 'Required. The icon and/or content to put inside the trigger button.']];
 
 const eventTableRows = [
     ['update:show', 'boolean', 'Event handler called when the open state of the popover changes.'],
@@ -156,10 +149,8 @@ onMounted(async () => {
             <div class="my-500">
                 <h2>Headings and CTAs</h2>
                 <p>
-                    These examples show the recommended styling for headings and how to insert a link or button into
-                    the bottom of the popover. Since the popover has padding on the right side to make room for the
-                    close button, the <code>cta</code> slot allows you to insert a link or button at the bottom of the
-                    popover that can go full width without that padding.
+                    These examples show the recommended styling for headings and how a link or button should appear at
+                    the bottom of the popover.
                 </p>
                 <p>
                     This popover contains a heading and a link
@@ -173,14 +164,12 @@ onMounted(async () => {
                         <p class="mb-50">
                             This is the body text for the popover and it can be long or short as needed.
                         </p>
-                        <template #cta>
-                            <a
-                                class="text-white"
-                                href="https://www.energysage.com/"
-                                target="_blank">
-                                Learn about EnergySage
-                            </a>
-                        </template>
+                        <a
+                            class="text-white"
+                            href="https://www.energysage.com/"
+                            target="_blank">
+                            Learn about EnergySage
+                        </a>
                     </es-popover>
                 </p>
                 <p>
@@ -193,16 +182,14 @@ onMounted(async () => {
                         </template>
                         <h3 class="font-size-100 mb-50 text-white">This is a heading</h3>
                         <p>This is the body text for the popover and it can be long or short as needed.</p>
-                        <template #cta>
-                            <es-button
-                                class="w-100"
-                                href="https://www.energysage.com/"
-                                outline
-                                target="_blank"
-                                variant="dark-bg">
-                                About EnergySage
-                            </es-button>
-                        </template>
+                        <es-button
+                            class="w-100"
+                            href="https://www.energysage.com/"
+                            outline
+                            target="_blank"
+                            variant="dark-bg">
+                            About EnergySage
+                        </es-button>
                     </es-popover>
                 </p>
             </div>
@@ -309,13 +296,11 @@ onMounted(async () => {
                         <p class="mb-50">
                             This is the body text for the popover and it can be long or short as needed.
                         </p>
-                        <template #cta>
-                            <a
-                                href="https://www.energysage.com/"
-                                target="_blank">
-                                Learn about EnergySage
-                            </a>
-                        </template>
+                        <a
+                            href="https://www.energysage.com/"
+                            target="_blank">
+                            Learn about EnergySage
+                        </a>
                     </es-popover>
                 </p>
                 <p>
@@ -331,15 +316,13 @@ onMounted(async () => {
                         </template>
                         <h3 class="font-size-100 mb-50">This is a heading</h3>
                         <p>This is the body text for the popover and it can be long or short as needed.</p>
-                        <template #cta>
-                            <es-button
-                                class="w-100"
-                                href="https://www.energysage.com/"
-                                outline
-                                target="_blank">
-                                About EnergySage
-                            </es-button>
-                        </template>
+                        <es-button
+                            class="w-100"
+                            href="https://www.energysage.com/"
+                            outline
+                            target="_blank">
+                            About EnergySage
+                        </es-button>
                     </es-popover>
                 </p>
             </div>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- n/a

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- All previous iterations of EsPopover had hardcoded right-side padding across the entire height of the popover contents in order to make room for the close button - this PR floats the close button to the right so text and other content can go full width beneath it and better make use of all available space (especially helpful for when the popover contains a lot of text)
- Because of this, the `cta` slot is no longer needed to allow buttons to go full width, so it's kept for backwards compatibilty but silently deprecated and no longer documented

### Before (side padding)
<img width="619" alt="Screenshot 2025-04-23 at 7 40 56 AM" src="https://github.com/user-attachments/assets/3c68712f-b0ee-42a1-99c7-c0b8569f7c58" />

### After (text wrapping around the floated close button)
<img width="591" alt="Screenshot 2025-04-23 at 7 49 34 AM" src="https://github.com/user-attachments/assets/ede4e6e0-b200-4fc3-9264-c10cfe71f422" />

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on EsPopover and EsTooltip docs pages
- Tested by npm linking to Pages and viewing solar data explorers page

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
