### PR TITLE
fix: reduce mystery focus items when keyboard-navigating back out of a submenu from two to one

### DIFF
--- a/es-ds-components/app/components/es-mobile-sub-nav.vue
+++ b/es-ds-components/app/components/es-mobile-sub-nav.vue
@@ -66,12 +66,10 @@ const focusOutside = (e: any) => {
         const classesOnTarget = [...e.target.classList];
 
         if (classesOnTarget.includes('es-mobile-sub-nav-item-trigger')) {
-            // if the user has moved focus outside of the this submenu and onto
-            // another submenu trigger, close this submenu
-            const triggerSubNav = e.target.closest('.es-mobile-sub-nav');
-            if (triggerSubNav !== subNavParentElement?.value?.$el) {
-                goBack();
-            }
+            // if the user has moved focus outside of this submenu and onto
+            // a submenu trigger (even the one that triggered this submenu),
+            // close this submenu
+            goBack();
         } else if (!isElementWithinMenu(e.target)) {
             // if focus is on something outside of the overall menu, close it
             closeMenu();


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-545

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Per [this comment](https://github.com/EnergySage/es-ds/pull/1722#pullrequestreview-4064151491) on the initial EsMobileNav PR:

> Within a sub-menu, navigating backwards with shift-tab will go over two invisible buttons before it gets to the ones with visible outline. One of those invisible buttons seems to do nothing, while the other seems to be another back button. Navigating forwards somehow doesn't trigger this condition.

- This reduces the number of invisible buttons in the above case from two to one, reducing user confusion.
- Before, the submenu was only closing when the item before the parent menu item that opened the subnav received focus. Now, the submenu closes when _any_ item in the parent menu receives focus, including the item that opened the subnav.

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally at http://localhost:8500/molecules/mobile-nav

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [x] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
