### PR TITLE
fix: remove unoverridable margin from form message

### DIFF
--- a/es-ds-components/components/es-form-msg.vue
+++ b/es-ds-components/components/es-form-msg.vue
@@ -64,6 +64,11 @@ watch(
 </template>
 
 <style lang="scss" scoped>
+.es-form-msg {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+}
+
 .form-msg {
     flex: 0 0 100%;
     padding-right: 2.5rem;

--- a/es-ds-components/components/es-form-msg.vue
+++ b/es-ds-components/components/es-form-msg.vue
@@ -42,7 +42,7 @@ watch(
             role="alert"
             aria-live="polite"
             aria-atomic="true"
-            class="alert es-form-msg my-100 alert-dismissible"
+            class="alert es-form-msg alert-dismissible"
             :class="`alert-${variant}`">
             <div class="d-flex pr-100">
                 <div class="icon-wrapper flex-shrink-0 mr-100">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-2506

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
We are using EsFormMessage on the edit details page of HomeScore, and realized that the `my-100` style is not easily overridden. This styling should be set by app using this component.

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested on http://localhost:8500/molecules/form-message, the docs page already had `class='my-100'` that was being overridden.

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [x] automated check with the WAVE browser extension
  - [x] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have updated any applicable documentation.
