### PR TITLE
fix: add missing orange line below EsMenuBar desktop flyout column headers

### DIFF
--- a/es-ds-components/app/components/es-menu-bar-flyout-column.vue
+++ b/es-ds-components/app/components/es-menu-bar-flyout-column.vue
@@ -16,7 +16,7 @@ withDefaults(defineProps<IProps>(), {
         xl="3">
         <h2
             v-if="heading"
-            class="eyebrow">
+            class="es-menu-bar-flyout-column-heading eyebrow pb-50 position-relative">
             {{ heading }}
         </h2>
         <navigation-menu-list class="list-unstyled">
@@ -24,3 +24,19 @@ withDefaults(defineProps<IProps>(), {
         </navigation-menu-list>
     </es-col>
 </template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables';
+
+.es-menu-bar-flyout-column-heading {
+    &::after {
+        background-color: variables.$warm-orange;
+        bottom: 0;
+        content: '';
+        height: 1px;
+        left: 0;
+        position: absolute;
+        width: 64px;
+    }
+}
+</style>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-555

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Adds the orange line from the design below the EsMenuBar desktop flyout column headers

<img width="1413" height="504" alt="Screenshot 2026-06-03 at 4 23 20 PM" src="https://github.com/user-attachments/assets/8e452b20-b3f9-4045-b3be-0d1e6b618e38" />

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally at:
    - http://localhost:8500/molecules/menu-bar
    - http://localhost:8500/examples/site-navigation

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
