### PR TITLE
fix: add another permission to allow github actions to add labels to PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ permissions:
     contents: write
     pull-requests: write
     id-token: write
+    issues: write
 
 name: release-please
 


### PR DESCRIPTION
Another permission tweak as per https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2780292262