### PR TITLE
fix: EsMenuBar and EsMobileNav now only teleport to body on client

### DIFF
--- a/es-ds-components/app/components/es-menu-bar.vue
+++ b/es-ds-components/app/components/es-menu-bar.vue
@@ -139,19 +139,28 @@ onUnmounted(() => {
                     'full-width': fullWidth,
                 }" />
         </navigation-menu-root>
-        <teleport
-            v-if="showOverlayWhenOpen"
-            to="body">
-            <transition name="es-menu-bar-overlay">
-                <div
-                    v-if="activeMenuId"
-                    class="es-menu-bar-overlay"
-                    :style="{
-                        '--es-menu-bar-height': heightPx,
-                        '--es-menu-bar-open-close-duration': `${ES_MENU_BAR_OPEN_CLOSE_DURATION_MS}ms`,
-                    }"></div>
-            </transition>
-        </teleport>
+
+        <!--
+            teleported to body to escape any ancestor stacking context (e.g. es-sticky-bar).
+            wrapped in <client-only> because <teleport to="body"> is position-sensitive during
+            hydration: any third-party script that injects a node into <body> before Vue
+            hydrates will desynchronize the teleport anchor and produce a hydration mismatch.
+        -->
+        <client-only>
+            <teleport
+                v-if="showOverlayWhenOpen"
+                to="body">
+                <transition name="es-menu-bar-overlay">
+                    <div
+                        v-if="activeMenuId"
+                        class="es-menu-bar-overlay"
+                        :style="{
+                            '--es-menu-bar-height': heightPx,
+                            '--es-menu-bar-open-close-duration': `${ES_MENU_BAR_OPEN_CLOSE_DURATION_MS}ms`,
+                        }"></div>
+                </transition>
+            </teleport>
+        </client-only>
     </div>
 </template>
 

--- a/es-ds-components/app/components/es-mobile-nav-content.vue
+++ b/es-ds-components/app/components/es-mobile-nav-content.vue
@@ -64,9 +64,13 @@ const isElementWithinMenu = (element: any) => {
     return parent.contains(element);
 };
 
+// gates the body teleport — see the v-if on the <teleport> in the template
+const isMounted = ref(false);
+
 onMounted(() => {
     // give EsMobileNav a reference to the scrollable content area so it can set the scroll position
     registerScrollableContentArea(mobileNavParentElement);
+    isMounted.value = true;
 });
 
 provide('backButtonSimulatedFocus', backButtonSimulatedFocus);
@@ -75,8 +79,21 @@ provide('isElementWithinMenu', isElementWithinMenu);
 </script>
 
 <template>
-    <!-- teleported to body to escape any ancestor stacking context (e.g. es-sticky-bar) -->
-    <teleport to="body">
+    <!--
+        teleported to body to escape any ancestor stacking context (e.g. es-sticky-bar).
+        gated by v-if="isMounted" rather than <client-only> for two reasons:
+          1. <teleport to="body"> is position-sensitive during hydration — any third-party
+             script that injects a node into <body> before Vue hydrates would
+             desynchronize the teleport anchor and cause a mismatch.
+          2. <client-only> always emits an empty <span> fallback during SSR. Used as a
+             template root, that span gets the component's scope and any v-bind() CSS
+             variables, becomes a sibling flex item in the consuming layout, and disrupts
+             positioning until hydration completes. v-if emits only a comment marker,
+             which is not a flex item.
+    -->
+    <teleport
+        v-if="isMounted"
+        to="body">
         <navigation-menu-content
             v-bind="$attrs"
             ref="mobileNavParentElement"

--- a/es-ds-components/app/components/es-mobile-nav.vue
+++ b/es-ds-components/app/components/es-mobile-nav.vue
@@ -32,6 +32,12 @@ const displayedName = computed(() => nameStack.value.at(-1) ?? '');
 const isScrollLocked = useBodyScrollLock(false);
 const widthPx = computed(() => `${props.width}px`);
 
+// gates the body teleport — see the v-if on the <teleport> in the template
+const isMounted = ref(false);
+onMounted(() => {
+    isMounted.value = true;
+});
+
 // closes the top-level menu
 const closeMenu = () => {
     // focus the trigger before closing so assistive technologies (e.g. VoiceOver)
@@ -171,10 +177,21 @@ watch(activeMenuId, async (newVal: string, oldVal: string) => {
     </navigation-menu-root>
 
     <!--
-        overlay teleport needs to live outside NavigationMenuRoot to prevent
-        a hydration issue caused by NavigationMenuRoot traversing its slot children
+        teleported to body to prevent a hydration issue caused by NavigationMenuRoot
+        traversing its slot children, and to escape any ancestor stacking context.
+
+        gated by v-if="isMounted" rather than <client-only> for two reasons:
+          1. <teleport to="body"> is position-sensitive during hydration — any third-party
+             script that injects a node into <body> before Vue hydrates would
+             desynchronize the teleport anchor and cause a mismatch.
+          2. <client-only> always emits an empty <span> fallback during SSR. As a second
+             root of this multi-root template, that span becomes a sibling flex item in
+             the consuming navbar and disrupts justify-content layout until hydration
+             completes. v-if emits only a comment marker, which is not a flex item.
     -->
-    <teleport to="body">
+    <teleport
+        v-if="isMounted"
+        to="body">
         <transition name="es-mobile-nav-overlay">
             <div
                 v-if="activeMenuId"


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-555

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- EsMenuBar and EsMobileNav both use `<teleport to="body">` to allow their flyouts and overlays to be positioned and stacked correctly. This caused a hydration error when a third-party client-side script was also adding elements to the body tag prior to hydration.
- EsMenuBar now uses a `<client-only>` tag surrounding the teleport to avoid this hydration error
- EsMobileNav uses a `v-if="isMounted"` flag instead of a `<client-only>` to accomplish the same thing because a `<client-only>` generates a `<span>` tag which was ruining the positioning of a `d-flex justify-content-between` layout (EsMenuBar won't have this issue because its teleport is wrapped in a div, unlike EsMobileNav)

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally with `make dev`
- Tested by npm linking to a downstream repo

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
