### PR TITLE
feat: dropdown tweaks

### DIFF
--- a/es-ds-components/components/es-dropdown-select.vue
+++ b/es-ds-components/components/es-dropdown-select.vue
@@ -73,7 +73,7 @@ const hide = () => {
         <dropdown
             :input-id="id"
             :class="[
-                'es-dropdown es-form-input form-control d-flex align-items-center justify-content-between',
+                'es-dropdown es-form-input form-control d-flex align-items-center justify-content-between position-relative',
                 {
                     disabled: isDisabled,
                     focused: isFocused && !isInputClicked && !isOpen && !isLabelClicked,
@@ -90,12 +90,12 @@ const hide = () => {
             :options="options"
             :placeholder="options.length === 0 ? 'No available options' : placeholder"
             :pt="{
-                panel: { class: 'es-dropdown-panel bg-white rounded-xs' },
+                panel: { class: 'es-dropdown-panel bg-white rounded-xs w-100' },
                 wrapper: { class: 'es-dropdown-wrapper' },
                 list: { class: 'p-0 m-0 list-unstyled' },
                 input: {
                     class: [
-                        'es-dropdown-input',
+                        'es-dropdown-input h-100 text-truncate',
                         {
                             'es-dropdown-input--placeholder': modelValue === undefined && state !== false,
                         },
@@ -103,13 +103,15 @@ const hide = () => {
                 },
                 item: {
                     class: [
-                        'es-dropdown-item d-flex justify-content-between p-100 pl-200',
+                        'es-dropdown-item d-flex justify-content-between p-100 pl-200 align-items-center',
                         {
                             'input-focused position-relative': isFocused && !isInputClicked && !isLabelClicked,
                         },
                     ],
                 },
+                trigger: { class: 'h-100' },
             }"
+            append-to="self"
             scroll-height="15.75rem"
             v-bind="$attrs"
             @update:model-value="emit('update:modelValue', $event)"
@@ -130,11 +132,13 @@ const hide = () => {
                     ]" />
             </template>
             <template #option="slotProps">
-                <span>{{ slotProps.option.label ? slotProps.option.label : slotProps.option }}</span>
+                <span class="option-label">{{
+                    slotProps.option.label ? slotProps.option.label : slotProps.option
+                }}</span>
                 <icon-check
                     v-if="isSelected(slotProps.option)"
                     height="1.5rem"
-                    class="text-gray-700" />
+                    class="text-gray-700 flex-shrink-0 ml-25" />
             </template>
         </dropdown>
         <small
@@ -167,10 +171,6 @@ const hide = () => {
     }
 
     .es-dropdown-input {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-
         &:focus-visible {
             outline: 0;
         }
@@ -224,6 +224,10 @@ const hide = () => {
 .es-dropdown-item {
     cursor: pointer;
     transition: background-color 0.15s ease-in-out;
+
+    .option-label {
+        overflow-wrap: anywhere;
+    }
 
     &:hover,
     &:not(.input-focused)[data-p-focused='true'] {

--- a/es-ds-components/components/es-dropdown-select.vue
+++ b/es-ds-components/components/es-dropdown-select.vue
@@ -29,6 +29,7 @@ const isOpen = ref(false);
 const isFocused = ref(false);
 const isInputClicked = ref(false);
 const isLabelClicked = ref(false);
+const isDisabled = computed(() => props.disabled || props.options.length === 0);
 
 const isSelected = (option: any) => option === props.modelValue;
 
@@ -74,25 +75,24 @@ const hide = () => {
             :class="[
                 'es-dropdown es-form-input form-control d-flex align-items-center justify-content-between',
                 {
-                    disabled: disabled,
+                    disabled: isDisabled,
                     focused: isFocused && !isInputClicked && !isOpen && !isLabelClicked,
                     'focused-on-click': isOpen || isLabelClicked || isInputClicked,
                     'is-invalid': state === false,
                 },
             ]"
             :aria-labelledby="labelId"
-            :disabled="disabled"
+            :disabled="isDisabled"
             :focus-on-hover="false"
             :model-value="modelValue"
             :option-label="options.length > 0 && typeof options[0] === 'object' ? 'label' : undefined"
             :option-value="options.length > 0 && typeof options[0] === 'object' ? 'value' : undefined"
             :options="options"
-            :placeholder="placeholder"
+            :placeholder="options.length === 0 ? 'No available options' : placeholder"
             :pt="{
                 panel: { class: 'es-dropdown-panel bg-white rounded-xs' },
                 wrapper: { class: 'es-dropdown-wrapper' },
                 list: { class: 'p-0 m-0 list-unstyled' },
-                emptyMessage: { class: 'p-100 pl-200 bg-gray-50' },
                 input: {
                     class: [
                         'es-dropdown-input',
@@ -124,8 +124,8 @@ const hide = () => {
                     height="1.125rem"
                     :class="[
                         {
-                            'text-gray-500': disabled,
-                            'text-gray-900': !disabled && state !== false,
+                            'text-gray-500': isDisabled,
+                            'text-gray-900': !isDisabled && state !== false,
                         },
                     ]" />
             </template>

--- a/es-ds-components/components/es-dropdown-select.vue
+++ b/es-ds-components/components/es-dropdown-select.vue
@@ -92,6 +92,7 @@ const hide = () => {
                 panel: { class: 'es-dropdown-panel bg-white rounded-xs' },
                 wrapper: { class: 'es-dropdown-wrapper' },
                 list: { class: 'p-0 m-0 list-unstyled' },
+                emptyMessage: { class: 'p-100 pl-200 bg-gray-50' },
                 input: {
                     class: [
                         'es-dropdown-input',
@@ -166,6 +167,10 @@ const hide = () => {
     }
 
     .es-dropdown-input {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
         &:focus-visible {
             outline: 0;
         }

--- a/es-ds-docs/pages/molecules/dropdown-select.vue
+++ b/es-ds-docs/pages/molecules/dropdown-select.vue
@@ -177,6 +177,17 @@ const dropdownProps = [
         </div>
 
         <div class="mb-500">
+            <h2>No options</h2>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-dropdown-select
+                        v-model="selectedSize"
+                        :options="[]" />
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
             <h2>No placeholder</h2>
             <div class="row">
                 <div class="col-md-6">

--- a/es-ds-docs/pages/molecules/dropdown-select.vue
+++ b/es-ds-docs/pages/molecules/dropdown-select.vue
@@ -19,7 +19,13 @@ const selectedColor = ref<string | undefined>(undefined);
 const selectedSize = ref<string | undefined>(undefined);
 const selectedContinent = ref<string | undefined>(undefined);
 
-const fruits = ['Apple', 'Banana', 'Grape', 'Orange'];
+const fruits = [
+    'Apple',
+    'Banana',
+    'Grape',
+    'Orange',
+    'This is a really long example to show that the dropdown can handle long text options',
+];
 
 const tropicalFruits = ['Mango', 'Papaya', 'Pineapple', 'Coconut'];
 


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://energysage.atlassian.net/browse/CED-2580

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR makes the following changes to `EsDropdown`:
- Long text within the dropdown control gets an ellipsis rather than wrapping to the next line
- The dropdown popup never grows in width beyond the width of the dropdown control
- Long text within an option wraps to the next line as needed (if selected, the check mark remains centered)
- The “no options” case is styled like the disabled example, with "No options available" placeholder text (already confirmed with Asheeta)

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested locally on http://localhost:8500/examples/form-field-validation and http://localhost:8500/molecules/dropdown-select to make sure all of the cases above work correct. I also tested with an option like "thisisareallylongwordthatshouldprobablynotbeusedbutshouldbecutoff" to show that it cuts off in the middle of the word

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- The form-field-validation example looks 1px shifted down, I'm not sure if it's a) noticeable and b) fixable?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
