### PR TITLE
fix: pass toggle attrs to inner div

### DIFF
--- a/es-ds-components/components/es-toggle.vue
+++ b/es-ds-components/components/es-toggle.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 import { SwitchRoot, SwitchThumb } from 'reka-ui';
+// Prevents attributes from being applied to first <div>
+defineOptions({
+    inheritAttrs: false,
+});
 
 const switchId = useId();
 const model = defineModel<boolean>({


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Our components that use Reka UI come with an interesting caveat - client vs. server-side rendering is different based on the following code:
```
// Workaround: Reka UI components don't play nice with the Nuxt 3.16+ dev server side rendering while using NPM link
const wrappingComponent = import.meta.dev ? resolveComponent('ClientOnly') : 'div';
```
In order to get classes to pass to the inner div that is only generated on the server side, `v-bind="$attrs"` must be added and `inheritAttrs: false` must be set so that classes aren't applied to the outer div

### 🥼 Testing

<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
Tested by adding a toggle to the docs page that passes utility and custom classes and running `npm run generate`. I removed it after testing because it is a rather specific example of styling for HomeScore

<img width="554" height="557" alt="Screenshot 2025-09-17 at 9 43 34 AM" src="https://github.com/user-attachments/assets/383a2a22-716a-41a4-8924-a1e396898386" />

#### 🧐 Feedback Requested / Focus Areas

<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->

- General

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [x] automated check with the WAVE browser extension
  - [x] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have updated any applicable documentation.
