### PR TITLE
fix: modals without headers are now accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.2 - 2025-07-10
+
+- Fixed an accessibility issue with EsModal where focus would not be given to the modal when opened if the `closeable` prop was set to false
+
 ## 3.2.1 - 2025-07-09
 
 - Fixed a visual bug with EsProgress where the circle appeared much larger than intended

--- a/es-ds-components/components/es-modal.vue
+++ b/es-ds-components/components/es-modal.vue
@@ -35,7 +35,7 @@ const modalPt = {
             {
                 // if closable is true, keep the close button around (for accessibility, and to
                 // allow Escape to still close the modal), but hide it visually
-                'sr-only': !props.closable
+                'sr-only': !props.closable,
             },
         ],
     },

--- a/es-ds-components/components/es-modal.vue
+++ b/es-ds-components/components/es-modal.vue
@@ -30,7 +30,14 @@ const modalPt = {
         class: 'modal-title',
     },
     closeButton: {
-        class: 'close',
+        class: [
+            'close',
+            {
+                // if closable is true, keep the close button around (for accessibility, and to
+                // allow Escape to still close the modal), but hide it visually
+                'sr-only': !props.closable
+            },
+        ],
     },
     content: {
         class: `modal-body ${props.bodyClass}`,
@@ -72,7 +79,6 @@ const getSizeClass = computed(() => {
         modal
         :class="getSizeClass"
         :pt="modalPt"
-        :closable="closable"
         dismissable-mask
         @update:visible="onChange">
         <template

--- a/es-ds-components/package-lock.json
+++ b/es-ds-components/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@energysage/es-ds-components",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@energysage/es-ds-components",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "license": "MIT",
             "dependencies": {
                 "@energysage/es-ds-styles": "^3.2.1",

--- a/es-ds-components/package.json
+++ b/es-ds-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@energysage/es-ds-components",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "private": false,
     "type": "module",
     "description": "An EnergySage Vue component library",

--- a/es-ds-docs/package-lock.json
+++ b/es-ds-docs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.2.1",
             "hasInstallScript": true,
             "dependencies": {
-                "@energysage/es-ds-components": "^3.2.1",
+                "@energysage/es-ds-components": "^3.2.2",
                 "@energysage/es-ds-styles": "^3.2.1",
                 "@nuxt/image": "^1.8.0",
                 "@nuxt/kit": "^3.13.1",
@@ -589,9 +589,9 @@
             }
         },
         "node_modules/@energysage/es-ds-components": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@energysage/es-ds-components/-/es-ds-components-3.2.1.tgz",
-            "integrity": "sha512-rL2gcrff9kIsJPVF5ZbrSlgwo5zCt5SXdQozLWqwLcyiEofnwJF1v9O9O7NIENiYodC9okKAOVWMUxnoJTi4Qg==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@energysage/es-ds-components/-/es-ds-components-3.2.2.tgz",
+            "integrity": "sha512-LEidiScTKLwxnZJuWQxCdeZOCuYKOl5aFowf4O0AlynTFVqNAWJAtJxPk7zRNIepaKiflcSWWpukH50aAQ0jug==",
             "license": "MIT",
             "dependencies": {
                 "@energysage/es-ds-styles": "^3.2.1",

--- a/es-ds-docs/package.json
+++ b/es-ds-docs/package.json
@@ -17,7 +17,7 @@
         "format": "npm run format:prettier && npm run format:eslint"
     },
     "dependencies": {
-        "@energysage/es-ds-components": "^3.2.1",
+        "@energysage/es-ds-components": "^3.2.2",
         "@energysage/es-ds-styles": "^3.2.1",
         "@nuxt/image": "^1.8.0",
         "@nuxt/kit": "^3.13.1",


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-2488

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes the no-header modal example's accessibility so that focus is again given to the modal when it opens (its focus trap was already working, but you had to tab through the whole page before you'd get put into it)
- Accomplishes this by retaining the close button even when the `closeable` prop is set to false, because [PrimeVue's focus logic](https://github.com/primefaces/primevue/blob/3.53.0/components/lib/dialog/Dialog.vue#L198) searches for elements with an `autofocus` attribute, and failing that, gives focus to the close button (which before this change, didn't exist, so it gave focus to nothing)
- This has the added benefit of meaning the no-header modal is closable via Esc key (because PrimeVue requires the `closeable` prop to be true before it enables that functionality)
- This does mean that tabbing through a modal for visual users will cycle through the close button, even though it's not visible, but that will allow screen reader users to access it (and it does already have an appropriate `aria-label`) - I think this is a good compromise to allow most accessibility features to work for the modal in this case

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on http://localhost:8500/molecules/modal

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [x] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
