### PR TITLE
fix: floating sticky bar no longer causes mobile layout shift

### DIFF
--- a/es-ds-components/app/components/es-sticky-bar.vue
+++ b/es-ds-components/app/components/es-sticky-bar.vue
@@ -7,12 +7,12 @@ import {
 } from '../utils/menu-bar';
 
 interface IProps {
-    initialState?: 'static' | 'absolute';
+    floatStartingAtBreakpoint?: 'lg' | 'xl' | 'xxl' | '';
     transparentColor?: string;
     transparentStartingAtBreakpoint?: 'lg' | 'xl' | 'xxl' | '';
 }
-const props = withDefaults(defineProps<IProps>(), {
-    initialState: 'static',
+withDefaults(defineProps<IProps>(), {
+    floatStartingAtBreakpoint: '',
     transparentColor: 'transparent',
     transparentStartingAtBreakpoint: '',
 });
@@ -28,7 +28,7 @@ const emitter = useEsdsEvents();
 // - fixed-visible: bar is pinned to the top of the viewport, visible
 // - fixed-hidden:  bar is pinned but translated off screen above the viewport
 type BarState = 'static' | 'absolute' | 'fixed-visible' | 'fixed-hidden';
-const barState = ref<BarState>(props.initialState);
+const barState = ref<BarState>('static');
 
 // ref to the bar element, used to read its rendered height
 const bar = ref<HTMLElement | null>(null);
@@ -189,6 +189,7 @@ onUnmounted(() => {
         class="es-sticky-bar"
         :class="[
             `es-sticky-bar--${barState}`,
+            floatStartingAtBreakpoint && `es-sticky-bar--float-from-${floatStartingAtBreakpoint}`,
             transparentStartingAtBreakpoint && `es-sticky-bar--transparent-from-${transparentStartingAtBreakpoint}`,
             {
                 'es-sticky-bar--no-transition': suppressTransition,
@@ -200,10 +201,11 @@ onUnmounted(() => {
         @mouseout="isHovered = false">
         <slot />
     </div>
-    <!-- holds the bar's space in normal flow when the bar is absolutely or fixed positioned -->
+    <!-- holds the bar's space in normal flow when the bar is absolutely or fixed positioned;
+         hidden at/above the float breakpoint, where the bar overlaps page content instead -->
     <div
         v-if="barState !== 'static'"
-        :class="{ 'd-xl-none': initialState !== 'static' }"
+        :class="floatStartingAtBreakpoint && `d-${floatStartingAtBreakpoint}-none`"
         :style="{ height: `${barHeight}px` }"
         aria-hidden="true" />
 </template>
@@ -231,6 +233,17 @@ $shadow: 0 0 6px 0 rgba(34, 38, 51, 0.2);
             @include breakpoints.media-breakpoint-up($bp) {
                 background-color: v-bind(transparentColor);
                 box-shadow: none;
+            }
+        }
+    }
+
+    // while still in the pre-mount static state, take the bar out of flow at/above the float
+    // breakpoint so it overlaps page content from the first paint; below the breakpoint the
+    // bar stays in flow until mount (when the spacer appears), avoiding a layout shift
+    @each $bp in (lg, xl, xxl) {
+        &--float-from-#{$bp}.es-sticky-bar--static {
+            @include breakpoints.media-breakpoint-up($bp) {
+                position: absolute;
             }
         }
     }

--- a/es-ds-docs/app/pages/molecules/sticky-bar.vue
+++ b/es-ds-docs/app/pages/molecules/sticky-bar.vue
@@ -12,12 +12,15 @@ const samplePageContent = Array(4).fill(LOREM_TEXT);
 
 const esStickyBarProps = [
     [
-        'initial-state',
-        "'static' or 'absolute'",
-        "'static'",
+        'float-starting-at-breakpoint',
+        "'lg' or 'xl' or 'xxl' or ''",
+        "''",
         `
-        The default behavior will keep the nav as part of the normal page flow. Set it to 'absolute'
-        if you want to float the nav on top of other page content.
+        If set, the sticky bar will float on top of other page content on the specified breakpoint
+        and above, with no space reserved for it in the normal page flow. Below the breakpoint,
+        the bar occupies normal page flow as usual. Operates independently of
+        transparent-starting-at-breakpoint, since a transparent bar doesn't necessarily need to
+        overlap page content (e.g. when shown over a body background color).
         `,
     ],
     [


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-600

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Fixes a bug with EsStickyBar where setting `initialState` to `'absolute'` caused a layout shift on page load on mobile where the nav would initially overlap page content and then correct itself on mount
- Changes the relevant prop from `initialState` to `floatStartingAtBreakpoint`
- Updated the EsStickyBar docs page accordingly with the prop documentation

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested by npm linking with downstream repos

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
