### PR TITLE
fix: menu bar no longer causes page shift when mouse/scrollbar is present

### DIFF
--- a/es-ds-components/app/components/es-menu-bar.vue
+++ b/es-ds-components/app/components/es-menu-bar.vue
@@ -281,6 +281,9 @@ $switch-menus-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .es-menu-bar {
+    /* allows interaction when EsMenuBar is open */
+    pointer-events: auto;
+
     :deep(.es-menu-bar-list) {
         align-items: center;
         display: flex;

--- a/es-ds-components/app/components/es-menu-bar.vue
+++ b/es-ds-components/app/components/es-menu-bar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { useScrollLock } from '@vueuse/core';
-import { NavigationMenuList, NavigationMenuRoot, NavigationMenuViewport } from 'reka-ui';
+import { NavigationMenuList, NavigationMenuRoot, NavigationMenuViewport, useBodyScrollLock } from 'reka-ui';
 import {
     ES_MENU_BAR_ALIGNMENT_REGISTRY_KEY,
     ES_MENU_BAR_CLOSE_EVENT_NAME,
@@ -28,7 +27,7 @@ const props = withDefaults(defineProps<IProps>(), {
 let isOpening = false;
 
 const emitter = useEsdsEvents();
-const isScrollLocked = useScrollLock(import.meta.client ? document.body : null);
+const isScrollLocked = useBodyScrollLock(false);
 
 const activeMenuId = ref('');
 
@@ -355,8 +354,10 @@ $switch-menus-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         &.full-width {
             left: 0;
             right: 0;
+            width: 100%;
 
             .es-menu-bar-flyout {
+                padding-right: var(--scrollbar-width);
                 width: 100%;
                 /* row's content box = pane − 2·wrapper-padding + grid-gutter (row's negative margins). matches <es-col md="6" lg="4" xl="3"> in es-menu-bar-flyout-column so column text stays aligned during the cross-slide */
                 --es-menu-bar-flyout-row-width: calc(

--- a/es-ds-components/app/components/es-menu-bar.vue
+++ b/es-ds-components/app/components/es-menu-bar.vue
@@ -26,6 +26,10 @@ const props = withDefaults(defineProps<IProps>(), {
 // used to ensure we don't close our menu when emitting our own menu open event
 let isOpening = false;
 
+// held until the close animation finishes so --scrollbar-width stays on <html> for the
+// duration — otherwise the scrollbar reappears mid-close and EsColorBand shifts inward
+let releaseScrollLockTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
 const emitter = useEsdsEvents();
 const isScrollLocked = useBodyScrollLock(false);
 
@@ -49,8 +53,29 @@ provide(ES_MENU_BAR_ALIGNMENT_REGISTRY_KEY, {
 const activeAlign = computed<EsMenuBarFlyoutAlign>(() => flyoutAlignments.get(activeMenuId.value) ?? 'center');
 
 watch(activeMenuId, async (newVal: string, oldVal: string) => {
-    // lock page scrolling when menu is open, unless we're not showing the overlay
-    isScrollLocked.value = props.showOverlayWhenOpen && !!newVal;
+    if (releaseScrollLockTimeoutId) {
+        clearTimeout(releaseScrollLockTimeoutId);
+        releaseScrollLockTimeoutId = null;
+    }
+
+    if (newVal) {
+        // lock page scrolling when menu is open, unless we're not showing the overlay
+        isScrollLocked.value = props.showOverlayWhenOpen;
+    } else if (oldVal) {
+        // defer scroll lock release until the close animation finishes so --scrollbar-width
+        // stays populated; skip the delay when reduced motion is on (no animation to cover)
+        const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) {
+            isScrollLocked.value = false;
+        } else {
+            releaseScrollLockTimeoutId = setTimeout(() => {
+                releaseScrollLockTimeoutId = null;
+                if (!activeMenuId.value) {
+                    isScrollLocked.value = false;
+                }
+            }, ES_MENU_BAR_OPEN_CLOSE_DURATION_MS);
+        }
+    }
 
     if (!oldVal && newVal) {
         // if the menu is opening, emit event so:
@@ -84,6 +109,10 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+    if (releaseScrollLockTimeoutId) {
+        clearTimeout(releaseScrollLockTimeoutId);
+        releaseScrollLockTimeoutId = null;
+    }
     emitter.off(ES_MENU_BAR_OPEN_EVENT_NAME, handleMenuOpen);
 });
 </script>
@@ -331,6 +360,11 @@ $switch-menus-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 
             &[data-state='closed'] {
                 animation: menuClose var(--es-menu-bar-open-close-duration) $open-close-timing-function;
+
+                /* prevent color band from shifting on scrollbar on/off */
+                .es-menu-bar-color-band {
+                    right: min(0px, calc(-1 * var(--scrollbar-width)));
+                }
             }
         }
 

--- a/es-ds-components/app/components/es-mobile-nav-content.vue
+++ b/es-ds-components/app/components/es-mobile-nav-content.vue
@@ -179,6 +179,8 @@ provide('isElementWithinMenu', isElementWithinMenu);
 
 .es-mobile-nav-content {
     --es-mobile-nav-header-height: 88px;
+    /* allows interaction when nav is is open */
+    pointer-events: auto;
 
     bottom: 0;
     box-shadow: 0 0 6px 0 rgba(34, 38, 51, 0.2);

--- a/es-ds-components/app/components/es-mobile-nav.vue
+++ b/es-ds-components/app/components/es-mobile-nav.vue
@@ -120,8 +120,12 @@ watch(activeMenuId, async (newVal: string, oldVal: string) => {
 
     // if the menu is closing
     if (!newVal && oldVal) {
-        // wait until the mobile nav closing animation is complete
-        await waitForAnimationDuration();
+        // wait until the mobile nav closing animation is complete; with reduced motion
+        // there is no animation, so skip the await entirely and run synchronously
+        const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+        if (!prefersReducedMotion) {
+            await waitForAnimationDuration();
+        }
 
         // release scroll lock now that the close animation is done, so --scrollbar-width
         // stayed populated through the animation and the panel didn't jump inward as the

--- a/es-ds-components/app/components/es-mobile-nav.vue
+++ b/es-ds-components/app/components/es-mobile-nav.vue
@@ -114,12 +114,21 @@ provide('width', toRef(props, 'width'));
 provide('widthPx', widthPx);
 
 watch(activeMenuId, async (newVal: string, oldVal: string) => {
-    isScrollLocked.value = !!newVal;
+    if (newVal) {
+        isScrollLocked.value = true;
+    }
 
     // if the menu is closing
     if (!newVal && oldVal) {
         // wait until the mobile nav closing animation is complete
         await waitForAnimationDuration();
+
+        // release scroll lock now that the close animation is done, so --scrollbar-width
+        // stayed populated through the animation and the panel didn't jump inward as the
+        // native scrollbar reappeared. guard against a re-open during the wait.
+        if (!activeMenuId.value) {
+            isScrollLocked.value = false;
+        }
 
         // reset the state of all submenus by closing all open ones (without animation)
         subNavCloseHandlers.value.forEach((callback: Function) => {

--- a/es-ds-components/app/components/es-mobile-nav.vue
+++ b/es-ds-components/app/components/es-mobile-nav.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { useScrollLock } from '@vueuse/core';
-import { type NavigationMenuContent, NavigationMenuItem, NavigationMenuList, NavigationMenuRoot } from 'reka-ui';
+import {
+    type NavigationMenuContent,
+    NavigationMenuItem,
+    NavigationMenuList,
+    NavigationMenuRoot,
+    useBodyScrollLock,
+} from 'reka-ui';
 import type { ShallowRef } from 'vue';
 
 interface IProps {
@@ -24,7 +29,7 @@ const scrollableContentAreaTemplateRef: Ref<Readonly<
 const subNavCloseHandlers: Ref<Function[]> = ref([]);
 
 const displayedName = computed(() => nameStack.value.at(-1) ?? '');
-const isScrollLocked = useScrollLock(import.meta.client ? document.body : null);
+const isScrollLocked = useBodyScrollLock(false);
 const widthPx = computed(() => `${props.width}px`);
 
 // closes the top-level menu

--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -174,7 +174,10 @@ onUnmounted(() => {
         v-bind="$attrs"
         @mouseover="isHovered = true"
         @mouseout="isHovered = false">
-        <slot />
+        <!-- prevent absolutely-positioned elements within sticky bar from shifting on scrollbar on/off -->
+        <div class="position-relative">
+            <slot />
+        </div>
     </div>
     <!-- holds the bar's space in normal flow when the bar is absolutely or fixed positioned -->
     <div

--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -174,10 +174,7 @@ onUnmounted(() => {
         v-bind="$attrs"
         @mouseover="isHovered = true"
         @mouseout="isHovered = false">
-        <!-- prevent absolutely-positioned elements within sticky bar from shifting on scrollbar on/off -->
-        <div class="position-relative">
-            <slot />
-        </div>
+        <slot />
     </div>
     <!-- holds the bar's space in normal flow when the bar is absolutely or fixed positioned -->
     <div

--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -193,6 +193,10 @@ $shadow: 0 0 6px 0 rgba(34, 38, 51, 0.2);
     background-color: variables.$white;
     box-shadow: $shadow;
     left: 0;
+    /* prevents scrollbar on/off from shifting the contents */
+    padding-right: var(--scrollbar-width);
+    /* allows interaction when EsMenuBar is open */
+    pointer-events: auto;
     right: 0;
     top: 0;
     z-index: 1000;

--- a/es-ds-docs/app/pages/examples/site-navigation.vue
+++ b/es-ds-docs/app/pages/examples/site-navigation.vue
@@ -291,6 +291,19 @@ const isSignedIn = ref(false);
 .site-navigation {
     height: 88px;
     max-width: map.get(variables.$container-max-widths, xxl);
+    /**
+     * prevent centered ES logo from shifting on scrollbar on/off
+     * and from starting mid-page outside the sticky bar pre-mount
+     */
+    position: relative;
+
+    /**
+     * allow EsMenuBar full-width flyout to go full width rather than
+     * being pushed to the left by the scrollbar-width padding right
+     */
+    @include breakpoints.media-breakpoint-up(xl) {
+        position: static;
+    }
 
     /* at xxl breakpoint only, match es-container padding */
     @include breakpoints.media-breakpoint-up(xxl) {


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-623

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Switched EsMobileNav and EsMenuBar from Vue's `useScrollLock` to Reka UI's `useBodyScrollLock` (the latter of which adds scrollbar width detection and automatically adding padding to page content to prevent shifting)
- Delayed turning off scroll lock for EsMobileNav and EsMenuBar until menu is closed (previously it was turned off as soon as the menu _started_ closing)
- Adjusted all necessary positioning and padding of EsMobileNav, EsMenuBar, and the site navigation example to prevent page shifting when menus are opened/closed
- Fixed bug in mobile site navigation example where the EnergySage logo appeared mid-page, outside the sticky bar, prior to JS mount

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested with mouse plugged in on Chrome (persistent scrollbar appears)
- Also tested without to ensure no regressions
- Tested on site navigation example, menu bar docs page, and mobile nav docs page

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
