### PR TITLE
feat: sticky bar now coordinates with other fixed position elements

### DIFF
--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -141,8 +141,8 @@ const onMenuBarClose = () => {
     }
 };
 
-// expose barHeight to other fixed-position elements via a CSS variable on <html> so they can
-// position themselves relative to the bar without subscribing to size changes
+// expose barHeight to other fixed position elements via a CSS variable on <html> so they can
+// position themselves relative to the bar
 watch(barHeight, (height) => {
     document.documentElement.style.setProperty('--es-sticky-bar-height', `${height}px`);
 });

--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -141,6 +141,12 @@ const onMenuBarClose = () => {
     }
 };
 
+// expose barHeight to other fixed-position elements via a CSS variable on <html> so they can
+// position themselves relative to the bar without subscribing to size changes
+watch(barHeight, (height) => {
+    document.documentElement.style.setProperty('--es-sticky-bar-height', `${height}px`);
+});
+
 onMounted(() => {
     // measure height before switching position so the placeholder matches exactly
     barHeight.value = bar.value?.offsetHeight ?? 0;
@@ -165,6 +171,8 @@ onMounted(() => {
 
 onUnmounted(() => {
     window.removeEventListener('scroll', onScroll);
+
+    document.documentElement.style.removeProperty('--es-sticky-bar-height');
 
     emitter.off(ES_MENU_BAR_OPEN_EVENT_NAME, onMenuBarOpen);
     emitter.off(ES_MENU_BAR_CLOSE_EVENT_NAME, onMenuBarClose);

--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -77,9 +77,15 @@ function updateVisibility() {
     if (currentScrollY <= 0) {
         // back at the very top: switch to absolute so bar scrolls away naturally on next scroll down
         barState.value = 'absolute';
+
+        // emit event notifying other fixed position elements of the change
+        emitter.emit(ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME);
     } else if (barState.value === 'absolute' && currentScrollY >= barHeight.value) {
         // bar has scrolled fully off screen: reposition to fixed-hidden while invisible
         hideWithoutAnimation();
+
+        // emit event notifying other fixed position elements of the change
+        emitter.emit(ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME);
     } else if (
         barState.value === 'fixed-hidden' &&
         scrollDirection < 0 &&
@@ -87,6 +93,9 @@ function updateVisibility() {
     ) {
         // scrolling up far enough: slide bar into view
         barState.value = 'fixed-visible';
+
+        // emit event notifying other fixed position elements of the change
+        emitter.emit(ES_STICKY_BAR_FIXED_SHOW_EVENT_NAME);
     } else if (
         barState.value === 'fixed-visible' &&
         scrollDirection > 0 &&
@@ -94,6 +103,9 @@ function updateVisibility() {
     ) {
         // scrolling down far enough: slide bar off screen
         barState.value = 'fixed-hidden';
+
+        // emit event notifying other fixed position elements of the change
+        emitter.emit(ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME);
     }
 
     lastScrollY = currentScrollY;

--- a/es-ds-components/app/utils/sticky-bar.ts
+++ b/es-ds-components/app/utils/sticky-bar.ts
@@ -1,0 +1,2 @@
+export const ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME = 'es-sticky-bar-fixed-hide';
+export const ES_STICKY_BAR_FIXED_SHOW_EVENT_NAME = 'es-sticky-bar-fixed-show';

--- a/es-ds-docs/app/pages/molecules/menu-bar.vue
+++ b/es-ds-docs/app/pages/molecules/menu-bar.vue
@@ -49,6 +49,11 @@ const esMenuBarProps = [
     ],
 ];
 
+const esMenuBarEvents = [
+    [ES_MENU_BAR_CLOSE_EVENT_NAME, 'none', 'Fires when a submenu is closed.'],
+    [ES_MENU_BAR_OPEN_EVENT_NAME, 'none', 'Fires when a submenu is opened.'],
+];
+
 const esMenuBarLinkProps = [
     [
         'href',
@@ -456,6 +461,25 @@ onMounted(async () => {
                     component.
                 </p>
                 <ds-prop-table :rows="esMenuBarProps" />
+            </div>
+
+            <div class="my-300">
+                <h2>EsMenuBar global events</h2>
+                <p>
+                    These events are not emitted directly by the component, but are instead transmitted via the
+                    <code>useEsdsEvents</code> composable and can be subscribed to via <code>on()</code> and
+                    <code>off()</code> methods.
+                </p>
+                <p>
+                    <nuxt-link to="/molecules/sticky-bar">Sticky bar</nuxt-link> consumes these events in order to wait
+                    for the menu to be closed before it changes its background from white to transparent.
+                </p>
+                <ds-prop-table
+                    :columns="['Name', 'Payload', 'Description']"
+                    :rows="esMenuBarEvents"
+                    :widths="{
+                        md: ['4', '2', '6'],
+                    }" />
             </div>
 
             <div class="my-300">

--- a/es-ds-docs/app/pages/molecules/sticky-bar.vue
+++ b/es-ds-docs/app/pages/molecules/sticky-bar.vue
@@ -1,4 +1,10 @@
 <script setup lang="ts">
+definePageMeta({
+    layout: 'minimal',
+});
+
+const emitter = useEsdsEvents();
+
 const LOREM_TEXT =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. In tellus integer feugiat scelerisque varius. Risus in hendrerit gravida rutrum. Faucibus interdum posuere lorem ipsum dolor sit amet consectetur adipiscing. Mi tempus imperdiet nulla malesuada pellentesque elit.';
 
@@ -18,15 +24,19 @@ const esStickyBarProps = [
     ],
 ];
 
-definePageMeta({
-    layout: 'minimal',
-});
+const isFixedStateShown = ref(false);
+
+const handleFixedStateHidden = () => (isFixedStateShown.value = false);
+const handleFixedStateShown = () => (isFixedStateShown.value = true);
 
 const { $prism } = useNuxtApp();
 const compCode = ref('');
 const docCode = ref('');
 
 onMounted(async () => {
+    emitter.on(ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME, handleFixedStateHidden);
+    emitter.on(ES_STICKY_BAR_FIXED_SHOW_EVENT_NAME, handleFixedStateShown);
+
     if ($prism) {
         const compSource = await import('@energysage/es-ds-components/app/components/es-sticky-bar.vue?raw');
         const docSource = await import('./sticky-bar.vue?raw');
@@ -35,6 +45,11 @@ onMounted(async () => {
         docCode.value = $prism.normalizeCode(docSource.default);
         $prism.highlight();
     }
+});
+
+onUnmounted(() => {
+    emitter.off(ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME, handleFixedStateHidden);
+    emitter.off(ES_STICKY_BAR_FIXED_SHOW_EVENT_NAME, handleFixedStateShown);
 });
 </script>
 
@@ -83,6 +98,18 @@ onMounted(async () => {
                 You can place anything inside of it and it will adapt to the height of that content. It will also
                 detect any changes to its height based on responsive breakpoints or other events and adjust its own
                 positioning accordingly.
+            </p>
+
+            <h2 class="mt-300">Global events</h2>
+            <p>
+                To coordinate with other fixed or sticky elements that may be at the top of the viewport and need to
+                adjust their position when the sticky bar is shown or hidden, the sticky bar emits global events
+                through the <code>useEsdsEvents</code> composable when its fixed position state is shown or hidden. The
+                text below is an example powered by these events and describes the current state. Try scrolling up and
+                down and see how the text changes.
+            </p>
+            <p class="font-weight-semibold">
+                {{ `(fixed sticky bar ${isFixedStateShown ? 'shown' : 'hidden'})` }}
             </p>
 
             <h2 class="mt-300">Additional sample paragraphs to test scrolling behavior</h2>

--- a/es-ds-docs/app/pages/molecules/sticky-bar.vue
+++ b/es-ds-docs/app/pages/molecules/sticky-bar.vue
@@ -24,6 +24,11 @@ const esStickyBarProps = [
     ],
 ];
 
+const esStickyBarEvents = [
+    [ES_STICKY_BAR_FIXED_HIDE_EVENT_NAME, 'none', 'Fires when the fixed state of the sticky bar is hidden.'],
+    [ES_STICKY_BAR_FIXED_SHOW_EVENT_NAME, 'none', 'Fires when the fixed state of the sticky bar is shown.'],
+];
+
 const isFixedStateShown = ref(false);
 
 const handleFixedStateHidden = () => (isFixedStateShown.value = false);
@@ -100,17 +105,31 @@ onUnmounted(() => {
                 positioning accordingly.
             </p>
 
-            <h2 class="mt-300">Global events</h2>
+            <h2 class="mt-300">Coordination with other fixed position elements</h2>
             <p>
-                To coordinate with other fixed or sticky elements that may be at the top of the viewport and need to
-                adjust their position when the sticky bar is shown or hidden, the sticky bar emits global events
-                through the <code>useEsdsEvents</code> composable when its fixed position state is shown or hidden. The
-                text below is an example powered by these events and describes the current state. Try scrolling up and
-                down and see how the text changes.
+                If there are other elements on a page that also need to be fixed to the top of the viewport, in order
+                to prevent overlap with the sticky bar, they need to know two things: (1) whether the sticky bar is
+                shown or hidden, and (2) the height of the sticky bar.
             </p>
-            <p class="font-weight-semibold">
-                {{ `(fixed sticky bar ${isFixedStateShown ? 'shown' : 'hidden'})` }}
+            <p>
+                Visibility is communicated via global events emitted through the <code>useEsdsEvents</code> composable.
+                The text below is an example powered by these events and describes the current state. Try scrolling up
+                and down and see how the text changes.
             </p>
+            <p
+                class="font-weight-semibold p-100 rounded-lg"
+                :class="{ 'bg-success-50': isFixedStateShown, 'bg-gray-50': !isFixedStateShown }">
+                {{ `fixed sticky bar is ${isFixedStateShown ? 'shown' : 'hidden'}` }}
+            </p>
+            <p>
+                The height is communicated via the CSS variable <code>--es-sticky-bar-height</code> made available on
+                the <code>&lt;html&gt;</code> tag. It will update dynamically on resize. The box below is an example
+                that uses this CSS variable to exactly match the height of the sticky bar. Try switching between mobile
+                and desktop breakpoints and see how the height changes.
+            </p>
+            <div
+                class="bg-soft-blue font-size-75 p-100 rounded-lg"
+                :style="{ height: 'var(--es-sticky-bar-height)' }"></div>
 
             <h2 class="mt-300">Additional sample paragraphs to test scrolling behavior</h2>
             <p
@@ -126,6 +145,21 @@ onUnmounted(() => {
                     :widths="{
                         md: ['3', '2', '2', '5'],
                         lg: ['3', '2', '1', '6'],
+                    }" />
+            </div>
+
+            <div class="my-300">
+                <h2>EsStickyBar global events</h2>
+                <p>
+                    These events are not emitted directly by the component, but are instead transmitted via the
+                    <code>useEsdsEvents</code> composable and can be subscribed to via <code>on()</code> and
+                    <code>off()</code> methods.
+                </p>
+                <ds-prop-table
+                    :columns="['Name', 'Payload', 'Description']"
+                    :rows="esStickyBarEvents"
+                    :widths="{
+                        md: ['4', '2', '6'],
                     }" />
             </div>
 


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-555

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Sticky bar now emits show and hide events (globally, via `useEsdsEvents`) when its fixed state is shown or hidden
- Sticky bar now sets a CSS variable on the `<html>` element with its height so other fixed elements can position around it
- Documented the new functionality and events on the sticky bar docs page
- Documented the global events the menu bar emits on its docs page as well

<img width="1338" height="741" alt="Screenshot 2026-06-01 at 11 50 58 AM" src="https://github.com/user-attachments/assets/fbfaee05-66e0-43f7-b405-f91342ddd974" />

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on http://localhost:8500/molecules/sticky-bar and http://localhost:8500/molecules/menu-bar

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [x] I have updated any applicable documentation.
