### PR TITLE
fix: mobile nav hydration issue

### DIFF
--- a/es-ds-components/app/components/es-mobile-nav.vue
+++ b/es-ds-components/app/components/es-mobile-nav.vue
@@ -155,16 +155,6 @@ watch(activeMenuId, async (newVal: string, oldVal: string) => {
         class="es-mobile-nav d-flex"
         disable-hover-trigger
         disable-pointer-leave-close>
-        <!-- overlay -->
-        <teleport to="body">
-            <div
-                class="es-mobile-nav-overlay position-fixed"
-                :class="{
-                    active: !!activeMenuId,
-                }"
-                @click="activeMenuId = ''" />
-        </teleport>
-
         <!--
             since the first level is a single item - the trigger to open the mobile nav -
             prevent it from being a <ul> and <li>
@@ -179,39 +169,54 @@ watch(activeMenuId, async (newVal: string, oldVal: string) => {
             </navigation-menu-item>
         </navigation-menu-list>
     </navigation-menu-root>
+
+    <!--
+        overlay teleport needs to live outside NavigationMenuRoot to prevent
+        a hydration issue caused by NavigationMenuRoot traversing its slot children
+    -->
+    <teleport to="body">
+        <transition name="es-mobile-nav-overlay">
+            <div
+                v-if="activeMenuId"
+                class="es-mobile-nav-overlay position-fixed"
+                :style="{ '--es-mobile-nav-animation-duration': ANIMATION_DURATION_MS }"
+                @click="activeMenuId = ''" />
+        </transition>
+    </teleport>
 </template>
 
 <style lang="scss" scoped>
 @use '@energysage/es-ds-styles/scss/mixins/breakpoints' as breakpoints;
 @use '@energysage/es-ds-styles/scss/variables';
 
-$animation-duration: v-bind(ANIMATION_DURATION_MS);
+.es-mobile-nav-overlay {
+    opacity: 0.3;
+    pointer-events: all;
+
+    @include breakpoints.media-breakpoint-up(sm) {
+        background-color: variables.$gray-900;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: 0;
+        z-index: 1010;
+    }
+
+    @media not (prefers-reduced-motion) {
+        &-enter-active,
+        &-leave-active {
+            transition: opacity var(--es-mobile-nav-animation-duration) ease-in-out;
+        }
+
+        &-enter-from,
+        &-leave-to {
+            opacity: 0;
+        }
+    }
+}
 
 .es-mobile-nav {
     --mobile-nav-width: v-bind(widthPx);
-
-    &-overlay {
-        opacity: 0;
-        pointer-events: none;
-
-        &.active {
-            opacity: 0.3;
-            pointer-events: all;
-        }
-
-        @include breakpoints.media-breakpoint-up(sm) {
-            background-color: variables.$gray-900;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            top: 0;
-            z-index: 1010;
-
-            @media not (prefers-reduced-motion) {
-                transition: opacity $animation-duration ease-in-out;
-            }
-        }
-    }
 
     :deep(> div) {
         /* ensure the button is full-height with the rest of the nav bar items */


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-555

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes a hydration issue encountered downstream on page load when a mobile nav is present by doing the overlay presence/absence and animation the same way that EsMenuBar does it

### Hydration error:
```
[Vue warn]: Hydration node mismatch:
- rendered on server: <!--teleport start anchor-->  
- expected on client: div 
  at <Primitive class="d-xl-none es-mobile-nav d-flex d-xl-none" as="nav" as-child=false  ... > 
  at <PrimitiveSlot ref=Ref< undefined > class="d-xl-none es-mobile-nav d-flex d-xl-none" > 
  at <CollectionSlot class="d-xl-none es-mobile-nav d-flex d-xl-none" > 
  at <NavigationMenuRoot modelValue="" onUpdate:modelValue=fn class="d-xl-none es-mobile-nav d-flex d-xl-none"  ... > 
  at <EsMobileNav class="d-xl-none" > 
  at <EsStickyBar transparent-starting-at-breakpoint="xl" class="order-lg-2" > 
```

### Claude's analysis of the cause:

> Two problems compound here:
> 1. The overlay div has no v-if — it's always rendered, just with a class toggle. So the teleport payload is always present.
> 2. The teleport sits inside NavigationMenuRoot, which wraps its slot in Reka's CollectionSlot → PrimitiveSlot → Primitive (you can see that exact chain in the hydration error stack). Reka's collection machinery traverses slot children to register them for keyboard nav. SSR and hydration appear to disagree about whether the teleport is transparent (treat its inner div as a collection item) or opaque (just an anchor comment) — which is the exact mismatch you're seeing: `<!--teleport start anchor-->` vs `<div>`.

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally with `make dev`, confirmed mobile nav and overlay functionality still worked
- Tested locally with a downstream repo npm linked to this one

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
