### PR TITLE
fix: update EsFormCheckbox focus state to only show on focus-visible

### DIFF
--- a/es-ds-styles/scss/_custom-forms.scss
+++ b/es-ds-styles/scss/_custom-forms.scss
@@ -43,7 +43,7 @@
     @include box-shadow.box-shadow(variables.$custom-control-indicator-checked-box-shadow);
   }
 
-  &:focus ~ .custom-control-label::before, &:has(.custom-radio-input:focus) ~ .custom-control-label::before {
+  &:focus-visible ~ .custom-control-label::before, &:has(.custom-radio-input:focus-visible) ~ .custom-control-label::before {
     // the mixin is not used here to make sure there is feedback
     @if variables.$enable-shadows {
       box-shadow: variables.$input-box-shadow, variables.$custom-control-indicator-focus-box-shadow;
@@ -52,11 +52,7 @@
     }
   }
 
-  &:focus:not(:checked) ~ .custom-control-label::before, &:has(.custom-radio-input:focus):not(:has(.custom-radio-input:checked)) ~ .custom-control-label::before {
-    border-color: variables.$custom-control-indicator-focus-border-color;
-  }
-
-  &:not(:disabled):not(:focus):not(:has(.custom-radio-input:disabled)):not(:has(.custom-radio-input:focus)) ~ .custom-control-label:hover::before {
+  &:not(:disabled):not(:focus-visible):not(:has(.custom-radio-input:disabled)):not(:has(.custom-radio-input:focus-visible)) ~ .custom-control-label:hover::before {
     // the mixin is not used here to make sure there is feedback
     box-shadow: variables.$custom-control-indicator-hover-box-shadow;
   }
@@ -67,6 +63,14 @@
     border-color: variables.$custom-control-indicator-active-border-color;
     // the mixin is not used here to make sure there is feedback
     box-shadow: variables.$custom-control-indicator-active-box-shadow;
+  }
+
+  &:focus-visible:not(:disabled):active ~ .custom-control-label::before, &:focus-visible:not(:has(.custom-radio-input:disabled)):active ~ .custom-control-label::before {
+    @if variables.$enable-shadows {
+      box-shadow: variables.$input-box-shadow, variables.$custom-control-indicator-focus-box-shadow;
+    } @else {
+      box-shadow: variables.$custom-control-indicator-focus-box-shadow;
+    }
   }
 
   // Use [disabled] and :disabled to work around https://github.com/twbs/bootstrap/issues/28247


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-2550

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- The focus state of EsFormCheckbox will now only show on `focus-visible` rather than `focus` so as not to distract mouse users
- Fixed a bug where the big round focus outline would briefly change to another color on mouse/key down
- Fixed a bug where the checkbox would lose its border when focused and unchecked

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
