### PR TITLE
fix: automatically bump package versions, update changelog to reflect reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+_**Note: This file is no longer being updated as a result of the adoption of release-please.
+Instead, the changelogs within each package are being updated automatically by release-please.
+See the changelogs for [es-ds-styles](./es-ds-styles/CHANGELOG.md), 
+[es-ds-components](./es-ds-components/CHANGELOG.md), and 
+[es-ds-docs](./es-ds-docs/CHANGELOG.md).**_
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,5 +4,6 @@
         "es-ds-components": {},
         "es-ds-docs": {}
     },
+    "plugins": ["node-workspace"],
     "bootstrap-sha": "65134ee8cb2806cff99b4924da2d06aa6a45ff17"
 }


### PR DESCRIPTION
- Added the node-workspace package as per https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#node-workspace in order to bump the referenced package versions automatically in the release-please PRs
- Update root CHANGELOG.md to reflect that changelogs are now stored in the packages