### PR TITLE
fix: bug with EsProgress preventing height prop from being reactive

### DIFF
--- a/es-ds-components/components/es-progress.vue
+++ b/es-ds-components/components/es-progress.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
     valueClass: '',
 });
 
-const progressBarPt = {
+const progressBarPt = computed(() => ({
     value: {
         class: [
             'EsProgressValue progress-bar overflow-visible position-relative rounded-sm',
@@ -37,7 +37,7 @@ const progressBarPt = {
             height: props.height,
         },
     },
-};
+}));
 
 const barHeight = computed(() => {
     let barHeight = DEFAULT_BAR_HEIGHT;

--- a/es-ds-docs/pages/molecules/progress.vue
+++ b/es-ds-docs/pages/molecules/progress.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const animatedProgressExample = ref(20);
+const dynamicSizeSetting = ref('sm');
 const showValueExample = ref(20);
 
 const { $prism } = useNuxtApp();
@@ -170,6 +171,31 @@ onMounted(async () => {
         </div>
 
         <div class="my-500">
+            <h2>Dynamic height change</h2>
+            <p>The height of the progress bar can also be changed dynamically as needed.</p>
+            <div class="dynamic-size-example align-items-center d-flex">
+                <es-progress
+                    class="mb-100 w-100"
+                    :height="dynamicSizeSetting === 'lg' ? '0.25rem' : '0.125rem'"
+                    :value="50" />
+            </div>
+            <div class="mb-100">
+                <es-button
+                    class="px-50 mr-50"
+                    size="sm"
+                    @click="dynamicSizeSetting = 'sm'">
+                    Small
+                </es-button>
+                <es-button
+                    class="px-50"
+                    size="sm"
+                    @click="dynamicSizeSetting = 'lg'">
+                    Large
+                </es-button>
+            </div>
+        </div>
+
+        <div class="my-500">
             <h2>Hide indicator circle</h2>
             <p>This example shows how to hide the indicator circle for a simpler progress bar.</p>
             <es-progress
@@ -207,3 +233,9 @@ onMounted(async () => {
             doc-source="es-ds-docs/pages/molecules/progress.vue" />
     </div>
 </template>
+
+<style lang="scss" scoped>
+.dynamic-size-example {
+    height: 40px;
+}
+</style>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CED-2616

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Realized while attempting to have a thicker progress bar on mobile than on desktop based on feedback from design that this wasn't possible because the `height` prop wasn't flowing into a `computed()` value, just an object that was initialized once and never changed
- Fixed this so `height` is now reactive
- Added an example to the Progress docs page to demonstrate dynamic height changing

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested on the Progress docs page

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
