### PR TITLE
feat: added glow to progress bar to match designs

### DIFF
--- a/es-ds-components/app/components/es-progress.vue
+++ b/es-ds-components/app/components/es-progress.vue
@@ -12,6 +12,7 @@ interface Props {
     formatter?: Function;
     height?: string;
     showCircle?: boolean;
+    showGlow?: boolean;
     showValue?: boolean;
     value: number;
     valueClass?: string;
@@ -21,6 +22,7 @@ const props = withDefaults(defineProps<Props>(), {
     formatter: (val: number) => `${val}%`,
     height: '0.125rem',
     showCircle: true,
+    showGlow: true,
     showValue: false,
     valueClass: '',
 });
@@ -31,6 +33,7 @@ const progressBarPt = computed(() => ({
             'EsProgressValue progress-bar overflow-visible position-relative rounded-sm',
             {
                 'progress-bar--with-circle': props.showCircle,
+                'progress-bar--with-glow': props.showGlow,
             },
         ],
         style: {

--- a/es-ds-docs/app/pages/molecules/progress.vue
+++ b/es-ds-docs/app/pages/molecules/progress.vue
@@ -16,6 +16,7 @@ const propTableRows = [
     ],
     ['height', 'String', '0.125rem', 'Specifies height of the progress bar.'],
     ['showCircle', 'Boolean', 'true', 'Set to false to hide the indicator circle.'],
+    ['showGlow', 'Boolean', 'true', 'Set to false to hide the glow around the bar.'],
     ['showValue', 'Boolean', 'false', 'When present, it shows the progress bar value below the bar.'],
     ['value', 'Number', 'n/a', 'Required. A value between 0 and 100 representing the progress.'],
     ['valueClass', 'String', "''", 'Allows control of styling for the value displayed when showValue is set to true.'],
@@ -196,27 +197,31 @@ onMounted(async () => {
         </div>
 
         <div class="my-500">
-            <h2>Hide indicator circle</h2>
-            <p>This example shows how to hide the indicator circle for a simpler progress bar.</p>
+            <h2>Hide glow and indicator circle</h2>
+            <p>This example shows how to hide the glow and indicator circle for a simpler progress bar.</p>
             <es-progress
                 class="mb-200"
                 height="0.375rem"
                 :show-circle="false"
+                :show-glow="false"
                 :value="0" />
             <es-progress
                 class="mb-200"
                 height="0.375rem"
                 :show-circle="false"
+                :show-glow="false"
                 :value="33" />
             <es-progress
                 class="mb-200"
                 height="0.375rem"
                 :show-circle="false"
+                :show-glow="false"
                 :value="67" />
             <es-progress
                 class="mb-200"
                 height="0.375rem"
                 :show-circle="false"
+                :show-glow="false"
                 :value="100" />
         </div>
 

--- a/es-ds-styles/scss/_progress.scss
+++ b/es-ds-styles/scss/_progress.scss
@@ -37,6 +37,10 @@
   @include transition.transition(variables.$progress-bar-transition);
 }
 
+.progress-bar--with-glow {
+  box-shadow: variables.$warm-orange 0px 0px 4px, rgba(255, 145, 51, 0.5) 0px 0px 24px;
+}
+
 .progress-bar--with-circle {
   &::after {
     background: variables.$white;

--- a/es-ds-styles/scss/_progress.scss
+++ b/es-ds-styles/scss/_progress.scss
@@ -38,7 +38,7 @@
 }
 
 .progress-bar--with-glow {
-  box-shadow: variables.$warm-orange 0px 0px 4px, rgba(255, 145, 51, 0.5) 0px 0px 24px;
+  box-shadow: variables.$warm-orange 0 0 4px, rgba(255, 145, 51, 0.5) 0 0 24px;
 }
 
 .progress-bar--with-circle {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CORE-7182

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- When I updated the style of EsProgress last year, I didn't include the glow because the Figma didn't provide a good box-shadow equivalent - I grabbed this one from a React prototype from the design team, so now we can finally make this match the designs
- Adds the glow by default, and adds a `showGlow` boolean prop that you can set to false if you don't want it
- This isn't _really_ a breaking change (won't impact layout) so I don't want to set it as such, otherwise it'll bump us up a whole major version just for this

### Before
<img width="888" height="193" alt="Screenshot 2026-04-21 at 10 39 15 AM" src="https://github.com/user-attachments/assets/ee5e9f75-86bb-4803-bfb5-798e3ed7d4a9" />

### After
<img width="886" height="190" alt="Screenshot 2026-04-21 at 10 39 21 AM" src="https://github.com/user-attachments/assets/dbcf5bc8-50e2-41ca-bd3f-041e84fb58b2" />

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally at http://localhost:8500/molecules/progress

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
