### PR TITLE
fix: EsProgress visual issue that appears only in SSG

### DIFF
--- a/es-ds-components/components/es-progress.vue
+++ b/es-ds-components/components/es-progress.vue
@@ -3,9 +3,7 @@ import ProgressBar from 'primevue/progressbar';
 
 const BASE_FONT_SIZE = 16;
 const DEFAULT_BAR_HEIGHT = 2;
-const DEFAULT_BORDER_WIDTH = 0.5;
 const DEFAULT_CIRCLE_GLOW_SIZE = 4;
-const DEFAULT_INSET_SHADOW_SIZE = 0.5;
 const DIFF_CIRCLE_SIZE_FROM_BAR_HEIGHT_IN_PX = 4;
 const DEFAULT_CIRCLE_DIMENSION = DEFAULT_BAR_HEIGHT + DIFF_CIRCLE_SIZE_FROM_BAR_HEIGHT_IN_PX;
 
@@ -57,14 +55,8 @@ const circleDimension = computed(
 
 const circleDimensionPx = computed(() => `${circleDimension.value}px`);
 const circleRightPx = computed(() => `${circleDimension.value * -0.5}px`);
-const circleBorderWidthPx = computed(
-    () => `${(DEFAULT_BORDER_WIDTH * circleDimension.value) / DEFAULT_CIRCLE_DIMENSION}px`,
-);
 const circleGlowSizePx = computed(
     () => `${(DEFAULT_CIRCLE_GLOW_SIZE * circleDimension.value) / DEFAULT_CIRCLE_DIMENSION}px`,
-);
-const circleInsetShadowSizePx = computed(
-    () => `${(DEFAULT_INSET_SHADOW_SIZE * circleDimension.value) / DEFAULT_CIRCLE_DIMENSION}px`,
 );
 
 const verticalContainerPaddingPx = computed(() =>
@@ -100,10 +92,18 @@ const verticalContainerPaddingPx = computed(() =>
     padding-top: v-bind(verticalContainerPaddingPx);
 
     :deep(.progress-bar--with-circle::after) {
-        border: v-bind(circleBorderWidthPx) solid variables.$warm-orange;
-        box-shadow:
-            0 0 v-bind(circleInsetShadowSizePx) v-bind(circleInsetShadowSizePx) variables.$warm-orange inset,
-            0 0 v-bind(circleGlowSizePx) 0 variables.$warm-orange;
+        /*
+         * using v-bind for this border width gets disappeared during npm run generate,
+         * so we need to hardcode it, and the radial background gradient makes it look
+         * good enough at larger sizes
+         */
+        border: 0.5px solid variables.$warm-orange;
+        /*
+         * do not mix both an inset box shadow (has been converted to radial background gradient)
+         * with a non-inset box shadow while using v-bind, or you will get unexpected results
+         * after npm run generate
+         */
+        box-shadow: 0 0 v-bind(circleGlowSizePx) variables.$warm-orange;
         height: v-bind(circleDimensionPx);
         right: v-bind(circleRightPx);
         width: v-bind(circleDimensionPx);

--- a/es-ds-styles/scss/_progress.scss
+++ b/es-ds-styles/scss/_progress.scss
@@ -40,6 +40,7 @@
 .progress-bar--with-circle {
   &::after {
     background: variables.$white;
+    background: radial-gradient(circle, variables.$white 0%, variables.$white 40%, variables.$warm-orange 70%, variables.$warm-orange 100%);
     border: 0.5px solid variables.$warm-orange;
     border-radius: 50%;
     box-shadow: (0 0 1px 1px variables.$warm-orange inset, 0 0 4px 0 variables.$warm-orange);


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-2478

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes a visual bug in EsProgress that only appeared on the static-site-generated version (which you can see at the [currently deployed version of the docs site](https://design.energysage.dev/molecules/progress/))
- The `border: var() solid #ff9133` style generated on local dev server was being static-site generated as `border: solid #ff9133` (and therefore not applying due to lack of width), so switched to a hardcoded border width of `0.5px`
- The `box-shadow: inset 0 0 var() var() #ff9133, 0 0 var() 0 #ff9133` style generated on local dev server was being static-site generated as `box-shadow: inset 0 0 var() var() #ff9133, 0 0 0 var() #ff9133` (the final zero switched positions), turning a blur radius into a spread radius and looking terrible, so removed the trailing zero (as it's technically unnecessary), which didn't totally fix it, so converted the inset box-shadow into a radial background gradient (which scales without the need for `v-bind`), which did fix it

### Before (generated version)
<img width="901" alt="Screenshot 2025-07-09 at 8 47 57 AM" src="https://github.com/user-attachments/assets/dfadebd0-69da-4b69-a655-38e3bbc7b2a2" />

### After (generated version)
<img width="897" alt="Screenshot 2025-07-09 at 8 48 13 AM" src="https://github.com/user-attachments/assets/83c50727-efc9-4e1e-98ed-d79c76118e2e" />

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally via `make dev` and `cd es-ds-docs && npm run generate` until they were the same

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
