### PR TITLE
feat: added EsAutocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ cdk.out
 .npmrc
 
 stats-*.html
+
+# Playwright MCP browser-session artifacts
+.playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ format:
 .PHONY: test
 test:
 	npm --prefix es-ds-styles run test
-# TODO: set up testing for es-ds-components and es-ds-docs
-#	npm --prefix es-ds-components run test
+	npm --prefix es-ds-components run test
+# TODO: set up testing for es-ds-docs
 #	npm --prefix es-ds-docs run test
 
 .PHONY: build

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -211,6 +211,13 @@ AutoComplete contract that `ZipOrAddressInput` consumes:
   `@complete` emitted below this length. `ZipOrAddressInput`'s 2-character minimum was
   a Google Places quota/usefulness concern, which is app-level: address-entry consumers
   can pass `:min-chars="2"`.
+- `noResultsText` prop, default "No results found" (decision 2026-07-02, superseding
+  the earlier closed-when-empty behavior): once suggestions have been shown, a search
+  that comes back empty keeps the panel and overlay open and shows this message —
+  closing them mid-typing was a jarring flicker. The message never shows while the
+  first search is still in flight (an empty list then just means "no answer yet"), and
+  the panel still closes when the query drops below `minChars`, on Escape, tap-away,
+  select, or submit.
 - `@complete(query)` — emitted (debounced via a `delay` prop, default ~300ms) when the
   app should fetch/filter new suggestions.
 - `@select(suggestion)` — a suggestion was chosen (click or Enter on highlighted item).
@@ -388,3 +395,6 @@ Open questions raised during planning, with the decisions now reflected inline a
    from Cancel.
 8. **Title-casing is the consumer's data responsibility** — the component renders
    suggestion text as given; document this on the docs page.
+9. **Empty results keep the panel open** (§5a, `noResultsText`) — supersedes the
+   original closed-when-empty behavior after it proved to be a jarring overlay flicker
+   when a longer query stopped matching mid-typing.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -411,3 +411,10 @@ Open questions raised during planning, with the decisions now reflected inline a
    shows mid-flight), it displays `noResultsText` — including for a first query that
    never matches anything. The mobile takeover shows the same prompt/no-results
    messages in its list area.
+10. **Selection-required use cases (e.g. address validation) stay app-level**
+    (2026-07-06): the component deliberately has no `requireSelection` mode. Per the
+    §5a data-ownership split, the app tracks the last `select`-ed suggestion,
+    invalidates it when the input text no longer matches it, and treats the `submit`
+    event as a validation trigger (`state=false` + `errorMessage`) instead of a
+    search. Demonstrated in the docs page's "Requiring a selection" example; this is
+    the same pattern `ZipOrAddressInput` uses around PrimeVue today.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -281,8 +281,14 @@ es-ds-components/app/
     es-autocomplete-item.vue      # item renderer: predictive bolding + scope styling
   composables/
     fit-to-viewport.ts            # measure-then-trim (§3), visualViewport-aware
+  utils/
+    autocomplete.ts               # splitAutocompleteText — token-based predictive-bolding
+                                  # segments (req #3), used by the default item renderer and
+                                  # exported for custom item slot renderers (auto-imported in
+                                  # consuming apps)
   types/
-    es-autocomplete.ts            # EsAutocompleteSuggestion (§5); re-export from types/index.ts
+    es-autocomplete.ts            # EsAutocompleteSuggestion + EsAutocompleteTextSegment (§5);
+                                  # re-export from types/index.ts
 
 es-ds-docs/app/
   pages/molecules/autocomplete.vue      # docs page (§7a)
@@ -418,3 +424,16 @@ Open questions raised during planning, with the decisions now reflected inline a
     event as a validation trigger (`state=false` + `errorMessage`) instead of a
     search. Demonstrated in the docs page's "Requiring a selection" example; this is
     the same pattern `ZipOrAddressInput` uses around PrimeVue today.
+11. **Predictive bolding is token-based and presentation-only** (2026-07-06): the
+    `splitAutocompleteText` utility (also used by the default item renderer) splits
+    the query on whitespace and matches each token case-insensitively at word starts,
+    so query terms highlight in any order ("boston main"). It never decides what
+    matches — the app's suggestion source already did — so a backend match it cannot
+    see (typo tolerance, synonyms) benignly renders regular rather than wrongly bold.
+    For suggestions rendered as multiple lines, `splitAutocompleteTextLines` decides
+    bolding across all lines together: a line without its own token match still
+    renders fully bold when another line matched, since it is part of what selecting
+    adds (no match anywhere → everything regular). The DS deliberately ships no
+    API-specific helpers (e.g. for Google Places `matched_substrings` offsets): apps
+    whose search API returns match offsets build their own segments in a custom
+    `item` slot renderer.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -41,14 +41,27 @@ Implement against this spec; ask before deviating from a decision recorded here.
 - Props/emits follow existing form-component patterns (`es-form-input`,
   `es-dropdown-select`): typed `defineProps` with `withDefaults`, `defineModel` for
   `v-model`, explicit typed `defineEmits`.
+- **Form-API parity (decision 2026-07-02):** match the other es-ds form inputs —
+  `label`, `required`, `state` (true/false/null) and an `errorMessage` slot, per the
+  `es-form-input`/`es-dropdown-select` patterns. Additionally support hiding the label
+  (e.g. a `hideLabel` prop that renders it `sr-only`) so the autocomplete can stand on
+  its own with only placeholder text describing it visually — the label still exists
+  for screen readers.
+- **Two `AutocompleteRoot`s (decision 2026-07-02):** Reka expects one input per root,
+  and the mobile input lives inside the Dialog — so each shell gets its own
+  `AutocompleteRoot`, both bound to the same `v-model` string and `suggestions` prop.
+  Only one is interactive at a time (the other's trigger is CSS-hidden, §1a below).
+  Give each shell distinct element ids/labels so the always-rendered markup never
+  duplicates ids.
 - Breakpoint switching is split by whether the element is visible before interaction —
   the rule is **zero visual shift between SSR HTML load and JS hydration**:
   - **Visible pre-interaction (CSS-only swap):** everything on the page at load — the
     desktop `AutocompleteInput` and the mobile fake-search-field button (§4b) — is
     **always rendered in the SSR HTML** and shown/hidden purely with CSS media queries
-    (e.g. `d-none d-lg-block` / `d-lg-none` utilities). No `v-if` on a JS breakpoint
-    check for these, so a mobile page never flashes the desktop input and then snaps to
-    the mobile one when hydration completes.
+    (`d-none d-md-block` / `d-md-none` utilities; takeover below `md` — decision
+    2026-07-02). No `v-if` on a JS breakpoint check for these, so a mobile page never
+    flashes the desktop input and then snaps to the mobile one when hydration
+    completes.
   - **Not visible pre-interaction (JS swap allowed):** the popover panel vs. the Dialog
     takeover only exist after the user interacts, so the existing
     `useBreakpointChecks()` composable
@@ -67,8 +80,8 @@ Implement against this spec; ask before deviating from a decision recorded here.
 | 3 | Highlight the **predictive** portion, not the typed portion | Typed prefix rendered regular weight; the completed/predictive remainder rendered **bold**. (This is the inverse of most libraries' defaults — implement in our item renderer, do not use any built-in match highlighting.) |
 | 4 | Avoid scrollbars | Never set `overflow: auto` on the suggestion list. Overflow is prevented by the fit-to-viewport trim (§3): we only render items that fully fit. |
 | 5 | Reduce visual noise | Suggestions only. No trending searches, product cards, images, or promos inside the panel. Minimal separators. |
-| 6 | Highlight active suggestion + keyboard nav | Reka provides arrow-key nav, looping, Enter-to-submit, `aria-activedescendant`. Style the highlighted item via its `data-highlighted` attribute (background shading) and `cursor: pointer` on items. **Verify:** arrow-key focus must copy the suggestion text into the input (Google-style) so users can extend the query before submitting. If Reka's Autocomplete does not do this out of the box, wire it: on highlight change, set the input value to the highlighted item's text (preserve the user's original typed query to restore on Escape/blur past the list ends). |
-| 7 | Visual depth (desktop) | When the popover is open, dim the page behind it (fixed inset-0 overlay, ~40% black, below the popover's z-index). Border + shadow on the panel. |
+| 6 | Highlight active suggestion + keyboard nav | Reka provides arrow-key nav, looping, Enter-to-submit, `aria-activedescendant`. Style the highlighted item via its `data-highlighted` attribute (background shading) and `cursor: pointer` on items. **Decision (2026-07-02):** we deliberately SKIP the Google-style "arrow key copies suggestion text into the input" behavior. Primary use cases are selection-oriented (e.g. address entry) where users pick a whole suggestion rather than building a query from pieces. Arrow keys move the highlight only; the typed input is unchanged; Enter selects the highlighted suggestion. (Verified against installed reka-ui 2.9.7 that this is also Reka's default behavior — no extra wiring needed.) |
+| 7 | Visual depth (desktop) | When the popover is open, dim the page behind it with an overlay matching the existing `.es-menu-bar-overlay` treatment in `es-menu-bar.vue`: fixed, `variables.$black` at 0.25 opacity, `z-index: 999`, below the popover's z-index. Blur/tap-away closes the popover (as it does the menu bar flyouts), so the two overlays are never active simultaneously. Border + shadow on the panel. |
 | 8 | No competing external elements (mobile) | Solved structurally by the full-screen Dialog takeover (§4) — nothing else is on screen. |
 | 9 | Adequate spacing/tap targets (mobile) | Min 44px row height (content may wrap to more), ≥16px font on mobile, generous horizontal padding, title-case suggestion text. |
 
@@ -79,8 +92,11 @@ measure-then-trim:
 
 1. Render up to the cap (10 desktop / 8 mobile) into the list container.
 2. Container has `overflow: hidden` and a max-height:
-   - Desktop popover: `max-height: var(--reka-autocomplete-content-available-height)`
-     (exposed by Reka's popper positioning when `position="popper"`).
+   - Desktop popover: `max-height: var(--reka-combobox-content-available-height)`
+     (exposed by Reka's popper positioning when `position="popper"`; note the
+     **combobox** naming — the `Autocomplete*` content components are re-exported
+     Combobox internals in the installed reka-ui 2.9.x, and no `--reka-autocomplete-*`
+     variables exist).
    - Mobile takeover: container height = visual viewport height minus the input bar
      (see §4 keyboard handling).
 3. After render (`nextTick`), walk children: count items where
@@ -121,16 +137,19 @@ users compare) is at the end of the string. Wrapping is preferred over truncatio
 ## 4. Two layouts, one core
 
 Build one core suggestion component (input wiring + item rendering + trim logic) and two
-shells: takeover below `lg`, popover at `lg` and up. Pre-interaction elements of both
-shells are always SSR-rendered and swapped via CSS media queries; only the
-post-interaction behavior (which shell opens) switches on `useBreakpointChecks()` —
-see §1a. Shared query state.
+shells: **takeover below `md`, popover at `md` and up** (decision 2026-07-02 — phones
+get the takeover; tablets get the popover). Pre-interaction elements of both shells are
+always SSR-rendered and swapped via CSS media queries; only the post-interaction
+behavior (which shell opens) switches on `useBreakpointChecks()`'s `isMobile` (true
+below `md`) — see §1a. Each shell has its own `AutocompleteRoot` (§1a); query state is
+shared via the same `v-model`.
 
 ### 4a. Desktop: anchored popover
 - `AutocompleteRoot` → `AutocompleteInput` + `AutocompletePortal` → `AutocompleteContent
   position="popper"`.
-- Panel width: `min-width: var(--reka-autocomplete-trigger-width)` plus a comfortable
-  `max-width` — the panel MAY be wider than a narrow input (reduces wrapping).
+- Panel width: `min-width: var(--reka-combobox-trigger-width)` (combobox naming — see
+  §3) plus a comfortable `max-width` — the panel MAY be wider than a narrow input
+  (reduces wrapping).
 - Page-dim overlay while open (req #7).
 
 ### 4b. Mobile: full-screen Dialog takeover
@@ -147,12 +166,21 @@ see §1a. Shared query state.
   equivalent) — the dialog IS the open state.
 - Dialog gives us for free: focus trap, body scroll lock, Escape handling, `aria-modal`.
 
+Closing the takeover (decision 2026-07-02):
+- **No Android back-button/history handling** — pushing history state risks conflicts
+  with vue-router in consuming Nuxt apps. Skipped for now; revisit only if user testing
+  shows back-button abandonment.
+- Instead, ensure a **clear, always-visible close affordance**: the `DialogClose`
+  ("Cancel") text button in the top bar next to the input. A text button deliberately
+  avoids visual conflict with a possible future X-in-the-input to **clear the field**
+  (Reka ships `AutocompleteCancel` for exactly that — worth considering as an
+  iteration, but if added, close-takeover and clear-input must remain visually
+  distinct). Escape also closes (Dialog default).
+
 Mobile gotchas (all required):
 - **Keyboard vs viewport:** `100dvh` does not shrink when the iOS keyboard opens. Use
   `visualViewport.height` for the trim-limit calculation and listen to its `resize`.
 - **Input font-size ≥ 16px** or iOS Safari auto-zooms on focus.
-- **Android back button:** push a history state on open; close the dialog on `popstate`
-  instead of navigating away.
 
 ## 5. Suggestion data model
 
@@ -179,6 +207,10 @@ AutoComplete contract that `ZipOrAddressInput` consumes:
 
 - `v-model` — the input string.
 - `suggestions: EsAutocompleteSuggestion[]` prop — the current list.
+- `minChars` prop, **default 1** (decision 2026-07-02, per UX guidelines) — no
+  `@complete` emitted below this length. `ZipOrAddressInput`'s 2-character minimum was
+  a Google Places quota/usefulness concern, which is app-level: address-entry consumers
+  can pass `:min-chars="2"`.
 - `@complete(query)` — emitted (debounced via a `delay` prop, default ~300ms) when the
   app should fetch/filter new suggestions.
 - `@select(suggestion)` — a suggestion was chosen (click or Enter on highlighted item).
@@ -221,12 +253,14 @@ es-ds-styles tokens. Port the visual treatment, not the PrimeVue plumbing:
 - Full keyboard: ArrowUp/Down navigates and **loops**; Enter submits the highlighted
   suggestion (or the raw input if none highlighted); Escape closes (desktop) / closes
   the takeover (mobile); Tab behaves sanely.
-- Arrow navigation copies suggestion text into the input (see table row #6).
+- Arrow navigation moves the highlight only — the typed input is unchanged (see table
+  row #6); Enter selects the highlighted suggestion.
 - Highlighted item visually distinct via `data-highlighted` styling.
-- Screen reader: list changes announced; item count communicated; label the input
-  (visually or via Reka's Label) — do not rely on placeholder alone. Follow
-  `ZipOrAddressInput`'s pattern of an `sr-only` label plus `aria-describedby` help text
-  ("Type your search and select from dropdown suggestions.").
+- Screen reader: list changes announced; item count communicated; the input always has
+  a label — visible by default (form-API parity, §1a), rendered `sr-only` when
+  `hideLabel` is set, so placeholder-only presentations still label the control. Also
+  provide `aria-describedby` help text as `ZipOrAddressInput` does ("Type your search
+  and select from dropdown suggestions.").
 - Touch targets ≥ 44px; text ≥ 16px on mobile.
 
 ## 7. File layout
@@ -308,7 +342,8 @@ On the docs page at `http://localhost:8500/molecules/autocomplete`:
       identical before and after hydration — no desktop-input flash (§1a)
 - [ ] Desktop: ≤10 suggestions, no scrollbar at any viewport height, dim overlay,
       hover + keyboard highlight, hand cursor
-- [ ] Arrow keys copy suggestion into input; Enter submits it; list loops
+- [ ] Arrow keys move the highlight without changing the typed input; Enter selects
+      the highlighted suggestion; list loops
 - [ ] Predictive portion bolded; typed prefix regular; scoped suggestions styled
       distinctly with separator
 - [ ] Visual parity with `ZipOrAddressInput` styling (§5b): focus ring, panel
@@ -316,7 +351,7 @@ On the docs page at `http://localhost:8500/molecules/autocomplete`:
 - [ ] Mobile (devtools emulation + at least one real iOS device): tap fake field →
       full-screen takeover opens with keyboard up in one tap
 - [ ] Mobile: suggestions never hidden behind the on-screen keyboard (rotate + small
-      devices tested); Android back closes takeover; no iOS focus zoom
+      devices tested); Cancel button and Escape close the takeover; no iOS focus zoom
 - [ ] Wrapped (2-line) suggestions are never clipped mid-item
 - [ ] axe/lighthouse a11y pass on both layouts; VoiceOver + TalkBack smoke test
 - [ ] Docs page renders correctly: examples, prop table, highlighted source via
@@ -328,3 +363,28 @@ Per the repo's publishing workflow: bump `es-ds-components` version (minor — n
 component), update its `CHANGELOG.md` (keepachangelog format), publish styles first if
 it also changed. PR title must be conventional-commit format, e.g.
 `feat: add EsAutocomplete component and docs page`.
+
+## 9. Decision log (resolved 2026-07-02)
+
+Open questions raised during planning, with the decisions now reflected inline above:
+
+1. **No Google-style copy-on-highlight** (req #6): arrow keys move the highlight only.
+   Primary use cases (e.g. address entry) are selection-oriented — users pick a whole
+   suggestion, they don't compose queries from suggestion fragments.
+2. **Two `AutocompleteRoot`s**, one per shell, sharing `v-model`/`suggestions` (§1a) —
+   matches Reka's one-input-per-root expectation.
+3. **Takeover breakpoint: below `md`** (§4) — phones get the takeover, tablets the
+   popover.
+4. **Form-API parity** with es-ds inputs (`label`, `required`, `state`, `errorMessage`)
+   plus `hideLabel` for placeholder-only presentation (§1a, §6).
+5. **Desktop dim overlay matches `.es-menu-bar-overlay`** (`$black` @ 0.25,
+   `z-index: 999`) (req #7). Blur closes the popover, so the menu bar and autocomplete
+   overlays are never active at once.
+6. **`minChars` defaults to 1** (§5a) — ZipOrAddressInput's 2-char minimum was a Google
+   Places quota concern, which stays app-level.
+7. **No Android back-button/history handling** (§4b) — router-conflict risk; the
+   takeover instead has an always-visible Cancel button (+ Escape). A clear-input X
+   (Reka `AutocompleteCancel`) is a possible iteration and must stay visually distinct
+   from Cancel.
+8. **Title-casing is the consumer's data responsibility** — the component renders
+   suggestion text as given; document this on the docs page.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -76,7 +76,7 @@ Implement against this spec; ask before deviating from a decision recorded here.
 | # | Requirement | How we implement it |
 |---|------------|---------------------|
 | 1 | Keep list manageable (≤10 desktop, 4–8 mobile) | Hard cap constant `MAX_DESKTOP = 10`, `MAX_MOBILE = 8`, further reduced by fit-to-viewport trim (§3) |
-| 2 | Style category-scope suggestions differently | Suggestion model has a `scope?` field; scope text rendered in muted color + italic within the item, after the query text. Horizontal separator between unscoped and scoped groups. |
+| 2 | Style category-scope suggestions differently | **Descoped (2026-07-06, decision 12):** no current EnergySage use case has category-scoped suggestions, so the `scope` field, its styling, and the group separator were removed. Apps that ever need scope-style rendering can build it with the `item` slot + `value` payload. |
 | 3 | Highlight the **predictive** portion, not the typed portion | Typed prefix rendered regular weight; the completed/predictive remainder rendered **bold**. (This is the inverse of most libraries' defaults — implement in our item renderer, do not use any built-in match highlighting.) |
 | 4 | Avoid scrollbars | Never set `overflow: auto` on the suggestion list. Overflow is prevented by the fit-to-viewport trim (§3): we only render items that fully fit. |
 | 5 | Reduce visual noise | Suggestions only. No trending searches, product cards, images, or promos inside the panel. Minimal separators. |
@@ -189,14 +189,11 @@ Mobile gotchas (all required):
 interface EsAutocompleteSuggestion {
   id: string
   text: string          // full suggested query, e.g. "backpack rain cover"
-  scope?: {             // present only for category-scoped suggestions (req #2)
-    label: string       // e.g. "in Outdoor Gear"
-  }
   value?: unknown       // opaque app payload, returned untouched on select
 }
 ```
-Consuming apps pass at most 10; the component trims further per §3. Order: unscoped
-suggestions first, then scoped, separated visually.
+Consuming apps pass at most 10; the component trims further per §3. (A `scope` field
+for category-scoped suggestions existed here originally — removed per decision 12.)
 
 ### 5a. Data ownership (presentational component)
 
@@ -278,7 +275,7 @@ es-ds-components/app/
     es-autocomplete.vue           # public component; breakpoint switch (§1a) between shells
     es-autocomplete-desktop.vue   # popover shell (§4a) + dim overlay
     es-autocomplete-mobile.vue    # Dialog takeover shell (§4b)
-    es-autocomplete-item.vue      # item renderer: predictive bolding + scope styling
+    es-autocomplete-item.vue      # item renderer: predictive bolding
     es-autocomplete-suggestion-text.vue  # public inline renderer of predictive-bolding
                                   # segments; takes text+query, or pre-computed segments
                                   # (from splitAutocompleteTextLines or API match offsets)
@@ -309,7 +306,7 @@ doc-page pattern (see `pages/molecules/dropdown-select.vue`):
 - `<h1>Autocomplete</h1>` + intro line "Extended from" linking to
   https://reka-ui.com/docs/components/autocomplete.
 - Example sections (each an `<h2>` in a `div.mb-500`, demos in `div.row > div.col-md-6`):
-  basic usage (static client-filtered list), scoped suggestions with separator,
+  basic usage (static client-filtered list),
   predictive-portion bolding, custom item slot (two-line, address-style), disabled
   state, and a note + demo for the mobile takeover (resize/emulate below `lg`).
 - Props documented via `<ds-prop-table :rows="autocompleteProps" />` (rows array of
@@ -360,8 +357,7 @@ On the docs page at `http://localhost:8500/molecules/autocomplete`:
       hover + keyboard highlight, hand cursor
 - [ ] Arrow keys move the highlight without changing the typed input; Enter selects
       the highlighted suggestion; list loops
-- [ ] Predictive portion bolded; typed prefix regular; scoped suggestions styled
-      distinctly with separator
+- [ ] Predictive portion bolded; typed/matched portions regular
 - [ ] Visual parity with `ZipOrAddressInput` styling (§5b): focus ring, panel
       border/shadow, item hover/active colors
 - [ ] Mobile (devtools emulation + at least one real iOS device): tap fake field →
@@ -446,3 +442,10 @@ Open questions raised during planning, with the decisions now reflected inline a
     API-specific helpers (e.g. for Google Places `matched_substrings` offsets): apps
     whose search API returns match offsets build their own segments in a custom
     `item` slot renderer.
+12. **Category-scope suggestions removed** (2026-07-06, supersedes req #2): the
+    `scope` field, its muted-italic styling, the unscoped-before-scoped ordering, and
+    the group separator were all removed — Baymard's recommendation applies to
+    category-scoped search results, and no current EnergySage use case has them. If
+    one appears, scope-style rendering can be built entirely app-side with the `item`
+    slot and the `value` payload, or the feature can be reintroduced from this plan's
+    history.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -1,0 +1,330 @@
+# EsAutocomplete — Implementation Plan (adapted for es-ds)
+
+Goal: build an accessible, SSR-safe search autocomplete **design system component
+(`EsAutocomplete`) in `es-ds-components`**, plus an accompanying **documentation page in
+`es-ds-docs`**, using **Reka UI** primitives and satisfying all 9 UX best practices from
+Baymard's autocomplete research (https://baymard.com/blog/autocomplete-design), plus a
+full-screen takeover experience on mobile.
+
+This document is the source of truth for requirements and architecture decisions.
+Implement against this spec; ask before deviating from a decision recorded here.
+
+---
+
+## 1. Stack decisions (already made — do not relitigate)
+
+- **Base library:** Reka UI (`reka-ui`) — headless, WAI-ARIA compliant, SSR-compatible.
+  Already a devDependency of `es-ds-components` at `^2.8.0`, which includes the
+  `Autocomplete*` primitives. **Do not add the `reka-ui/nuxt` module** — this repo's
+  convention is direct named imports from `'reka-ui'` inside the component (see
+  `es-ds-components/app/components/es-popover.vue`), and `es-ds-components` has no build
+  step (consumed as source), so no nuxt.config changes are needed.
+- **Primary primitive:** `Autocomplete*` components (NOT `Combobox*`). Autocomplete is
+  free-form text — `modelValue` is the input string itself, which is correct for search.
+  Docs: https://reka-ui.com/docs/components/autocomplete (LLM-optimized markdown available
+  at https://reka-ui.com/docs/components/autocomplete.md).
+- **Mobile shell:** Reka UI `Dialog*` components as a full-screen takeover (see §4).
+  Not Drawer (swipe-dismiss fights scrolling; drawers want to be partial-height). Note:
+  `EsModal` exists but is a general-purpose modal — the takeover shell needs bespoke
+  layout (input bar + inline suggestion list), so use the Dialog primitives directly.
+- **Filtering:** the component is **presentational** — the consuming app owns fetching,
+  debouncing, and filtering (see §5a). Set `ignore-filter` on the root so Reka does not
+  re-filter; the app passes the already-trimmed array (see §3).
+
+## 1a. Component API & placement (es-ds conventions)
+
+- Files live in `es-ds-components/app/components/`, kebab-case with the `es-` prefix,
+  and are auto-imported into consuming Nuxt apps (`EsAutocomplete` / `<es-autocomplete>`).
+- Multi-part components follow the suffix convention (`es-menu-bar-*`, `es-mobile-nav-*`):
+  internal shells are separate `es-autocomplete-*.vue` files (see §7). They will be
+  globally registered like everything else; document only `EsAutocomplete` as public.
+- Props/emits follow existing form-component patterns (`es-form-input`,
+  `es-dropdown-select`): typed `defineProps` with `withDefaults`, `defineModel` for
+  `v-model`, explicit typed `defineEmits`.
+- Breakpoint switching is split by whether the element is visible before interaction —
+  the rule is **zero visual shift between SSR HTML load and JS hydration**:
+  - **Visible pre-interaction (CSS-only swap):** everything on the page at load — the
+    desktop `AutocompleteInput` and the mobile fake-search-field button (§4b) — is
+    **always rendered in the SSR HTML** and shown/hidden purely with CSS media queries
+    (e.g. `d-none d-lg-block` / `d-lg-none` utilities). No `v-if` on a JS breakpoint
+    check for these, so a mobile page never flashes the desktop input and then snaps to
+    the mobile one when hydration completes.
+  - **Not visible pre-interaction (JS swap allowed):** the popover panel vs. the Dialog
+    takeover only exist after the user interacts, so the existing
+    `useBreakpointChecks()` composable
+    (`es-ds-components/app/composables/breakpoints.ts`) may decide which shell to open,
+    as `es-menu-bar`/`es-mobile-nav` do. Its doc comment warns against using it for
+    show/hide styling — this use is **behavioral** (two different interaction modes),
+    which is what it's for.
+  - Verify both: no hydration warnings AND no visual shift at load (§8).
+
+## 2. The 9 Baymard requirements → implementation mapping
+
+| # | Requirement | How we implement it |
+|---|------------|---------------------|
+| 1 | Keep list manageable (≤10 desktop, 4–8 mobile) | Hard cap constant `MAX_DESKTOP = 10`, `MAX_MOBILE = 8`, further reduced by fit-to-viewport trim (§3) |
+| 2 | Style category-scope suggestions differently | Suggestion model has a `scope?` field; scope text rendered in muted color + italic within the item, after the query text. Horizontal separator between unscoped and scoped groups. |
+| 3 | Highlight the **predictive** portion, not the typed portion | Typed prefix rendered regular weight; the completed/predictive remainder rendered **bold**. (This is the inverse of most libraries' defaults — implement in our item renderer, do not use any built-in match highlighting.) |
+| 4 | Avoid scrollbars | Never set `overflow: auto` on the suggestion list. Overflow is prevented by the fit-to-viewport trim (§3): we only render items that fully fit. |
+| 5 | Reduce visual noise | Suggestions only. No trending searches, product cards, images, or promos inside the panel. Minimal separators. |
+| 6 | Highlight active suggestion + keyboard nav | Reka provides arrow-key nav, looping, Enter-to-submit, `aria-activedescendant`. Style the highlighted item via its `data-highlighted` attribute (background shading) and `cursor: pointer` on items. **Verify:** arrow-key focus must copy the suggestion text into the input (Google-style) so users can extend the query before submitting. If Reka's Autocomplete does not do this out of the box, wire it: on highlight change, set the input value to the highlighted item's text (preserve the user's original typed query to restore on Escape/blur past the list ends). |
+| 7 | Visual depth (desktop) | When the popover is open, dim the page behind it (fixed inset-0 overlay, ~40% black, below the popover's z-index). Border + shadow on the panel. |
+| 8 | No competing external elements (mobile) | Solved structurally by the full-screen Dialog takeover (§4) — nothing else is on screen. |
+| 9 | Adequate spacing/tap targets (mobile) | Min 44px row height (content may wrap to more), ≥16px font on mobile, generous horizontal padding, title-case suggestion text. |
+
+## 3. Fit-to-viewport trimming (no scrollbars, no clipped items)
+
+Rows may **wrap** (panels can be narrow), so row height is not fixed. Use
+measure-then-trim:
+
+1. Render up to the cap (10 desktop / 8 mobile) into the list container.
+2. Container has `overflow: hidden` and a max-height:
+   - Desktop popover: `max-height: var(--reka-autocomplete-content-available-height)`
+     (exposed by Reka's popper positioning when `position="popper"`).
+   - Mobile takeover: container height = visual viewport height minus the input bar
+     (see §4 keyboard handling).
+3. After render (`nextTick`), walk children: count items where
+   `offsetTop + offsetHeight <= container.clientHeight`. Slice state to that count
+   (min 1).
+4. Stability property: an item's height depends only on panel width, not sibling count,
+   so trimming never changes remaining heights — converges in one pass, no loop.
+5. Re-measure on: suggestions change, container resize (`ResizeObserver`), and on mobile,
+   `visualViewport` `resize` events (keyboard open/close is just a resize).
+6. Set `visibility: hidden` on the container until the first measurement completes to
+   avoid a one-frame flash of clipped items.
+7. **Slice the actual array passed to the component** — never hide overflow items with
+   CSS. Reka's keyboard nav must only know about visible items.
+
+```ts
+// composable sketch — es-ds-components/app/composables/fit-to-viewport.ts
+const CAP = isMobile ? 8 : 10
+const visibleCount = ref(CAP)
+async function remeasure() {
+  visibleCount.value = CAP
+  await nextTick()
+  const el = contentEl.value; if (!el) return
+  const limit = el.clientHeight
+  let fits = 0
+  for (const child of el.children) {
+    const c = child as HTMLElement
+    if (c.offsetTop + c.offsetHeight <= limit) fits++
+    else break
+  }
+  visibleCount.value = Math.max(fits, 1)
+}
+const visibleSuggestions = computed(() => suggestions.value.slice(0, visibleCount.value))
+```
+
+Do NOT ellipsize suggestions to force single lines: the predictive part (the information
+users compare) is at the end of the string. Wrapping is preferred over truncation.
+
+## 4. Two layouts, one core
+
+Build one core suggestion component (input wiring + item rendering + trim logic) and two
+shells: takeover below `lg`, popover at `lg` and up. Pre-interaction elements of both
+shells are always SSR-rendered and swapped via CSS media queries; only the
+post-interaction behavior (which shell opens) switches on `useBreakpointChecks()` —
+see §1a. Shared query state.
+
+### 4a. Desktop: anchored popover
+- `AutocompleteRoot` → `AutocompleteInput` + `AutocompletePortal` → `AutocompleteContent
+  position="popper"`.
+- Panel width: `min-width: var(--reka-autocomplete-trigger-width)` plus a comfortable
+  `max-width` — the panel MAY be wider than a narrow input (reduces wrapping).
+- Page-dim overlay while open (req #7).
+
+### 4b. Mobile: full-screen Dialog takeover
+- On-page trigger is a **fake search field** (a `<button>` styled as an input). Tapping
+  it opens the Dialog and focuses the real input **synchronously within the tap's event
+  chain** (iOS only shows the keyboard for focus inside a user gesture). Use
+  `DialogContent`'s `@open-auto-focus` to redirect initial focus to the input.
+- Structure: `DialogRoot` → `DialogPortal` → `DialogContent` (fixed inset-0, flex column,
+  `height: 100dvh`) containing:
+  - top bar: `AutocompleteInput` (full width, flex-1) + `DialogClose` ("Cancel")
+  - below: `AutocompleteContent` rendered **inline** (default positioning — no Portal,
+    no `position="popper"`), `flex-1`, `overflow: hidden`, trim logic from §3.
+- Keep the autocomplete open state pinned while the dialog is open (`:open="true"` or
+  equivalent) — the dialog IS the open state.
+- Dialog gives us for free: focus trap, body scroll lock, Escape handling, `aria-modal`.
+
+Mobile gotchas (all required):
+- **Keyboard vs viewport:** `100dvh` does not shrink when the iOS keyboard opens. Use
+  `visualViewport.height` for the trim-limit calculation and listen to its `resize`.
+- **Input font-size ≥ 16px** or iOS Safari auto-zooms on focus.
+- **Android back button:** push a history state on open; close the dialog on `popstate`
+  instead of navigating away.
+
+## 5. Suggestion data model
+
+```ts
+// es-ds-components/app/types/es-autocomplete.ts
+interface EsAutocompleteSuggestion {
+  id: string
+  text: string          // full suggested query, e.g. "backpack rain cover"
+  scope?: {             // present only for category-scoped suggestions (req #2)
+    label: string       // e.g. "in Outdoor Gear"
+  }
+  value?: unknown       // opaque app payload, returned untouched on select
+}
+```
+Consuming apps pass at most 10; the component trims further per §3. Order: unscoped
+suggestions first, then scoped, separated visually.
+
+### 5a. Data ownership (presentational component)
+
+A design system component cannot know the data source (Google Places, search API,
+static list…), so — unlike the original app-specific plan — there is **no
+`useSearchSuggestions` composable in es-ds**. Instead, mirroring the PrimeVue
+AutoComplete contract that `ZipOrAddressInput` consumes:
+
+- `v-model` — the input string.
+- `suggestions: EsAutocompleteSuggestion[]` prop — the current list.
+- `@complete(query)` — emitted (debounced via a `delay` prop, default ~300ms) when the
+  app should fetch/filter new suggestions.
+- `@select(suggestion)` — a suggestion was chosen (click or Enter on highlighted item).
+- `@submit(query)` — Enter with no highlighted suggestion.
+
+Fetching, session tokens, error states, and validation (everything `ZipOrAddressInput`
+does around Google Places) stay in the consuming app. The docs page demos with
+client-side filtering of a static array.
+
+## 5b. Starting styles (port from `ZipOrAddressInput`)
+
+Initial look-and-feel comes from `ZipOrAddressInput.vue` in the sibling
+`es-storyblok-shared` repo (`app/components/ZipOrAddressInput.vue`), which already uses
+es-ds-styles tokens. Port the visual treatment, not the PrimeVue plumbing:
+
+- **SCSS setup:** scoped `<style lang="scss">` with
+  `@use '@energysage/es-ds-styles/scss/variables' as variables;`.
+- **Input wrapper:** `es-form-input form-control` utility classes; on `:focus-within`,
+  `border-color: variables.$blue-600`, `outline: 0.125rem solid variables.$blue-600`,
+  `outline-offset: 0.125rem`. Inner `AutocompleteInput` is borderless/transparent with
+  `outline: none` on `:focus-visible`; placeholder color
+  `variables.$input-color-placeholder`.
+- **Panel:** `bg-white rounded-xs text-gray-900` utilities;
+  `border: variables.$border-width solid variables.$gray-500`;
+  `box-shadow: variables.$popover-box-shadow`. List: `list-unstyled font-size-75 m-0 p-0
+  text-left`. Subtle open/close transition (opacity + slight scaleY, ~120ms) like the
+  `.es-address-panel` enter/leave states.
+- **Items:** `px-100 py-50`, `cursor: pointer`, `transition: background-color 0.15s
+  ease-in-out`; hover and highlighted (`[data-highlighted]` in Reka, vs PrimeVue's
+  `[data-p-focus]`) background `variables.$blue-50`; `:active` background
+  `variables.$blue-100`. Two-line item layout (primary line semibold, secondary line
+  `font-size-50`) is available via the item slot, as in the address suggestions.
+- **Deliberate divergence:** `ZipOrAddressInput` scrolls its panel
+  (`overflow-y: auto`, `scroll-height="17rem"`). Req #4 forbids scrollbars — keep the
+  fit-to-viewport trim (§3) and drop the scroll behavior; adopt the visuals only.
+
+## 6. Accessibility acceptance criteria
+
+- Adheres to WAI-ARIA combobox pattern (Reka handles roles/attrs; do not override them).
+- Full keyboard: ArrowUp/Down navigates and **loops**; Enter submits the highlighted
+  suggestion (or the raw input if none highlighted); Escape closes (desktop) / closes
+  the takeover (mobile); Tab behaves sanely.
+- Arrow navigation copies suggestion text into the input (see table row #6).
+- Highlighted item visually distinct via `data-highlighted` styling.
+- Screen reader: list changes announced; item count communicated; label the input
+  (visually or via Reka's Label) — do not rely on placeholder alone. Follow
+  `ZipOrAddressInput`'s pattern of an `sr-only` label plus `aria-describedby` help text
+  ("Type your search and select from dropdown suggestions.").
+- Touch targets ≥ 44px; text ≥ 16px on mobile.
+
+## 7. File layout
+
+```
+es-ds-components/app/
+  components/
+    es-autocomplete.vue           # public component; breakpoint switch (§1a) between shells
+    es-autocomplete-desktop.vue   # popover shell (§4a) + dim overlay
+    es-autocomplete-mobile.vue    # Dialog takeover shell (§4b)
+    es-autocomplete-item.vue      # item renderer: predictive bolding + scope styling
+  composables/
+    fit-to-viewport.ts            # measure-then-trim (§3), visualViewport-aware
+  types/
+    es-autocomplete.ts            # EsAutocompleteSuggestion (§5); re-export from types/index.ts
+
+es-ds-docs/app/
+  pages/molecules/autocomplete.vue      # docs page (§7a)
+  components/ds-molecules-list.vue      # add nav link (§7a)
+```
+
+### 7a. Documentation page (es-ds-docs)
+
+New page `es-ds-docs/app/pages/molecules/autocomplete.vue`, following the established
+doc-page pattern (see `pages/molecules/dropdown-select.vue`):
+
+- `$prism` setup in `onMounted`: raw-import both the component source
+  (`@energysage/es-ds-components/app/components/es-autocomplete.vue?raw`) and the doc
+  page's own source (`./autocomplete.vue?raw`), normalize and highlight.
+- `<h1>Autocomplete</h1>` + intro line "Extended from" linking to
+  https://reka-ui.com/docs/components/autocomplete.
+- Example sections (each an `<h2>` in a `div.mb-500`, demos in `div.row > div.col-md-6`):
+  basic usage (static client-filtered list), scoped suggestions with separator,
+  predictive-portion bolding, custom item slot (two-line, address-style), disabled
+  state, and a note + demo for the mobile takeover (resize/emulate below `lg`).
+- Props documented via `<ds-prop-table :rows="autocompleteProps" />` (rows array of
+  `[name, type, default, description]`).
+- Emitted events documented in prose or a second table, matching pages that document
+  events.
+- `<ds-doc-source>` at the bottom with `comp-source="es-ds-components/components/es-autocomplete.vue"`
+  and `doc-source="es-ds-docs/pages/molecules/autocomplete.vue"`.
+- Register the page in `es-ds-docs/app/components/ds-molecules-list.vue` — alphabetical:
+  `<ds-link to="/molecules/autocomplete"> Autocomplete </ds-link>` between Accordion and
+  Badge.
+
+## 8. Testing & verification plan (adapted to es-ds)
+
+There is currently **no unit-test infrastructure** for `es-ds-components` (its `npm test`
+is a stub; the root `Makefile` has a TODO to add it). Do not build one as part of this
+work. Verification is via the repo's quality gates plus manual/browser checks against
+the docs page.
+
+### 8a. Repo quality gates (must pass)
+
+```bash
+make install && make symlink   # once; symlinks local packages into es-ds-docs
+make dev                       # docs site with HMR at http://localhost:8500
+make lint                      # eslint + prettier across all three packages
+make format                    # run before lint if it complains
+make typecheck                 # nuxi typecheck in es-ds-docs (covers linked components)
+make build                     # es-ds-styles + es-ds-docs build (es-ds-components has no build step)
+make test                      # styles-only today; must still pass
+```
+
+SSR is verified through the docs site: `make build` must succeed, and loading
+`/molecules/autocomplete` under `make dev` must produce **zero hydration warnings** in
+the browser console AND **zero visual shift** between the initial HTML paint and
+hydration (§1a). Check with devtools mobile emulation + network throttling (slow
+hydration makes any pre-hydration flash obvious); any `v-if` on a JS breakpoint check
+for pre-interaction markup is the likely offender.
+
+### 8b. Manual verification checklist (definition of done)
+
+On the docs page at `http://localhost:8500/molecules/autocomplete`:
+
+- [ ] `make lint`, `make typecheck`, `make build`, `make test` all pass
+- [ ] SSR: no hydration warnings on page load (desktop and emulated mobile)
+- [ ] Zero visual shift at load: on mobile (throttled network), the input area looks
+      identical before and after hydration — no desktop-input flash (§1a)
+- [ ] Desktop: ≤10 suggestions, no scrollbar at any viewport height, dim overlay,
+      hover + keyboard highlight, hand cursor
+- [ ] Arrow keys copy suggestion into input; Enter submits it; list loops
+- [ ] Predictive portion bolded; typed prefix regular; scoped suggestions styled
+      distinctly with separator
+- [ ] Visual parity with `ZipOrAddressInput` styling (§5b): focus ring, panel
+      border/shadow, item hover/active colors
+- [ ] Mobile (devtools emulation + at least one real iOS device): tap fake field →
+      full-screen takeover opens with keyboard up in one tap
+- [ ] Mobile: suggestions never hidden behind the on-screen keyboard (rotate + small
+      devices tested); Android back closes takeover; no iOS focus zoom
+- [ ] Wrapped (2-line) suggestions are never clipped mid-item
+- [ ] axe/lighthouse a11y pass on both layouts; VoiceOver + TalkBack smoke test
+- [ ] Docs page renders correctly: examples, prop table, highlighted source via
+      `ds-doc-source`, and the new nav link in `ds-molecules-list.vue`
+
+### 8c. Release notes (post-merge, when publishing)
+
+Per the repo's publishing workflow: bump `es-ds-components` version (minor — new
+component), update its `CHANGELOG.md` (keepachangelog format), publish styles first if
+it also changed. PR title must be conventional-commit format, e.g.
+`feat: add EsAutocomplete component and docs page`.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -391,8 +391,12 @@ Open questions raised during planning, with the decisions now reflected inline a
    Places quota concern, which stays app-level.
 7. **No Android back-button/history handling** (§4b) — router-conflict risk; the
    takeover instead has an always-visible Cancel button (+ Escape). A clear-input X
-   (Reka `AutocompleteCancel`) is a possible iteration and must stay visually distinct
-   from Cancel.
+   (Reka `AutocompleteCancel`) was added 2026-07-06 (per Baymard's clear-button
+   examples): an `icon-x` button inside the right edge of the input, shown only when
+   the input has text, ≥44px tap target, rendered as a flex sibling so it can never
+   overlap the entered text, with an i18n-able `clearText` aria-label. It clears the
+   value and refocuses the input. Visually distinct from the takeover's Cancel text
+   button, as required.
 8. **Title-casing is the consumer's data responsibility** — the component renders
    suggestion text as given; document this on the docs page.
 9. **Empty results keep the panel open** (§5a, `noResultsText`) — supersedes the

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -339,6 +339,24 @@ wired into `make test` and therefore the ci.yml PR workflow):**
   (submit vs select vs ignore: auto-highlight vs user highlight, IME composition,
   Enter from the clear button) plus select/clear behavior. These encode the two
   Enter regressions found during the code review.
+- `app/composables/autocomplete-search.test.ts` — the debounced `complete`
+  contract: one emission per typing pause with the trimmed query, minChars gating,
+  suppression after selection, cancellation on submit/unmount so a late response
+  can never reopen the panel, and the prompt → results → no-results →
+  prompt-while-pending message lifecycle. Made unit-testable by extracting the
+  parent's search state into `useAutocompleteSearch` (2026-07-07), which removed
+  the need for the @nuxt/test-utils component test previously deferred below.
+- `app/composables/autocomplete-content-el.test.ts` — panel-element resolution:
+  resolves only real elements (never Reka's placeholder comment node), clears on
+  deactivate, re-resolves a swapped `$el`. Encodes the two `$el` bugs found during
+  development (ResizeObserver crash; panel stuck invisible).
+- `app/composables/fit-to-viewport.test.ts` — the trim counting/limit logic with
+  mocked geometry: only fully-fitting items count, non-item children consume space
+  but aren't counted, the min-1 floor, resolved max-height preferred over
+  content-sized clientHeight (the grow-back regression), clientHeight fallback for
+  the mobile list, re-measure on suggestion change. NOTE: happy-dom has no real
+  layout, so this covers the logic only — real-browser behavior belongs to the
+  deferred Playwright specs below.
 
 **Deferred — Playwright end-to-end specs (docs site as fixture).** Deliberately NOT
 built yet: the docs page is due a complete manual overhaul (examples are
@@ -362,12 +380,11 @@ docs site:
    closes. Optionally add an @axe-core/playwright scan of both layouts as an
    a11y smoke test.
 
-**Deferred — component test (Vitest + @nuxt/test-utils runtime environment).** The
-parent emit contract with fake timers: `complete` debounced to one emission per
-pause, suppressed after selection, and cancelled by submit/select so a late
-response cannot reopen the panel. Deferred with the Playwright work for the same
-reason (its observable behavior will ride along in e2e spec 1) and because
-@nuxt/test-utils is the one genuinely new piece of test infrastructure it needs.
+**No longer deferred — the component test.** The parent emit contract (debounce,
+suppression, cancellation) was originally deferred because testing it required
+mounting the SFC under @nuxt/test-utils; extracting the logic into
+`useAutocompleteSearch` (2026-07-07) made it a plain Vitest with fake timers
+instead — see `autocomplete-search.test.ts` above. No @nuxt/test-utils needed.
 
 ### 8b. Repo quality gates (must pass)
 

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -321,12 +321,55 @@ doc-page pattern (see `pages/molecules/dropdown-select.vue`):
 
 ## 8. Testing & verification plan (adapted to es-ds)
 
-There is currently **no unit-test infrastructure** for `es-ds-components` (its `npm test`
-is a stub; the root `Makefile` has a TODO to add it). Do not build one as part of this
-work. Verification is via the repo's quality gates plus manual/browser checks against
-the docs page.
+Unit tests now exist for `es-ds-components` (Vitest, added 2026-07-07 — see §8a);
+end-to-end and component tests are documented below but deliberately deferred until
+after the planned docs-page overhaul. Beyond the automated tests, verification is
+via the repo's quality gates plus manual/browser checks against the docs page.
 
-### 8a. Repo quality gates (must pass)
+### 8a. Automated tests (partially implemented 2026-07-07)
+
+**Implemented — unit tests (Vitest, run by `npm --prefix es-ds-components run test`,
+wired into `make test` and therefore the ci.yml PR workflow):**
+
+- `app/utils/autocomplete.test.ts` — the predictive-bolding utilities: prefix and
+  out-of-order token matching, word-start preference with mid-word fallback,
+  no-match renders regular, cross-line bolding mode, and the invariant that
+  segments always reconstruct the input text exactly.
+- `app/composables/autocomplete-shell.test.ts` — the Enter-key decision matrix
+  (submit vs select vs ignore: auto-highlight vs user highlight, IME composition,
+  Enter from the clear button) plus select/clear behavior. These encode the two
+  Enter regressions found during the code review.
+
+**Deferred — Playwright end-to-end specs (docs site as fixture).** Deliberately NOT
+built yet: the docs page is due a complete manual overhaul (examples are
+inconsistent with each other and with other docs pages, and downstream integration
+of EsAutocomplete may reshape the examples toward real-world use), and these specs
+would assert against exactly those examples. Build them once the docs page is
+stable, in es-ds-docs with @playwright/test and a webServer config pointing at the
+docs site:
+
+1. Focus-model choreography: focus → panel + overlay + promptText; type → items;
+   empty response → stays open with noResultsText (promptText mid-flight); clear →
+   stays open with promptText; blur/tap-away → closes; select → closes and
+   populates v-model.
+2. Fit-to-viewport trim: at a short viewport only fully-fitting items render (no
+   clipping, no scrollbars), and the list grows back when the window grows
+   (regression for review finding 3). Layout-dependent — cannot be tested in
+   jsdom/happy-dom, must be a real browser.
+3. Mobile takeover (390px viewport): tap the fake field → dialog opens with the
+   real input already focused (the one-tap iOS keyboard prerequisite), trimmed
+   suggestions render, tap-select closes and updates the fake field, Cancel
+   closes. Optionally add an @axe-core/playwright scan of both layouts as an
+   a11y smoke test.
+
+**Deferred — component test (Vitest + @nuxt/test-utils runtime environment).** The
+parent emit contract with fake timers: `complete` debounced to one emission per
+pause, suppressed after selection, and cancelled by submit/select so a late
+response cannot reopen the panel. Deferred with the Playwright work for the same
+reason (its observable behavior will ride along in e2e spec 1) and because
+@nuxt/test-utils is the one genuinely new piece of test infrastructure it needs.
+
+### 8b. Repo quality gates (must pass)
 
 ```bash
 make install && make symlink   # once; symlinks local packages into es-ds-docs
@@ -345,7 +388,7 @@ hydration (§1a). Check with devtools mobile emulation + network throttling (slo
 hydration makes any pre-hydration flash obvious); any `v-if` on a JS breakpoint check
 for pre-interaction markup is the likely offender.
 
-### 8b. Manual verification checklist (definition of done)
+### 8c. Manual verification checklist (definition of done)
 
 On the docs page at `http://localhost:8500/molecules/autocomplete`:
 
@@ -369,7 +412,7 @@ On the docs page at `http://localhost:8500/molecules/autocomplete`:
 - [ ] Docs page renders correctly: examples, prop table, highlighted source via
       `ds-doc-source`, and the new nav link in `ds-molecules-list.vue`
 
-### 8c. Release notes (post-merge, when publishing)
+### 8d. Release notes (post-merge, when publishing)
 
 Per the repo's publishing workflow: bump `es-ds-components` version (minor — new
 component), update its `CHANGELOG.md` (keepachangelog format), publish styles first if

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -279,6 +279,9 @@ es-ds-components/app/
     es-autocomplete-desktop.vue   # popover shell (§4a) + dim overlay
     es-autocomplete-mobile.vue    # Dialog takeover shell (§4b)
     es-autocomplete-item.vue      # item renderer: predictive bolding + scope styling
+    es-autocomplete-suggestion-text.vue  # public inline renderer of predictive-bolding
+                                  # segments; takes text+query, or pre-computed segments
+                                  # (from splitAutocompleteTextLines or API match offsets)
   composables/
     fit-to-viewport.ts            # measure-then-trim (§3), visualViewport-aware
   utils/
@@ -426,14 +429,20 @@ Open questions raised during planning, with the decisions now reflected inline a
     the same pattern `ZipOrAddressInput` uses around PrimeVue today.
 11. **Predictive bolding is token-based and presentation-only** (2026-07-06): the
     `splitAutocompleteText` utility (also used by the default item renderer) splits
-    the query on whitespace and matches each token case-insensitively at word starts,
-    so query terms highlight in any order ("boston main"). It never decides what
+    the query on whitespace and matches each token case-insensitively, preferring
+    word starts ("st" matches "St", not the middle of "Boston") and falling back to
+    anywhere for tokens with no word-start match ("3" highlights within "123"), so
+    query terms highlight in any order ("boston main"). It never decides what
     matches — the app's suggestion source already did — so a backend match it cannot
     see (typo tolerance, synonyms) benignly renders regular rather than wrongly bold.
     For suggestions rendered as multiple lines, `splitAutocompleteTextLines` decides
     bolding across all lines together: a line without its own token match still
     renders fully bold when another line matched, since it is part of what selecting
-    adds (no match anywhere → everything regular). The DS deliberately ships no
+    adds (no match anywhere → everything regular). The `EsAutocompleteSuggestionText`
+    component (also used by the default item renderer) renders the segments so apps
+    don't hand-roll the span loop: pass `text` + `query` for a single string, or
+    pre-computed `segments` (from `splitAutocompleteTextLines` or from API match
+    offsets), with app classes applied directly to it. The DS deliberately ships no
     API-specific helpers (e.g. for Google Places `matched_substrings` offsets): apps
     whose search API returns match offsets build their own segments in a custom
     `item` slot renderer.

--- a/docs/plans/autocomplete-implementation-plan.md
+++ b/docs/plans/autocomplete-implementation-plan.md
@@ -402,3 +402,12 @@ Open questions raised during planning, with the decisions now reflected inline a
 9. **Empty results keep the panel open** (§5a, `noResultsText`) — supersedes the
    original closed-when-empty behavior after it proved to be a jarring overlay flicker
    when a longer query stopped matching mid-typing.
+   **Revised 2026-07-06 (e-commerce-style focus model):** on desktop the panel and
+   overlay now open on input focus and close on blur (or Escape/select/submit),
+   staying up for the entire interaction — suggestion changes only swap the panel's
+   content, never open or close it. With nothing to show, the panel displays a
+   `promptText` message (default "Type for suggestions"); once a search has actually
+   come back empty (tracked by the parent from suggestions-prop updates, so it never
+   shows mid-flight), it displays `noResultsText` — including for a first query that
+   never matches anything. The mobile takeover shows the same prompt/no-results
+   messages in its list area.

--- a/es-ds-components/app/components/es-autocomplete-clear-button.vue
+++ b/es-ds-components/app/components/es-autocomplete-clear-button.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+interface Props {
+    clearText?: string;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    clear: [];
+}>();
+</script>
+
+<template>
+    <button
+        class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
+        type="button"
+        :aria-label="clearText"
+        @click="emit('clear')">
+        <icon-x
+            height="20px"
+            width="20px" />
+    </button>
+</template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables' as variables;
+
+// ≥44px square so it is comfortably tappable; a flex sibling of the input, so
+// it can never overlap the entered text
+.es-autocomplete-clear {
+    cursor: pointer;
+    width: 2.75rem;
+
+    &:hover {
+        color: variables.$gray-900;
+    }
+
+    &:focus-visible {
+        outline: 0.125rem solid variables.$blue-600;
+        outline-offset: -0.25rem;
+    }
+}
+</style>

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -6,7 +6,6 @@ import {
     AutocompleteInput,
     AutocompletePortal,
     AutocompleteRoot,
-    AutocompleteSeparator,
 } from 'reka-ui';
 import type { ComponentPublicInstance } from 'vue';
 import type { EsAutocompleteSuggestion } from '../types';
@@ -181,25 +180,20 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 ]"
                 :side-offset="4"
                 @mousedown.prevent>
-                <template
-                    v-for="(suggestion, index) in visibleSuggestions"
-                    :key="suggestion.id">
-                    <autocomplete-separator
-                        v-if="index > 0 && suggestion.scope && !visibleSuggestions[index - 1]?.scope"
-                        class="es-autocomplete-separator" />
-                    <es-autocomplete-item
-                        :query="model ?? ''"
-                        :suggestion="suggestion"
-                        @select="onSelect">
-                        <template
-                            v-if="$slots.item"
-                            #default="slotProps">
-                            <slot
-                                name="item"
-                                v-bind="slotProps" />
-                        </template>
-                    </es-autocomplete-item>
-                </template>
+                <es-autocomplete-item
+                    v-for="suggestion in visibleSuggestions"
+                    :key="suggestion.id"
+                    :query="model ?? ''"
+                    :suggestion="suggestion"
+                    @select="onSelect">
+                    <template
+                        v-if="$slots.item"
+                        #default="slotProps">
+                        <slot
+                            name="item"
+                            v-bind="slotProps" />
+                    </template>
+                </es-autocomplete-item>
                 <div
                     v-if="panelMessage"
                     class="es-autocomplete-no-results px-100 py-50 text-gray-700">
@@ -295,12 +289,6 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
     &.es-autocomplete-panel--measuring {
         visibility: hidden;
     }
-}
-
-:deep(.es-autocomplete-separator) {
-    background-color: variables.$gray-200;
-    height: variables.$border-width;
-    margin: 0.25rem 0;
 }
 
 .es-autocomplete-overlay {

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -54,11 +54,24 @@ const model = defineModel<string>({ default: '' });
 const open = ref(false);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 
+// Reka auto-highlights the first item whenever results arrive from an empty list,
+// which is NOT a user choice — Enter must submit the typed query then, not select.
+// Only a highlight the user created (arrow keys or pointer movement over the panel)
+// makes Enter select. Reset whenever the list content changes or the panel reopens.
+const userHighlighted = ref(false);
+watch(
+    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
+    () => {
+        userHighlighted.value = false;
+    },
+);
+
 // $el is not reactive (and is a placeholder comment node while the panel is
 // closed), so resolve the panel element after open/close has taken effect in
 // the DOM instead of computing from $el directly
 const contentEl = ref<HTMLElement | null>(null);
 watch(open, async (isOpen) => {
+    userHighlighted.value = false;
     await nextTick();
     const el = contentRef.value?.$el as Node | undefined;
     contentEl.value = isOpen && el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
@@ -99,15 +112,18 @@ const panelMessage = computed(() => {
     return props.noResults && queryLongEnough.value ? props.noResultsText : props.promptText;
 });
 
-function onEnterKey() {
-    // Enter with a highlighted suggestion is handled by Reka (selection); Enter
-    // without one submits the raw query. Checked via the DOM rather than Reka's
-    // exposed highlightedElement, which can hold a stale (detached) element after
-    // a previous selection re-renders the list.
-    if (!contentEl.value?.querySelector('[data-highlighted]')) {
-        open.value = false;
-        emit('submit', model.value ?? '');
+// runs in the capture phase on the anchor, ahead of Reka's input-level handler
+function onEnterKey(event: KeyboardEvent) {
+    // highlight checked via the DOM rather than Reka's exposed highlightedElement,
+    // which can hold a stale (detached) element after the list re-renders
+    if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
+        // let the event through to Reka, which selects the highlighted item
+        return;
     }
+    // keep Reka from selecting an auto-highlighted item the user never chose
+    event.stopPropagation();
+    open.value = false;
+    emit('submit', model.value ?? '');
 }
 
 function onSelect(suggestion: EsAutocompleteSuggestion) {
@@ -145,7 +161,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 'es-autocomplete-field--disabled': disabled,
             }"
             @focusin="onFocusIn"
-            @focusout="onFocusOut">
+            @focusout="onFocusOut"
+            @keydown.capture.enter="onEnterKey">
             <autocomplete-input
                 :id="id"
                 class="es-autocomplete-input h-100 w-100 px-100"
@@ -154,7 +171,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 :disabled="disabled"
                 :placeholder="placeholder"
                 :required="required"
-                @keydown.enter="onEnterKey" />
+                @keydown.down="userHighlighted = true"
+                @keydown.up="userHighlighted = true" />
             <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
             <autocomplete-cancel
                 v-if="model && !disabled"
@@ -179,7 +197,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                     { 'es-autocomplete-panel--measuring': !measured },
                 ]"
                 :side-offset="4"
-                @mousedown.prevent>
+                @mousedown.prevent
+                @pointermove="userHighlighted = true">
                 <es-autocomplete-item
                     v-for="suggestion in visibleSuggestions"
                     :key="suggestion.id"

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -168,6 +168,9 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
             </autocomplete-cancel>
         </autocomplete-anchor>
         <autocomplete-portal>
+            <!-- mousedown.prevent keeps the input focused while clicking in the panel:
+                 without it, the click blurs the input, whose focusout closes the panel
+                 before the click can select (Reka items select on click, not mousedown) -->
             <autocomplete-content
                 ref="contentRef"
                 align="start"
@@ -176,7 +179,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                     'es-autocomplete-panel bg-white rounded-xs text-gray-900 font-size-75 text-left',
                     { 'es-autocomplete-panel--measuring': !measured },
                 ]"
-                :side-offset="4">
+                :side-offset="4"
+                @mousedown.prevent>
                 <template
                     v-for="(suggestion, index) in visibleSuggestions"
                     :key="suggestion.id">

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+import {
+    AutocompleteAnchor,
+    AutocompleteContent,
+    AutocompleteInput,
+    AutocompletePortal,
+    AutocompleteRoot,
+    AutocompleteSeparator,
+} from 'reka-ui';
+import type { ComponentPublicInstance } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+
+// Baymard: keep the list manageable — at most 10 suggestions on desktop,
+// further reduced by the fit-to-viewport trim
+const MAX_VISIBLE = 10;
+
+interface Props {
+    describedBy: string;
+    disabled?: boolean;
+    id: string;
+    label: string;
+    labelSrOnly?: boolean;
+    minChars?: number;
+    noResultsText?: string;
+    placeholder?: string;
+    required?: boolean;
+    state?: boolean | null;
+    suggestions: EsAutocompleteSuggestion[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    disabled: false,
+    labelSrOnly: false,
+    minChars: 1,
+    noResultsText: 'No results found',
+    placeholder: '',
+    required: false,
+    state: null,
+});
+
+const emit = defineEmits<{
+    select: [suggestion: EsAutocompleteSuggestion];
+    submit: [query: string];
+}>();
+
+const model = defineModel<string>({ default: '' });
+
+const open = ref(false);
+const inputHasFocus = ref(false);
+const contentRef = ref<ComponentPublicInstance | null>(null);
+
+// $el is not reactive (and is a placeholder comment node while the panel is
+// closed), so resolve the panel element after open/close has taken effect in
+// the DOM instead of computing from $el directly
+const contentEl = ref<HTMLElement | null>(null);
+watch(open, async (isOpen) => {
+    await nextTick();
+    const el = contentRef.value?.$el as Node | undefined;
+    contentEl.value = isOpen && el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
+});
+const suggestionsRef = computed(() => props.suggestions);
+const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
+
+const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
+
+// Reka opens on typing regardless of whether there is anything to show; keep the
+// panel closed until the app has provided suggestions. Once open, it may stay open
+// with an empty list (the no-results message) so the overlay doesn't flicker.
+function onOpenChange(value: boolean) {
+    open.value = value && (props.suggestions.length > 0 || (open.value && queryLongEnough.value));
+}
+
+const showNoResults = computed(() => !props.suggestions.length && queryLongEnough.value);
+
+// clearing the input below minChars must close the panel even when the suggestion
+// ids don't change (e.g. from the no-results state, where the list is already empty)
+watch(queryLongEnough, (longEnough) => {
+    if (!longEnough && !props.suggestions.length) {
+        open.value = false;
+    }
+});
+
+// watch the suggestion ids, not the array identity: the parent recomputes the array
+// on every model change (including selection), and reopening on identity alone would
+// pop the panel back open right after a suggestion is chosen
+watch(
+    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
+    () => {
+        if (!props.suggestions.length) {
+            // a search came back empty: keep the panel (and overlay) up and show
+            // the no-results message instead of flickering closed — unless the
+            // query dropped below the minimum, which is not a "no results" case
+            if (!queryLongEnough.value) {
+                open.value = false;
+            }
+        } else if (inputHasFocus.value) {
+            open.value = true;
+        }
+    },
+);
+
+function onEnterKey() {
+    // Enter with a highlighted suggestion is handled by Reka (selection); Enter
+    // without one submits the raw query. Checked via the DOM rather than Reka's
+    // exposed highlightedElement, which can hold a stale (detached) element after
+    // a previous selection re-renders the list.
+    if (!contentEl.value?.querySelector('[data-highlighted]')) {
+        open.value = false;
+        emit('submit', model.value ?? '');
+    }
+}
+
+function onSelect(suggestion: EsAutocompleteSuggestion) {
+    open.value = false;
+    emit('select', suggestion);
+}
+</script>
+
+<template>
+    <autocomplete-root
+        v-model="model"
+        class="d-none d-md-block"
+        ignore-filter
+        :disabled="disabled"
+        :open="open"
+        @update:open="onOpenChange">
+        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+        <label
+            class="label justify-content-start"
+            :class="{ 'sr-only': labelSrOnly }"
+            :for="id">
+            {{ label }}
+            <span
+                v-if="required"
+                class="text-danger">
+                *
+            </span>
+        </label>
+        <autocomplete-anchor
+            class="es-autocomplete-field es-form-input form-control align-items-center d-flex p-0"
+            :class="{
+                'is-invalid': state === false,
+                'es-autocomplete-field--raised': open,
+                'es-autocomplete-field--disabled': disabled,
+            }">
+            <autocomplete-input
+                :id="id"
+                class="es-autocomplete-input h-100 w-100 px-100"
+                :aria-describedby="describedBy"
+                :aria-invalid="state === false ? true : undefined"
+                :disabled="disabled"
+                :placeholder="placeholder"
+                :required="required"
+                @blur="inputHasFocus = false"
+                @focus="inputHasFocus = true"
+                @keydown.enter="onEnterKey" />
+        </autocomplete-anchor>
+        <autocomplete-portal>
+            <autocomplete-content
+                ref="contentRef"
+                align="start"
+                position="popper"
+                :class="[
+                    'es-autocomplete-panel bg-white rounded-xs text-gray-900 font-size-75 text-left',
+                    { 'es-autocomplete-panel--measuring': !measured },
+                ]"
+                :side-offset="4">
+                <template
+                    v-for="(suggestion, index) in visibleSuggestions"
+                    :key="suggestion.id">
+                    <autocomplete-separator
+                        v-if="index > 0 && suggestion.scope && !visibleSuggestions[index - 1]?.scope"
+                        class="es-autocomplete-separator" />
+                    <es-autocomplete-item
+                        :query="model ?? ''"
+                        :suggestion="suggestion"
+                        @select="onSelect">
+                        <template
+                            v-if="$slots.item"
+                            #default="slotProps">
+                            <slot
+                                name="item"
+                                v-bind="slotProps" />
+                        </template>
+                    </es-autocomplete-item>
+                </template>
+                <div
+                    v-if="showNoResults"
+                    class="es-autocomplete-no-results px-100 py-50 text-gray-700">
+                    {{ noResultsText }}
+                </div>
+            </autocomplete-content>
+        </autocomplete-portal>
+    </autocomplete-root>
+    <teleport to="body">
+        <transition name="es-autocomplete-overlay">
+            <div
+                v-if="open"
+                aria-hidden="true"
+                class="es-autocomplete-overlay d-none d-md-block" />
+        </transition>
+    </teleport>
+</template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables' as variables;
+
+.es-autocomplete-field:focus-within {
+    border-color: variables.$blue-600;
+    outline: 0.125rem solid variables.$blue-600;
+    outline-offset: 0.125rem;
+}
+
+// while the panel is open, lift the input above the page-dim overlay so it
+// stays fully visible and interactive
+.es-autocomplete-field--raised {
+    position: relative;
+    z-index: 1000;
+}
+
+// match the disabled styling of es-form-input: the :disabled rules in es-ds-styles
+// target the element carrying form-control, which here is this wrapper div rather
+// than the real (disabled) input inside it
+.es-autocomplete-field--disabled {
+    background-color: variables.$input-disabled-bg;
+    border: 0;
+
+    .es-autocomplete-input {
+        color: variables.$input-disabled-color;
+        // iOS fix for unreadable disabled content, as in es-ds-styles' form-control rule
+        opacity: 1;
+    }
+}
+
+.es-autocomplete-input {
+    background: transparent;
+    border: none;
+
+    &:focus-visible {
+        outline: none;
+    }
+
+    &::placeholder {
+        color: variables.$input-color-placeholder;
+    }
+}
+
+// the panel is portaled to <body> and Reka's popper wrapper strips the scope
+// attribute from the content root, so target it with :deep() through the popper
+// wrapper element, which keeps the scope attribute (same pattern as es-popover)
+:deep(.es-autocomplete-panel) {
+    border: variables.$border-width solid variables.$gray-500;
+    box-shadow: variables.$popover-box-shadow;
+    // the fit-to-viewport trim guarantees no partially-visible items behind this
+    max-height: var(--reka-combobox-content-available-height);
+    max-width: min(90vw, 30rem);
+    min-width: var(--reka-combobox-trigger-width);
+    overflow: hidden;
+    // required by useFitToViewport: item offsetTop must be relative to this panel
+    position: relative;
+    // above .es-autocomplete-overlay; Reka copies this onto its popper wrapper
+    z-index: 1000;
+
+    &.es-autocomplete-panel--measuring {
+        visibility: hidden;
+    }
+}
+
+:deep(.es-autocomplete-separator) {
+    background-color: variables.$gray-200;
+    height: variables.$border-width;
+    margin: 0.25rem 0;
+}
+
+.es-autocomplete-overlay {
+    background-color: variables.$black;
+    inset: 0;
+    opacity: 0.25;
+    position: fixed;
+    // matches .es-menu-bar-overlay in es-menu-bar; the two are never open at once
+    z-index: 999;
+
+    @media not (prefers-reduced-motion) {
+        &-enter-active,
+        &-leave-active {
+            transition: opacity 0.15s ease-in-out;
+        }
+
+        &-enter-from,
+        &-leave-to {
+            opacity: 0;
+        }
+    }
+}
+</style>

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -23,8 +23,10 @@ interface Props {
     label: string;
     labelSrOnly?: boolean;
     minChars?: number;
+    noResults?: boolean;
     noResultsText?: string;
     placeholder?: string;
+    promptText?: string;
     required?: boolean;
     state?: boolean | null;
     suggestions: EsAutocompleteSuggestion[];
@@ -35,8 +37,10 @@ const props = withDefaults(defineProps<Props>(), {
     disabled: false,
     labelSrOnly: false,
     minChars: 1,
+    noResults: false,
     noResultsText: 'No results found',
     placeholder: '',
+    promptText: 'Type for suggestions',
     required: false,
     state: null,
 });
@@ -49,7 +53,6 @@ const emit = defineEmits<{
 const model = defineModel<string>({ default: '' });
 
 const open = ref(false);
-const inputHasFocus = ref(false);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 
 // $el is not reactive (and is a placeholder comment node while the panel is
@@ -66,41 +69,36 @@ const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestions
 
 const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
 
-// Reka opens on typing regardless of whether there is anything to show; keep the
-// panel closed until the app has provided suggestions. Once open, it may stay open
-// with an empty list (the no-results message) so the overlay doesn't flicker.
+// The panel and overlay stay up for the entire interaction: they open when the
+// field gains focus and close when focus leaves it (or on Escape/select/submit).
+// Suggestion changes never open or close the panel — they only swap its content.
 function onOpenChange(value: boolean) {
-    open.value = value && (props.suggestions.length > 0 || (open.value && queryLongEnough.value));
+    open.value = value;
 }
 
-const showNoResults = computed(() => !props.suggestions.length && queryLongEnough.value);
+function onFocusIn() {
+    if (!props.disabled) {
+        open.value = true;
+    }
+}
 
-// clearing the input below minChars must close the panel even when the suggestion
-// ids don't change (e.g. from the no-results state, where the list is already empty)
-watch(queryLongEnough, (longEnough) => {
-    if (!longEnough && !props.suggestions.length) {
+function onFocusOut(event: FocusEvent) {
+    // ignore focus moves within the field (input <-> clear button)
+    const field = event.currentTarget as HTMLElement;
+    if (!event.relatedTarget || !field.contains(event.relatedTarget as Node)) {
         open.value = false;
     }
-});
+}
 
-// watch the suggestion ids, not the array identity: the parent recomputes the array
-// on every model change (including selection), and reopening on identity alone would
-// pop the panel back open right after a suggestion is chosen
-watch(
-    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
-    () => {
-        if (!props.suggestions.length) {
-            // a search came back empty: keep the panel (and overlay) up and show
-            // the no-results message instead of flickering closed — unless the
-            // query dropped below the minimum, which is not a "no results" case
-            if (!queryLongEnough.value) {
-                open.value = false;
-            }
-        } else if (inputHasFocus.value) {
-            open.value = true;
-        }
-    },
-);
+// what the open panel shows when there are no suggestions to render: the
+// no-results message once a search has actually come back empty, otherwise
+// the prompt (nothing searched yet, or the query is below minChars)
+const panelMessage = computed(() => {
+    if (props.suggestions.length) {
+        return '';
+    }
+    return props.noResults && queryLongEnough.value ? props.noResultsText : props.promptText;
+});
 
 function onEnterKey() {
     // Enter with a highlighted suggestion is handled by Reka (selection); Enter
@@ -124,6 +122,7 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
         v-model="model"
         class="d-none d-md-block"
         ignore-filter
+        open-on-click
         :disabled="disabled"
         :open="open"
         @update:open="onOpenChange">
@@ -145,7 +144,9 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 'is-invalid': state === false,
                 'es-autocomplete-field--raised': open,
                 'es-autocomplete-field--disabled': disabled,
-            }">
+            }"
+            @focusin="onFocusIn"
+            @focusout="onFocusOut">
             <autocomplete-input
                 :id="id"
                 class="es-autocomplete-input h-100 w-100 px-100"
@@ -154,8 +155,6 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 :disabled="disabled"
                 :placeholder="placeholder"
                 :required="required"
-                @blur="inputHasFocus = false"
-                @focus="inputHasFocus = true"
                 @keydown.enter="onEnterKey" />
             <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
             <autocomplete-cancel
@@ -198,9 +197,9 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                     </es-autocomplete-item>
                 </template>
                 <div
-                    v-if="showNoResults"
+                    v-if="panelMessage"
                     class="es-autocomplete-no-results px-100 py-50 text-gray-700">
-                    {{ noResultsText }}
+                    {{ panelMessage }}
                 </div>
             </autocomplete-content>
         </autocomplete-portal>

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import {
     AutocompleteAnchor,
-    AutocompleteCancel,
     AutocompleteContent,
     AutocompleteInput,
     AutocompletePortal,
@@ -53,6 +52,7 @@ const model = defineModel<string>({ default: '' });
 
 const open = ref(false);
 const contentRef = ref<ComponentPublicInstance | null>(null);
+const inputRef = ref<ComponentPublicInstance | null>(null);
 
 // Reka auto-highlights the first item whenever results arrive from an empty list,
 // which is NOT a user choice — Enter must submit the typed query then, not select.
@@ -66,15 +66,9 @@ watch(
     },
 );
 
-// $el is not reactive (and is a placeholder comment node while the panel is
-// closed), so resolve the panel element after open/close has taken effect in
-// the DOM instead of computing from $el directly
-const contentEl = ref<HTMLElement | null>(null);
-watch(open, async (isOpen) => {
+const contentEl = useAutocompleteContentEl(contentRef, open);
+watch(open, () => {
     userHighlighted.value = false;
-    await nextTick();
-    const el = contentRef.value?.$el as Node | undefined;
-    contentEl.value = isOpen && el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
 });
 const suggestionsRef = computed(() => props.suggestions);
 const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
@@ -135,6 +129,11 @@ const panelMessage = computed(() => {
 
 // runs in the capture phase on the anchor, ahead of Reka's input-level handler
 function onEnterKey(event: KeyboardEvent) {
+    // only Enter from the input itself submits — Enter on the clear button (also
+    // inside the anchor) is a click and must reach the button
+    if (event.target !== inputRef.value?.$el) {
+        return;
+    }
     // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
     // is not a submit
     if (event.isComposing) {
@@ -157,6 +156,11 @@ function onEnterKey(event: KeyboardEvent) {
 function onSelect(suggestion: EsAutocompleteSuggestion) {
     open.value = false;
     emit('select', suggestion);
+}
+
+function onClear() {
+    model.value = '';
+    (inputRef.value?.$el as HTMLElement | undefined)?.focus();
 }
 </script>
 
@@ -193,6 +197,7 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
             @keydown.capture.enter="onEnterKey">
             <autocomplete-input
                 :id="id"
+                ref="inputRef"
                 class="es-autocomplete-input h-100 w-100 px-100"
                 :aria-describedby="describedBy"
                 :aria-invalid="state === false ? true : undefined"
@@ -201,16 +206,16 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 :required="required"
                 @keydown.down="userHighlighted = true"
                 @keydown.up="userHighlighted = true" />
-            <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
-            <autocomplete-cancel
+            <button
                 v-if="model && !disabled"
                 class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
-                tabindex="0"
-                :aria-label="clearText">
+                type="button"
+                :aria-label="clearText"
+                @click="onClear">
                 <icon-x
                     height="20px"
                     width="20px" />
-            </autocomplete-cancel>
+            </button>
         </autocomplete-anchor>
         <autocomplete-portal>
             <autocomplete-content

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -221,11 +221,10 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
 <style lang="scss" scoped>
 @use '@energysage/es-ds-styles/scss/variables' as variables;
 
-.es-autocomplete-field:focus-within {
-    border-color: variables.$blue-600;
-    outline: 0.125rem solid variables.$blue-600;
-    outline-offset: 0.125rem;
-}
+// deliberately no focus styling on the field: the page-dim overlay appearing on
+// focus is the focus indicator. (es-form-input's lighter :focus border reads as
+// the border disappearing against the dimmed page, and a :focus-visible ring is
+// not an option — browsers match :focus-visible on ANY focus of a text field.)
 
 // while the panel is open, lift the input above the page-dim overlay so it
 // stays fully visible and interactive

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -13,6 +13,8 @@ import type { EsAutocompleteSuggestion } from '../types';
 // further reduced by the fit-to-viewport trim
 const MAX_VISIBLE = 10;
 
+// defaults live on the public es-autocomplete.vue wrapper, which always binds
+// every prop; declaring them again here would be dead code that could drift
 interface Props {
     clearText?: string;
     describedBy: string;
@@ -20,28 +22,14 @@ interface Props {
     id: string;
     label: string;
     labelSrOnly?: boolean;
-    minChars?: number;
-    noResults?: boolean;
-    noResultsText?: string;
+    panelMessage: string;
     placeholder?: string;
-    promptText?: string;
     required?: boolean;
     state?: boolean | null;
     suggestions: EsAutocompleteSuggestion[];
 }
 
-const props = withDefaults(defineProps<Props>(), {
-    clearText: 'Clear',
-    disabled: false,
-    labelSrOnly: false,
-    minChars: 1,
-    noResults: false,
-    noResultsText: 'No results found',
-    placeholder: '',
-    promptText: 'Type for suggestions',
-    required: false,
-    state: null,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     select: [suggestion: EsAutocompleteSuggestion];
@@ -53,27 +41,21 @@ const model = defineModel<string>({ default: '' });
 const open = ref(false);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 const inputRef = ref<ComponentPublicInstance | null>(null);
-
-// Reka auto-highlights the first item whenever results arrive from an empty list,
-// which is NOT a user choice — Enter must submit the typed query then, not select.
-// Only a highlight the user created (arrow keys or pointer movement over the panel)
-// makes Enter select. Reset whenever the list content changes or the panel reopens.
-const userHighlighted = ref(false);
-watch(
-    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
-    () => {
-        userHighlighted.value = false;
-    },
-);
-
 const contentEl = useAutocompleteContentEl(contentRef, open);
-watch(open, () => {
-    userHighlighted.value = false;
-});
-const suggestionsRef = computed(() => props.suggestions);
-const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
+const { measured, visibleSuggestions } = useFitToViewport(contentEl, toRef(props, 'suggestions'), MAX_VISIBLE);
 
-const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
+const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight } = useAutocompleteShell({
+    close: () => {
+        open.value = false;
+    },
+    contentEl,
+    emitSelect: (suggestion) => emit('select', suggestion),
+    emitSubmit: (query) => emit('submit', query),
+    inputRef,
+    model,
+    suggestions: () => props.suggestions,
+});
+watch(open, resetUserHighlight);
 
 // The panel and overlay stay up for the entire interaction: they open when the
 // field gains focus and close when focus leaves it (or on Escape/select/submit).
@@ -116,52 +98,6 @@ function onPanelMousedown(event: MouseEvent) {
         event.preventDefault();
     }
 }
-
-// what the open panel shows when there are no suggestions to render: the
-// no-results message once a search has actually come back empty, otherwise
-// the prompt (nothing searched yet, or the query is below minChars)
-const panelMessage = computed(() => {
-    if (props.suggestions.length) {
-        return '';
-    }
-    return props.noResults && queryLongEnough.value ? props.noResultsText : props.promptText;
-});
-
-// runs in the capture phase on the anchor, ahead of Reka's input-level handler
-function onEnterKey(event: KeyboardEvent) {
-    // only Enter from the input itself submits — Enter on the clear button (also
-    // inside the anchor) is a click and must reach the button
-    if (event.target !== inputRef.value?.$el) {
-        return;
-    }
-    // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
-    // is not a submit
-    if (event.isComposing) {
-        return;
-    }
-    // highlight checked via the DOM rather than Reka's exposed highlightedElement,
-    // which can hold a stale (detached) element after the list re-renders
-    if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
-        // let the event through to Reka, which selects the highlighted item
-        return;
-    }
-    // keep Reka from selecting an auto-highlighted item the user never chose, and
-    // keep a surrounding <form> from natively submitting
-    event.preventDefault();
-    event.stopPropagation();
-    open.value = false;
-    emit('submit', model.value ?? '');
-}
-
-function onSelect(suggestion: EsAutocompleteSuggestion) {
-    open.value = false;
-    emit('select', suggestion);
-}
-
-function onClear() {
-    model.value = '';
-    (inputRef.value?.$el as HTMLElement | undefined)?.focus();
-}
 </script>
 
 <template>
@@ -173,18 +109,11 @@ function onClear() {
         :disabled="disabled"
         :open="open"
         @update:open="onOpenChange">
-        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-        <label
-            class="label justify-content-start"
-            :class="{ 'sr-only': labelSrOnly }"
-            :for="id">
-            {{ label }}
-            <span
-                v-if="required"
-                class="text-danger">
-                *
-            </span>
-        </label>
+        <es-autocomplete-label
+            :html-for="id"
+            :label="label"
+            :label-sr-only="labelSrOnly"
+            :required="required" />
         <autocomplete-anchor
             class="es-autocomplete-field es-form-input form-control align-items-center d-flex p-0"
             :class="{
@@ -204,18 +133,12 @@ function onClear() {
                 :disabled="disabled"
                 :placeholder="placeholder"
                 :required="required"
-                @keydown.down="userHighlighted = true"
-                @keydown.up="userHighlighted = true" />
-            <button
+                @keydown.down="markUserHighlight"
+                @keydown.up="markUserHighlight" />
+            <es-autocomplete-clear-button
                 v-if="model && !disabled"
-                class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
-                type="button"
-                :aria-label="clearText"
-                @click="onClear">
-                <icon-x
-                    height="20px"
-                    width="20px" />
-            </button>
+                :clear-text="clearText"
+                @clear="onClear" />
         </autocomplete-anchor>
         <autocomplete-portal>
             <autocomplete-content
@@ -228,7 +151,7 @@ function onClear() {
                 ]"
                 :side-offset="4"
                 @mousedown="onPanelMousedown"
-                @pointermove="userHighlighted = true">
+                @pointermove="markUserHighlight">
                 <es-autocomplete-item
                     v-for="suggestion in visibleSuggestions"
                     :key="suggestion.id"
@@ -300,22 +223,6 @@ function onClear() {
 
     &::placeholder {
         color: variables.$input-color-placeholder;
-    }
-}
-
-// ≥44px square so it is comfortably tappable; a flex sibling of the input, so
-// it can never overlap the entered text
-.es-autocomplete-clear {
-    cursor: pointer;
-    width: 2.75rem;
-
-    &:hover {
-        color: variables.$gray-900;
-    }
-
-    &:focus-visible {
-        outline: 0.125rem solid variables.$blue-600;
-        outline-offset: -0.25rem;
     }
 }
 

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -114,13 +114,20 @@ const panelMessage = computed(() => {
 
 // runs in the capture phase on the anchor, ahead of Reka's input-level handler
 function onEnterKey(event: KeyboardEvent) {
+    // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
+    // is not a submit
+    if (event.isComposing) {
+        return;
+    }
     // highlight checked via the DOM rather than Reka's exposed highlightedElement,
     // which can hold a stale (detached) element after the list re-renders
     if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
         // let the event through to Reka, which selects the highlighted item
         return;
     }
-    // keep Reka from selecting an auto-highlighted item the user never chose
+    // keep Reka from selecting an auto-highlighted item the user never chose, and
+    // keep a surrounding <form> from natively submitting
+    event.preventDefault();
     event.stopPropagation();
     open.value = false;
     emit('submit', model.value ?? '');

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -44,17 +44,19 @@ const inputRef = ref<ComponentPublicInstance | null>(null);
 const contentEl = useAutocompleteContentEl(contentRef, open);
 const { measured, visibleSuggestions } = useFitToViewport(contentEl, toRef(props, 'suggestions'), MAX_VISIBLE);
 
-const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight } = useAutocompleteShell({
-    close: () => {
-        open.value = false;
+const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight, userHighlighted } = useAutocompleteShell(
+    {
+        close: () => {
+            open.value = false;
+        },
+        contentEl,
+        emitSelect: (suggestion) => emit('select', suggestion),
+        emitSubmit: (query) => emit('submit', query),
+        inputRef,
+        model,
+        suggestions: () => props.suggestions,
     },
-    contentEl,
-    emitSelect: (suggestion) => emit('select', suggestion),
-    emitSubmit: (query) => emit('submit', query),
-    inputRef,
-    model,
-    suggestions: () => props.suggestions,
-});
+);
 watch(open, resetUserHighlight);
 
 // The panel and overlay stay up for the entire interaction: they open when the
@@ -109,6 +111,7 @@ function onPanelMousedown(event: MouseEvent) {
         :disabled="disabled"
         :open="open"
         @update:open="onOpenChange">
+        <es-autocomplete-highlight-guard :user-highlighted="userHighlighted" />
         <es-autocomplete-label
             :html-for="id"
             :label="label"

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -155,7 +155,7 @@ function onPanelMousedown(event: MouseEvent) {
                 <es-autocomplete-item
                     v-for="suggestion in visibleSuggestions"
                     :key="suggestion.id"
-                    :query="model ?? ''"
+                    :query="model"
                     :suggestion="suggestion"
                     @select="onSelect">
                     <template

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -95,10 +95,31 @@ function onFocusIn() {
 }
 
 function onFocusOut(event: FocusEvent) {
-    // ignore focus moves within the field (input <-> clear button)
     const field = event.currentTarget as HTMLElement;
-    if (!event.relatedTarget || !field.contains(event.relatedTarget as Node)) {
-        open.value = false;
+    const related = event.relatedTarget as Node | null;
+    // ignore focus moves within the field (input <-> clear button) or into the
+    // panel (interactive elements a consumer renders in the item slot)
+    if (related && (field.contains(related) || contentEl.value?.contains(related))) {
+        return;
+    }
+    // ignore the window itself losing focus (alt-tab, devtools) — the input is
+    // still the active element and the interaction resumes when the user returns
+    if (!related && !document.hasFocus()) {
+        return;
+    }
+    open.value = false;
+}
+
+// keep the input focused while clicking in the panel: without this, the click
+// blurs the input, whose focusout closes the panel before the click can select.
+// Interactive elements a consumer renders in the item slot are exempt so they
+// remain focusable (suggestion items themselves have tabindex="-1").
+function onPanelMousedown(event: MouseEvent) {
+    const target = event.target as HTMLElement | null;
+    const interactive =
+        'a[href], button, input, select, textarea, [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
+    if (!target?.closest(interactive)) {
+        event.preventDefault();
     }
 }
 
@@ -192,9 +213,6 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
             </autocomplete-cancel>
         </autocomplete-anchor>
         <autocomplete-portal>
-            <!-- mousedown.prevent keeps the input focused while clicking in the panel:
-                 without it, the click blurs the input, whose focusout closes the panel
-                 before the click can select (Reka items select on click, not mousedown) -->
             <autocomplete-content
                 ref="contentRef"
                 align="start"
@@ -204,7 +222,7 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                     { 'es-autocomplete-panel--measuring': !measured },
                 ]"
                 :side-offset="4"
-                @mousedown.prevent
+                @mousedown="onPanelMousedown"
                 @pointermove="userHighlighted = true">
                 <es-autocomplete-item
                     v-for="suggestion in visibleSuggestions"

--- a/es-ds-components/app/components/es-autocomplete-desktop.vue
+++ b/es-ds-components/app/components/es-autocomplete-desktop.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
     AutocompleteAnchor,
+    AutocompleteCancel,
     AutocompleteContent,
     AutocompleteInput,
     AutocompletePortal,
@@ -15,6 +16,7 @@ import type { EsAutocompleteSuggestion } from '../types';
 const MAX_VISIBLE = 10;
 
 interface Props {
+    clearText?: string;
     describedBy: string;
     disabled?: boolean;
     id: string;
@@ -29,6 +31,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+    clearText: 'Clear',
     disabled: false,
     labelSrOnly: false,
     minChars: 1,
@@ -154,6 +157,16 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                 @blur="inputHasFocus = false"
                 @focus="inputHasFocus = true"
                 @keydown.enter="onEnterKey" />
+            <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
+            <autocomplete-cancel
+                v-if="model && !disabled"
+                class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
+                tabindex="0"
+                :aria-label="clearText">
+                <icon-x
+                    height="20px"
+                    width="20px" />
+            </autocomplete-cancel>
         </autocomplete-anchor>
         <autocomplete-portal>
             <autocomplete-content
@@ -242,6 +255,22 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
 
     &::placeholder {
         color: variables.$input-color-placeholder;
+    }
+}
+
+// ≥44px square so it is comfortably tappable; a flex sibling of the input, so
+// it can never overlap the entered text
+.es-autocomplete-clear {
+    cursor: pointer;
+    width: 2.75rem;
+
+    &:hover {
+        color: variables.$gray-900;
+    }
+
+    &:focus-visible {
+        outline: 0.125rem solid variables.$blue-600;
+        outline-offset: -0.25rem;
     }
 }
 

--- a/es-ds-components/app/components/es-autocomplete-highlight-guard.vue
+++ b/es-ds-components/app/components/es-autocomplete-highlight-guard.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { injectListboxRootContext } from 'reka-ui';
+
+interface Props {
+    /** whether the current highlight came from the user (hover or arrow keys) */
+    userHighlighted: boolean;
+}
+
+const props = defineProps<Props>();
+
+// Reka auto-highlights the first item when results arrive from an empty list (and
+// re-highlights the selected item on open), but Enter only selects a highlight the
+// USER created (see useAutocompleteShell) — an auto-highlight would therefore
+// render as active while behaving as inactive. Clear it at the source, the Listbox
+// context's highlightedElement ref, so the visual highlight, aria-activedescendant,
+// the arrow keys' starting position, and Enter always agree: a suggestion is only
+// highlighted when hovering or arrowing to it, and Enter then selects it.
+//
+// This component must render inside AutocompleteRoot so the inject resolves.
+const listbox = injectListboxRootContext();
+watch(
+    () => listbox.highlightedElement.value,
+    (element) => {
+        if (element && !props.userHighlighted) {
+            listbox.highlightedElement.value = null;
+        }
+    },
+);
+</script>
+
+<template>
+    <!-- renderless (nothing is ever passed to this slot): the component exists
+         only to run the highlight guard inside AutocompleteRoot's inject tree -->
+    <slot />
+</template>

--- a/es-ds-components/app/components/es-autocomplete-item.vue
+++ b/es-ds-components/app/components/es-autocomplete-item.vue
@@ -29,11 +29,6 @@ const emit = defineEmits<{
             <es-autocomplete-suggestion-text
                 :query="query"
                 :text="suggestion.text" />
-            <span
-                v-if="suggestion.scope"
-                class="es-autocomplete-item-scope text-gray-700">
-                {{ suggestion.scope.label }}
-            </span>
         </slot>
     </autocomplete-item>
 </template>
@@ -54,10 +49,5 @@ const emit = defineEmits<{
     &:active {
         background-color: variables.$blue-100;
     }
-}
-
-.es-autocomplete-item-scope {
-    font-style: italic;
-    margin-left: 0.25rem;
 }
 </style>

--- a/es-ds-components/app/components/es-autocomplete-item.vue
+++ b/es-ds-components/app/components/es-autocomplete-item.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { AutocompleteItem } from 'reka-ui';
+import type { EsAutocompleteSuggestion } from '../types';
+
+interface Props {
+    query: string;
+    suggestion: EsAutocompleteSuggestion;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    select: [suggestion: EsAutocompleteSuggestion];
+}>();
+
+// the typed prefix renders regular weight and the predictive remainder renders bold,
+// so users scan what would be ADDED to their query (the inverse of most libraries)
+const typedLength = computed(() => {
+    const query = props.query.trim();
+    if (query && props.suggestion.text.toLowerCase().startsWith(query.toLowerCase())) {
+        return query.length;
+    }
+    return props.suggestion.text.length;
+});
+</script>
+
+<template>
+    <autocomplete-item
+        class="es-autocomplete-item d-block px-100 py-50"
+        data-es-autocomplete-item
+        :value="suggestion.text"
+        @select="emit('select', suggestion)">
+        <slot
+            :query="query"
+            :suggestion="suggestion">
+            <span>
+                <span>{{ suggestion.text.slice(0, typedLength) }}</span>
+                <span class="font-weight-bold">{{ suggestion.text.slice(typedLength) }}</span>
+            </span>
+            <span
+                v-if="suggestion.scope"
+                class="es-autocomplete-item-scope text-gray-700">
+                {{ suggestion.scope.label }}
+            </span>
+        </slot>
+    </autocomplete-item>
+</template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables' as variables;
+
+.es-autocomplete-item {
+    cursor: pointer;
+    transition: background-color 0.15s ease-in-out;
+
+    // highlightOnHover is enabled on the root, so hover and keyboard
+    // navigation both surface as data-highlighted
+    &[data-highlighted] {
+        background-color: variables.$blue-50;
+    }
+
+    &:active {
+        background-color: variables.$blue-100;
+    }
+}
+
+.es-autocomplete-item-scope {
+    font-style: italic;
+    margin-left: 0.25rem;
+}
+</style>

--- a/es-ds-components/app/components/es-autocomplete-item.vue
+++ b/es-ds-components/app/components/es-autocomplete-item.vue
@@ -7,16 +7,11 @@ interface Props {
     suggestion: EsAutocompleteSuggestion;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 
 const emit = defineEmits<{
     select: [suggestion: EsAutocompleteSuggestion];
 }>();
-
-// the query-matching portion renders regular weight and the predictive portions
-// render bold, so users scan what would be ADDED to their query (the inverse of
-// most libraries); custom item renderers can reuse splitAutocompleteText directly
-const segments = computed(() => splitAutocompleteText(props.suggestion.text, props.query));
 </script>
 
 <template>
@@ -28,14 +23,12 @@ const segments = computed(() => splitAutocompleteText(props.suggestion.text, pro
         <slot
             :query="query"
             :suggestion="suggestion">
-            <span>
-                <span
-                    v-for="(segment, index) in segments"
-                    :key="index"
-                    :class="{ 'font-weight-bold': segment.predictive }"
-                    >{{ segment.text }}</span
-                >
-            </span>
+            <!-- the query-matching portions render regular weight and the predictive
+                 portions render bold, so users scan what would be ADDED to their
+                 query (the inverse of most libraries) -->
+            <es-autocomplete-suggestion-text
+                :query="query"
+                :text="suggestion.text" />
             <span
                 v-if="suggestion.scope"
                 class="es-autocomplete-item-scope text-gray-700">

--- a/es-ds-components/app/components/es-autocomplete-item.vue
+++ b/es-ds-components/app/components/es-autocomplete-item.vue
@@ -13,15 +13,10 @@ const emit = defineEmits<{
     select: [suggestion: EsAutocompleteSuggestion];
 }>();
 
-// the typed prefix renders regular weight and the predictive remainder renders bold,
-// so users scan what would be ADDED to their query (the inverse of most libraries)
-const typedLength = computed(() => {
-    const query = props.query.trim();
-    if (query && props.suggestion.text.toLowerCase().startsWith(query.toLowerCase())) {
-        return query.length;
-    }
-    return props.suggestion.text.length;
-});
+// the query-matching portion renders regular weight and the predictive portions
+// render bold, so users scan what would be ADDED to their query (the inverse of
+// most libraries); custom item renderers can reuse splitAutocompleteText directly
+const segments = computed(() => splitAutocompleteText(props.suggestion.text, props.query));
 </script>
 
 <template>
@@ -34,8 +29,12 @@ const typedLength = computed(() => {
             :query="query"
             :suggestion="suggestion">
             <span>
-                <span>{{ suggestion.text.slice(0, typedLength) }}</span>
-                <span class="font-weight-bold">{{ suggestion.text.slice(typedLength) }}</span>
+                <span
+                    v-for="(segment, index) in segments"
+                    :key="index"
+                    :class="{ 'font-weight-bold': segment.predictive }"
+                    >{{ segment.text }}</span
+                >
             </span>
             <span
                 v-if="suggestion.scope"

--- a/es-ds-components/app/components/es-autocomplete-label.vue
+++ b/es-ds-components/app/components/es-autocomplete-label.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+interface Props {
+    htmlFor: string;
+    label: string;
+    labelSrOnly?: boolean;
+    required?: boolean;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+    <label
+        class="label justify-content-start"
+        :class="{ 'sr-only': labelSrOnly }"
+        :for="htmlFor">
+        {{ label }}
+        <span
+            v-if="required"
+            class="text-danger">
+            *
+        </span>
+    </label>
+</template>

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import {
     AutocompleteAnchor,
-    AutocompleteCancel,
     AutocompleteContent,
     AutocompleteInput,
     AutocompleteRoot,
@@ -64,11 +63,7 @@ const triggerId = computed(() => `${props.id}-trigger`);
 const inputRef = ref<ComponentPublicInstance | null>(null);
 const contentRef = ref<ComponentPublicInstance | null>(null);
 
-// when the panel is closed, $el is a placeholder comment node, not an element
-const contentEl = computed<HTMLElement | null>(() => {
-    const el = contentRef.value?.$el as Node | undefined;
-    return el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
-});
+const contentEl = useAutocompleteContentEl(contentRef, takeoverOpen);
 const suggestionsRef = computed(() => props.suggestions);
 const { measured, remeasure, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
 
@@ -135,6 +130,11 @@ function onOpenAutoFocus(event: Event) {
 
 // runs in the capture phase on the anchor, ahead of Reka's input-level handler
 function onEnterKey(event: KeyboardEvent) {
+    // only Enter from the input itself submits — Enter on the clear button (also
+    // inside the anchor) is a click and must reach the button
+    if (event.target !== inputRef.value?.$el) {
+        return;
+    }
     // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
     // is not a submit
     if (event.isComposing) {
@@ -157,6 +157,11 @@ function onEnterKey(event: KeyboardEvent) {
 function onSelect(suggestion: EsAutocompleteSuggestion) {
     takeoverOpen.value = false;
     emit('select', suggestion);
+}
+
+function onClear() {
+    model.value = '';
+    (inputRef.value?.$el as HTMLElement | undefined)?.focus();
 }
 </script>
 
@@ -219,16 +224,16 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                                     :placeholder="placeholder"
                                     @keydown.down="userHighlighted = true"
                                     @keydown.up="userHighlighted = true" />
-                                <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
-                                <autocomplete-cancel
+                                <button
                                     v-if="model"
                                     class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
-                                    tabindex="0"
-                                    :aria-label="clearText">
+                                    type="button"
+                                    :aria-label="clearText"
+                                    @click="onClear">
                                     <icon-x
                                         height="20px"
                                         width="20px" />
-                                </autocomplete-cancel>
+                                </button>
                             </autocomplete-anchor>
                             <dialog-close class="es-autocomplete-cancel bg-transparent border-0 flex-shrink-0 ml-100">
                                 {{ cancelText }}

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -74,6 +74,18 @@ const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestions
 
 const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
 
+// Reka auto-highlights the first item whenever results arrive from an empty list,
+// which is NOT a user choice — Enter must submit the typed query then, not select.
+// Only a highlight the user created (arrow keys or pointer movement over the list)
+// makes Enter select. Reset whenever the list content changes or the takeover opens.
+const userHighlighted = ref(false);
+watch(
+    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
+    () => {
+        userHighlighted.value = false;
+    },
+);
+
 // what the list shows when there are no suggestions to render: the no-results
 // message once a search has actually come back empty (per the parent), otherwise
 // the prompt (nothing searched yet, or the query is below minChars)
@@ -98,6 +110,7 @@ function updateListHeight() {
 }
 
 watch(takeoverOpen, async (isOpen) => {
+    userHighlighted.value = false;
     const viewport = window.visualViewport;
     if (isOpen) {
         await nextTick();
@@ -119,15 +132,18 @@ function onOpenAutoFocus(event: Event) {
     (inputRef.value?.$el as HTMLElement | undefined)?.focus();
 }
 
-function onEnterKey() {
-    // Enter with a highlighted suggestion is handled by Reka (selection); Enter
-    // without one submits the raw query. Checked via the DOM rather than Reka's
-    // exposed highlightedElement, which can hold a stale (detached) element after
-    // a previous selection re-renders the list.
-    if (!contentEl.value?.querySelector('[data-highlighted]')) {
-        takeoverOpen.value = false;
-        emit('submit', model.value ?? '');
+// runs in the capture phase on the anchor, ahead of Reka's input-level handler
+function onEnterKey(event: KeyboardEvent) {
+    // highlight checked via the DOM rather than Reka's exposed highlightedElement,
+    // which can hold a stale (detached) element after the list re-renders
+    if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
+        // let the event through to Reka, which selects the highlighted item
+        return;
     }
+    // keep Reka from selecting an auto-highlighted item the user never chose
+    event.stopPropagation();
+    takeoverOpen.value = false;
+    emit('submit', model.value ?? '');
 }
 
 function onSelect(suggestion: EsAutocompleteSuggestion) {
@@ -186,13 +202,15 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                         open>
                         <div class="align-items-center d-flex p-100">
                             <autocomplete-anchor
-                                class="es-autocomplete-field es-form-input form-control align-items-center d-flex flex-grow-1 p-0">
+                                class="es-autocomplete-field es-form-input form-control align-items-center d-flex flex-grow-1 p-0"
+                                @keydown.capture.enter="onEnterKey">
                                 <autocomplete-input
                                     ref="inputRef"
                                     class="es-autocomplete-input h-100 w-100 px-100"
                                     :aria-label="label"
                                     :placeholder="placeholder"
-                                    @keydown.enter="onEnterKey" />
+                                    @keydown.down="userHighlighted = true"
+                                    @keydown.up="userHighlighted = true" />
                                 <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
                                 <autocomplete-cancel
                                     v-if="model"
@@ -213,7 +231,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                             :class="[
                                 'es-autocomplete-takeover-list text-left',
                                 { 'es-autocomplete-takeover-list--measuring': !measured },
-                            ]">
+                            ]"
+                            @pointermove="userHighlighted = true">
                             <es-autocomplete-item
                                 v-for="suggestion in visibleSuggestions"
                                 :key="suggestion.id"

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -134,13 +134,20 @@ function onOpenAutoFocus(event: Event) {
 
 // runs in the capture phase on the anchor, ahead of Reka's input-level handler
 function onEnterKey(event: KeyboardEvent) {
+    // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
+    // is not a submit
+    if (event.isComposing) {
+        return;
+    }
     // highlight checked via the DOM rather than Reka's exposed highlightedElement,
     // which can hold a stale (detached) element after the list re-renders
     if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
         // let the event through to Reka, which selects the highlighted item
         return;
     }
-    // keep Reka from selecting an auto-highlighted item the user never chose
+    // keep Reka from selecting an auto-highlighted item the user never chose, and
+    // keep a surrounding <form> from natively submitting
+    event.preventDefault();
     event.stopPropagation();
     takeoverOpen.value = false;
     emit('submit', model.value ?? '');

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -5,7 +5,6 @@ import {
     AutocompleteContent,
     AutocompleteInput,
     AutocompleteRoot,
-    AutocompleteSeparator,
     DialogClose,
     DialogContent,
     DialogDescription,
@@ -215,25 +214,20 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                                 'es-autocomplete-takeover-list text-left',
                                 { 'es-autocomplete-takeover-list--measuring': !measured },
                             ]">
-                            <template
-                                v-for="(suggestion, index) in visibleSuggestions"
-                                :key="suggestion.id">
-                                <autocomplete-separator
-                                    v-if="index > 0 && suggestion.scope && !visibleSuggestions[index - 1]?.scope"
-                                    class="es-autocomplete-separator" />
-                                <es-autocomplete-item
-                                    :query="model ?? ''"
-                                    :suggestion="suggestion"
-                                    @select="onSelect">
-                                    <template
-                                        v-if="$slots.item"
-                                        #default="slotProps">
-                                        <slot
-                                            name="item"
-                                            v-bind="slotProps" />
-                                    </template>
-                                </es-autocomplete-item>
-                            </template>
+                            <es-autocomplete-item
+                                v-for="suggestion in visibleSuggestions"
+                                :key="suggestion.id"
+                                :query="model ?? ''"
+                                :suggestion="suggestion"
+                                @select="onSelect">
+                                <template
+                                    v-if="$slots.item"
+                                    #default="slotProps">
+                                    <slot
+                                        name="item"
+                                        v-bind="slotProps" />
+                                </template>
+                            </es-autocomplete-item>
                             <div
                                 v-if="panelMessage"
                                 class="es-autocomplete-no-results px-100 py-50 text-gray-700">
@@ -317,11 +311,5 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
     .es-autocomplete-no-results {
         font-size: 1rem;
     }
-}
-
-.es-autocomplete-separator {
-    background-color: variables.$gray-200;
-    height: variables.$border-width;
-    margin: 0.25rem 0;
 }
 </style>

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -56,17 +56,19 @@ const { measured, remeasure, visibleSuggestions } = useFitToViewport(
     MAX_VISIBLE,
 );
 
-const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight } = useAutocompleteShell({
-    close: () => {
-        takeoverOpen.value = false;
+const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight, userHighlighted } = useAutocompleteShell(
+    {
+        close: () => {
+            takeoverOpen.value = false;
+        },
+        contentEl,
+        emitSelect: (suggestion) => emit('select', suggestion),
+        emitSubmit: (query) => emit('submit', query),
+        inputRef,
+        model,
+        suggestions: () => props.suggestions,
     },
-    contentEl,
-    emitSelect: (suggestion) => emit('select', suggestion),
-    emitSubmit: (query) => emit('submit', query),
-    inputRef,
-    model,
-    suggestions: () => props.suggestions,
-});
+);
 
 // 100dvh does not shrink when the iOS keyboard opens, so the list height is
 // derived from the visual viewport instead; the keyboard opening/closing is
@@ -163,6 +165,7 @@ function onOpenAutoFocus(event: Event) {
                         class="d-flex flex-column flex-grow-1"
                         ignore-filter
                         open>
+                        <es-autocomplete-highlight-guard :user-highlighted="userHighlighted" />
                         <div class="align-items-center d-flex p-100">
                             <autocomplete-anchor
                                 class="es-autocomplete-field es-form-input form-control align-items-center d-flex flex-grow-1 p-0"

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -262,11 +262,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
     z-index: 1050;
 }
 
-.es-autocomplete-field:focus-within {
-    border-color: variables.$blue-600;
-    outline: 0.125rem solid variables.$blue-600;
-    outline-offset: 0.125rem;
-}
+// deliberately no focus styling on the field: the full-screen takeover itself is
+// the focus indicator (see es-autocomplete-desktop.vue for the fuller rationale)
 
 .es-autocomplete-input {
     background: transparent;

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -82,20 +82,36 @@ function updateListHeight() {
     remeasure();
 }
 
+// the keyboard open/close animation emits a burst of visualViewport resizes;
+// coalesce to one layout read + height write per frame
+let listHeightFrame: number | null = null;
+function onViewportResize() {
+    if (listHeightFrame !== null) {
+        cancelAnimationFrame(listHeightFrame);
+    }
+    listHeightFrame = requestAnimationFrame(() => {
+        listHeightFrame = null;
+        updateListHeight();
+    });
+}
+
 watch(takeoverOpen, async (isOpen) => {
     resetUserHighlight();
     const viewport = window.visualViewport;
     if (isOpen) {
         await nextTick();
         updateListHeight();
-        viewport?.addEventListener('resize', updateListHeight);
+        viewport?.addEventListener('resize', onViewportResize);
     } else {
-        viewport?.removeEventListener('resize', updateListHeight);
+        viewport?.removeEventListener('resize', onViewportResize);
     }
 });
 
 onBeforeUnmount(() => {
-    window.visualViewport?.removeEventListener('resize', updateListHeight);
+    window.visualViewport?.removeEventListener('resize', onViewportResize);
+    if (listHeightFrame !== null) {
+        cancelAnimationFrame(listHeightFrame);
+    }
 });
 
 // iOS only shows the keyboard when focus happens inside the tap's event chain,

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -177,7 +177,7 @@ function onOpenAutoFocus(event: Event) {
                             <es-autocomplete-item
                                 v-for="suggestion in visibleSuggestions"
                                 :key="suggestion.id"
-                                :query="model ?? ''"
+                                :query="model"
                                 :suggestion="suggestion"
                                 @select="onSelect">
                                 <template

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -19,6 +19,8 @@ import type { EsAutocompleteSuggestion } from '../types';
 // further reduced by the fit-to-viewport trim
 const MAX_VISIBLE = 8;
 
+// defaults live on the public es-autocomplete.vue wrapper, which always binds
+// every prop; declaring them again here would be dead code that could drift
 interface Props {
     cancelText?: string;
     clearText?: string;
@@ -27,29 +29,14 @@ interface Props {
     id: string;
     label: string;
     labelSrOnly?: boolean;
-    minChars?: number;
-    noResults?: boolean;
-    noResultsText?: string;
+    panelMessage: string;
     placeholder?: string;
-    promptText?: string;
     required?: boolean;
     state?: boolean | null;
     suggestions: EsAutocompleteSuggestion[];
 }
 
-const props = withDefaults(defineProps<Props>(), {
-    cancelText: 'Cancel',
-    clearText: 'Clear',
-    disabled: false,
-    labelSrOnly: false,
-    minChars: 1,
-    noResults: false,
-    noResultsText: 'No results found',
-    placeholder: '',
-    promptText: 'Type for suggestions',
-    required: false,
-    state: null,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     select: [suggestion: EsAutocompleteSuggestion];
@@ -62,33 +49,23 @@ const takeoverOpen = ref(false);
 const triggerId = computed(() => `${props.id}-trigger`);
 const inputRef = ref<ComponentPublicInstance | null>(null);
 const contentRef = ref<ComponentPublicInstance | null>(null);
-
 const contentEl = useAutocompleteContentEl(contentRef, takeoverOpen);
-const suggestionsRef = computed(() => props.suggestions);
-const { measured, remeasure, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
-
-const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
-
-// Reka auto-highlights the first item whenever results arrive from an empty list,
-// which is NOT a user choice — Enter must submit the typed query then, not select.
-// Only a highlight the user created (arrow keys or pointer movement over the list)
-// makes Enter select. Reset whenever the list content changes or the takeover opens.
-const userHighlighted = ref(false);
-watch(
-    () => props.suggestions.map((suggestion) => suggestion.id).join('\n'),
-    () => {
-        userHighlighted.value = false;
-    },
+const { measured, remeasure, visibleSuggestions } = useFitToViewport(
+    contentEl,
+    toRef(props, 'suggestions'),
+    MAX_VISIBLE,
 );
 
-// what the list shows when there are no suggestions to render: the no-results
-// message once a search has actually come back empty (per the parent), otherwise
-// the prompt (nothing searched yet, or the query is below minChars)
-const panelMessage = computed(() => {
-    if (props.suggestions.length) {
-        return '';
-    }
-    return props.noResults && queryLongEnough.value ? props.noResultsText : props.promptText;
+const { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight } = useAutocompleteShell({
+    close: () => {
+        takeoverOpen.value = false;
+    },
+    contentEl,
+    emitSelect: (suggestion) => emit('select', suggestion),
+    emitSubmit: (query) => emit('submit', query),
+    inputRef,
+    model,
+    suggestions: () => props.suggestions,
 });
 
 // 100dvh does not shrink when the iOS keyboard opens, so the list height is
@@ -106,7 +83,7 @@ function updateListHeight() {
 }
 
 watch(takeoverOpen, async (isOpen) => {
-    userHighlighted.value = false;
+    resetUserHighlight();
     const viewport = window.visualViewport;
     if (isOpen) {
         await nextTick();
@@ -127,58 +104,15 @@ function onOpenAutoFocus(event: Event) {
     event.preventDefault();
     (inputRef.value?.$el as HTMLElement | undefined)?.focus();
 }
-
-// runs in the capture phase on the anchor, ahead of Reka's input-level handler
-function onEnterKey(event: KeyboardEvent) {
-    // only Enter from the input itself submits — Enter on the clear button (also
-    // inside the anchor) is a click and must reach the button
-    if (event.target !== inputRef.value?.$el) {
-        return;
-    }
-    // the Enter that commits an IME composition (Japanese/Chinese/Korean input)
-    // is not a submit
-    if (event.isComposing) {
-        return;
-    }
-    // highlight checked via the DOM rather than Reka's exposed highlightedElement,
-    // which can hold a stale (detached) element after the list re-renders
-    if (userHighlighted.value && contentEl.value?.querySelector('[data-highlighted]')) {
-        // let the event through to Reka, which selects the highlighted item
-        return;
-    }
-    // keep Reka from selecting an auto-highlighted item the user never chose, and
-    // keep a surrounding <form> from natively submitting
-    event.preventDefault();
-    event.stopPropagation();
-    takeoverOpen.value = false;
-    emit('submit', model.value ?? '');
-}
-
-function onSelect(suggestion: EsAutocompleteSuggestion) {
-    takeoverOpen.value = false;
-    emit('select', suggestion);
-}
-
-function onClear() {
-    model.value = '';
-    (inputRef.value?.$el as HTMLElement | undefined)?.focus();
-}
 </script>
 
 <template>
     <div class="d-md-none">
-        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-        <label
-            class="label justify-content-start"
-            :class="{ 'sr-only': labelSrOnly }"
-            :for="triggerId">
-            {{ label }}
-            <span
-                v-if="required"
-                class="text-danger">
-                *
-            </span>
-        </label>
+        <es-autocomplete-label
+            :html-for="triggerId"
+            :label="label"
+            :label-sr-only="labelSrOnly"
+            :required="required" />
         <dialog-root v-model:open="takeoverOpen">
             <!-- fake search field: tapping it opens the takeover with the real input focused -->
             <dialog-trigger
@@ -222,18 +156,12 @@ function onClear() {
                                     class="es-autocomplete-input h-100 w-100 px-100"
                                     :aria-label="label"
                                     :placeholder="placeholder"
-                                    @keydown.down="userHighlighted = true"
-                                    @keydown.up="userHighlighted = true" />
-                                <button
+                                    @keydown.down="markUserHighlight"
+                                    @keydown.up="markUserHighlight" />
+                                <es-autocomplete-clear-button
                                     v-if="model"
-                                    class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
-                                    type="button"
-                                    :aria-label="clearText"
-                                    @click="onClear">
-                                    <icon-x
-                                        height="20px"
-                                        width="20px" />
-                                </button>
+                                    :clear-text="clearText"
+                                    @clear="onClear" />
                             </autocomplete-anchor>
                             <dialog-close class="es-autocomplete-cancel bg-transparent border-0 flex-shrink-0 ml-100">
                                 {{ cancelText }}
@@ -245,7 +173,7 @@ function onClear() {
                                 'es-autocomplete-takeover-list text-left',
                                 { 'es-autocomplete-takeover-list--measuring': !measured },
                             ]"
-                            @pointermove="userHighlighted = true">
+                            @pointermove="markUserHighlight">
                             <es-autocomplete-item
                                 v-for="suggestion in visibleSuggestions"
                                 :key="suggestion.id"
@@ -309,18 +237,6 @@ function onClear() {
 .es-autocomplete-cancel {
     color: variables.$blue-600;
     font-weight: variables.$font-weight-semibold;
-}
-
-// ≥44px square so it is comfortably tappable; a flex sibling of the input, so
-// it can never overlap the entered text
-.es-autocomplete-clear {
-    cursor: pointer;
-    width: 2.75rem;
-
-    &:focus-visible {
-        outline: 0.125rem solid variables.$blue-600;
-        outline-offset: -0.25rem;
-    }
 }
 
 .es-autocomplete-takeover-list {

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -70,7 +70,7 @@ const contentEl = computed<HTMLElement | null>(() => {
     return el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
 });
 const suggestionsRef = computed(() => props.suggestions);
-const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
+const { measured, remeasure, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
 
 const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
 
@@ -98,7 +98,7 @@ const panelMessage = computed(() => {
 
 // 100dvh does not shrink when the iOS keyboard opens, so the list height is
 // derived from the visual viewport instead; the keyboard opening/closing is
-// just a resize event. The ResizeObserver in useFitToViewport re-trims.
+// just a resize event. Re-trim after every height change.
 function updateListHeight() {
     const el = contentEl.value;
     const viewport = window.visualViewport;
@@ -107,6 +107,7 @@ function updateListHeight() {
     }
     const top = el.getBoundingClientRect().top;
     el.style.height = `${Math.max(viewport.offsetTop + viewport.height - top, 0)}px`;
+    remeasure();
 }
 
 watch(takeoverOpen, async (isOpen) => {

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -30,8 +30,10 @@ interface Props {
     label: string;
     labelSrOnly?: boolean;
     minChars?: number;
+    noResults?: boolean;
     noResultsText?: string;
     placeholder?: string;
+    promptText?: string;
     required?: boolean;
     state?: boolean | null;
     suggestions: EsAutocompleteSuggestion[];
@@ -43,8 +45,10 @@ const props = withDefaults(defineProps<Props>(), {
     disabled: false,
     labelSrOnly: false,
     minChars: 1,
+    noResults: false,
     noResultsText: 'No results found',
     placeholder: '',
+    promptText: 'Type for suggestions',
     required: false,
     state: null,
 });
@@ -69,20 +73,17 @@ const contentEl = computed<HTMLElement | null>(() => {
 const suggestionsRef = computed(() => props.suggestions);
 const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
 
-// show "no results" only after a search in this takeover session has returned
-// results at least once — never during the first fetch, when an empty list just
-// means the app hasn't answered yet
-const hadResults = ref(false);
 const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
-const showNoResults = computed(() => hadResults.value && queryLongEnough.value && !props.suggestions.length);
-watch(
-    () => props.suggestions.length,
-    (length) => {
-        if (length) {
-            hadResults.value = true;
-        }
-    },
-);
+
+// what the list shows when there are no suggestions to render: the no-results
+// message once a search has actually come back empty (per the parent), otherwise
+// the prompt (nothing searched yet, or the query is below minChars)
+const panelMessage = computed(() => {
+    if (props.suggestions.length) {
+        return '';
+    }
+    return props.noResults && queryLongEnough.value ? props.noResultsText : props.promptText;
+});
 
 // 100dvh does not shrink when the iOS keyboard opens, so the list height is
 // derived from the visual viewport instead; the keyboard opening/closing is
@@ -100,7 +101,6 @@ function updateListHeight() {
 watch(takeoverOpen, async (isOpen) => {
     const viewport = window.visualViewport;
     if (isOpen) {
-        hadResults.value = props.suggestions.length > 0;
         await nextTick();
         updateListHeight();
         viewport?.addEventListener('resize', updateListHeight);
@@ -235,9 +235,9 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                                 </es-autocomplete-item>
                             </template>
                             <div
-                                v-if="showNoResults"
+                                v-if="panelMessage"
                                 class="es-autocomplete-no-results px-100 py-50 text-gray-700">
-                                {{ noResultsText }}
+                                {{ panelMessage }}
                             </div>
                         </autocomplete-content>
                     </autocomplete-root>

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
     AutocompleteAnchor,
+    AutocompleteCancel,
     AutocompleteContent,
     AutocompleteInput,
     AutocompleteRoot,
@@ -22,6 +23,7 @@ const MAX_VISIBLE = 8;
 
 interface Props {
     cancelText?: string;
+    clearText?: string;
     describedBy: string;
     disabled?: boolean;
     id: string;
@@ -37,6 +39,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     cancelText: 'Cancel',
+    clearText: 'Clear',
     disabled: false,
     labelSrOnly: false,
     minChars: 1,
@@ -191,6 +194,16 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
                                     :aria-label="label"
                                     :placeholder="placeholder"
                                     @keydown.enter="onEnterKey" />
+                                <!-- tabindex overrides the -1 Reka renders, so keyboard users can reach the button -->
+                                <autocomplete-cancel
+                                    v-if="model"
+                                    class="es-autocomplete-clear align-items-center bg-transparent border-0 d-flex flex-shrink-0 h-100 justify-content-center p-0 text-gray-700"
+                                    tabindex="0"
+                                    :aria-label="clearText">
+                                    <icon-x
+                                        height="20px"
+                                        width="20px" />
+                                </autocomplete-cancel>
                             </autocomplete-anchor>
                             <dialog-close class="es-autocomplete-cancel bg-transparent border-0 flex-shrink-0 ml-100">
                                 {{ cancelText }}
@@ -273,6 +286,18 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
 .es-autocomplete-cancel {
     color: variables.$blue-600;
     font-weight: variables.$font-weight-semibold;
+}
+
+// ≥44px square so it is comfortably tappable; a flex sibling of the input, so
+// it can never overlap the entered text
+.es-autocomplete-clear {
+    cursor: pointer;
+    width: 2.75rem;
+
+    &:focus-visible {
+        outline: 0.125rem solid variables.$blue-600;
+        outline-offset: -0.25rem;
+    }
 }
 
 .es-autocomplete-takeover-list {

--- a/es-ds-components/app/components/es-autocomplete-mobile.vue
+++ b/es-ds-components/app/components/es-autocomplete-mobile.vue
@@ -1,0 +1,305 @@
+<script setup lang="ts">
+import {
+    AutocompleteAnchor,
+    AutocompleteContent,
+    AutocompleteInput,
+    AutocompleteRoot,
+    AutocompleteSeparator,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogPortal,
+    DialogRoot,
+    DialogTitle,
+    DialogTrigger,
+} from 'reka-ui';
+import type { ComponentPublicInstance } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+
+// Baymard: keep the list manageable — at most 8 suggestions on mobile,
+// further reduced by the fit-to-viewport trim
+const MAX_VISIBLE = 8;
+
+interface Props {
+    cancelText?: string;
+    describedBy: string;
+    disabled?: boolean;
+    id: string;
+    label: string;
+    labelSrOnly?: boolean;
+    minChars?: number;
+    noResultsText?: string;
+    placeholder?: string;
+    required?: boolean;
+    state?: boolean | null;
+    suggestions: EsAutocompleteSuggestion[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    cancelText: 'Cancel',
+    disabled: false,
+    labelSrOnly: false,
+    minChars: 1,
+    noResultsText: 'No results found',
+    placeholder: '',
+    required: false,
+    state: null,
+});
+
+const emit = defineEmits<{
+    select: [suggestion: EsAutocompleteSuggestion];
+    submit: [query: string];
+}>();
+
+const model = defineModel<string>({ default: '' });
+
+const takeoverOpen = ref(false);
+const triggerId = computed(() => `${props.id}-trigger`);
+const inputRef = ref<ComponentPublicInstance | null>(null);
+const contentRef = ref<ComponentPublicInstance | null>(null);
+
+// when the panel is closed, $el is a placeholder comment node, not an element
+const contentEl = computed<HTMLElement | null>(() => {
+    const el = contentRef.value?.$el as Node | undefined;
+    return el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
+});
+const suggestionsRef = computed(() => props.suggestions);
+const { measured, visibleSuggestions } = useFitToViewport(contentEl, suggestionsRef, MAX_VISIBLE);
+
+// show "no results" only after a search in this takeover session has returned
+// results at least once — never during the first fetch, when an empty list just
+// means the app hasn't answered yet
+const hadResults = ref(false);
+const queryLongEnough = computed(() => (model.value ?? '').trim().length >= props.minChars);
+const showNoResults = computed(() => hadResults.value && queryLongEnough.value && !props.suggestions.length);
+watch(
+    () => props.suggestions.length,
+    (length) => {
+        if (length) {
+            hadResults.value = true;
+        }
+    },
+);
+
+// 100dvh does not shrink when the iOS keyboard opens, so the list height is
+// derived from the visual viewport instead; the keyboard opening/closing is
+// just a resize event. The ResizeObserver in useFitToViewport re-trims.
+function updateListHeight() {
+    const el = contentEl.value;
+    const viewport = window.visualViewport;
+    if (!el || !viewport) {
+        return;
+    }
+    const top = el.getBoundingClientRect().top;
+    el.style.height = `${Math.max(viewport.offsetTop + viewport.height - top, 0)}px`;
+}
+
+watch(takeoverOpen, async (isOpen) => {
+    const viewport = window.visualViewport;
+    if (isOpen) {
+        hadResults.value = props.suggestions.length > 0;
+        await nextTick();
+        updateListHeight();
+        viewport?.addEventListener('resize', updateListHeight);
+    } else {
+        viewport?.removeEventListener('resize', updateListHeight);
+    }
+});
+
+onBeforeUnmount(() => {
+    window.visualViewport?.removeEventListener('resize', updateListHeight);
+});
+
+// iOS only shows the keyboard when focus happens inside the tap's event chain,
+// so redirect the dialog's initial focus to the real input
+function onOpenAutoFocus(event: Event) {
+    event.preventDefault();
+    (inputRef.value?.$el as HTMLElement | undefined)?.focus();
+}
+
+function onEnterKey() {
+    // Enter with a highlighted suggestion is handled by Reka (selection); Enter
+    // without one submits the raw query. Checked via the DOM rather than Reka's
+    // exposed highlightedElement, which can hold a stale (detached) element after
+    // a previous selection re-renders the list.
+    if (!contentEl.value?.querySelector('[data-highlighted]')) {
+        takeoverOpen.value = false;
+        emit('submit', model.value ?? '');
+    }
+}
+
+function onSelect(suggestion: EsAutocompleteSuggestion) {
+    takeoverOpen.value = false;
+    emit('select', suggestion);
+}
+</script>
+
+<template>
+    <div class="d-md-none">
+        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+        <label
+            class="label justify-content-start"
+            :class="{ 'sr-only': labelSrOnly }"
+            :for="triggerId">
+            {{ label }}
+            <span
+                v-if="required"
+                class="text-danger">
+                *
+            </span>
+        </label>
+        <dialog-root v-model:open="takeoverOpen">
+            <!-- fake search field: tapping it opens the takeover with the real input focused -->
+            <dialog-trigger
+                :id="triggerId"
+                class="es-autocomplete-fake-field es-form-input form-control align-items-center d-flex px-100 text-left w-100"
+                :class="{ 'is-invalid': state === false }"
+                :aria-describedby="describedBy"
+                :disabled="disabled">
+                <span
+                    v-if="model"
+                    class="text-truncate">
+                    {{ model }}
+                </span>
+                <span
+                    v-else
+                    class="es-autocomplete-fake-field-placeholder text-truncate">
+                    {{ placeholder }}
+                </span>
+            </dialog-trigger>
+            <dialog-portal>
+                <dialog-content
+                    class="es-autocomplete-takeover bg-white d-flex flex-column"
+                    @open-auto-focus="onOpenAutoFocus">
+                    <dialog-title class="sr-only">
+                        {{ label }}
+                    </dialog-title>
+                    <dialog-description class="sr-only">
+                        Type your search and select from dropdown suggestions.
+                    </dialog-description>
+                    <autocomplete-root
+                        v-model="model"
+                        class="d-flex flex-column flex-grow-1"
+                        ignore-filter
+                        open>
+                        <div class="align-items-center d-flex p-100">
+                            <autocomplete-anchor
+                                class="es-autocomplete-field es-form-input form-control align-items-center d-flex flex-grow-1 p-0">
+                                <autocomplete-input
+                                    ref="inputRef"
+                                    class="es-autocomplete-input h-100 w-100 px-100"
+                                    :aria-label="label"
+                                    :placeholder="placeholder"
+                                    @keydown.enter="onEnterKey" />
+                            </autocomplete-anchor>
+                            <dialog-close class="es-autocomplete-cancel bg-transparent border-0 flex-shrink-0 ml-100">
+                                {{ cancelText }}
+                            </dialog-close>
+                        </div>
+                        <autocomplete-content
+                            ref="contentRef"
+                            :class="[
+                                'es-autocomplete-takeover-list text-left',
+                                { 'es-autocomplete-takeover-list--measuring': !measured },
+                            ]">
+                            <template
+                                v-for="(suggestion, index) in visibleSuggestions"
+                                :key="suggestion.id">
+                                <autocomplete-separator
+                                    v-if="index > 0 && suggestion.scope && !visibleSuggestions[index - 1]?.scope"
+                                    class="es-autocomplete-separator" />
+                                <es-autocomplete-item
+                                    :query="model ?? ''"
+                                    :suggestion="suggestion"
+                                    @select="onSelect">
+                                    <template
+                                        v-if="$slots.item"
+                                        #default="slotProps">
+                                        <slot
+                                            name="item"
+                                            v-bind="slotProps" />
+                                    </template>
+                                </es-autocomplete-item>
+                            </template>
+                            <div
+                                v-if="showNoResults"
+                                class="es-autocomplete-no-results px-100 py-50 text-gray-700">
+                                {{ noResultsText }}
+                            </div>
+                        </autocomplete-content>
+                    </autocomplete-root>
+                </dialog-content>
+            </dialog-portal>
+        </dialog-root>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@use '@energysage/es-ds-styles/scss/variables' as variables;
+
+.es-autocomplete-fake-field-placeholder {
+    color: variables.$input-color-placeholder;
+}
+
+.es-autocomplete-takeover {
+    height: 100dvh;
+    inset: 0;
+    position: fixed;
+    // above the page and any menu bar (1000); same layer as modals
+    z-index: 1050;
+}
+
+.es-autocomplete-field:focus-within {
+    border-color: variables.$blue-600;
+    outline: 0.125rem solid variables.$blue-600;
+    outline-offset: 0.125rem;
+}
+
+.es-autocomplete-input {
+    background: transparent;
+    border: none;
+    // ≥16px or iOS Safari auto-zooms on focus
+    font-size: 1rem;
+
+    &:focus-visible {
+        outline: none;
+    }
+
+    &::placeholder {
+        color: variables.$input-color-placeholder;
+    }
+}
+
+.es-autocomplete-cancel {
+    color: variables.$blue-600;
+    font-weight: variables.$font-weight-semibold;
+}
+
+.es-autocomplete-takeover-list {
+    // no scrolling by design: the fit-to-viewport trim only renders items that fit
+    overflow: hidden;
+    // required by useFitToViewport: item offsetTop must be relative to this container
+    position: relative;
+
+    &--measuring {
+        visibility: hidden;
+    }
+
+    // adequate tap targets: ≥44px rows and ≥16px text
+    .es-autocomplete-item {
+        align-content: center;
+        font-size: 1rem;
+        min-height: 2.75rem;
+    }
+
+    .es-autocomplete-no-results {
+        font-size: 1rem;
+    }
+}
+
+.es-autocomplete-separator {
+    background-color: variables.$gray-200;
+    height: variables.$border-width;
+    margin: 0.25rem 0;
+}
+</style>

--- a/es-ds-components/app/components/es-autocomplete-suggestion-text.vue
+++ b/es-ds-components/app/components/es-autocomplete-suggestion-text.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EsAutocompleteTextSegment } from '../types';
+import { splitAutocompleteText } from '../utils/autocomplete';
 
 interface Props {
     query?: string;

--- a/es-ds-components/app/components/es-autocomplete-suggestion-text.vue
+++ b/es-ds-components/app/components/es-autocomplete-suggestion-text.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { EsAutocompleteTextSegment } from '../types';
+
+interface Props {
+    query?: string;
+    /**
+     * Pre-computed segments — e.g. from splitAutocompleteTextLines when several
+     * lines form one suggestion, or built from a search API's own match offsets.
+     * When provided, text/query are ignored.
+     */
+    segments?: EsAutocompleteTextSegment[] | null;
+    text?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    query: '',
+    segments: null,
+    text: '',
+});
+
+const resolvedSegments = computed(() => props.segments ?? splitAutocompleteText(props.text, props.query));
+</script>
+
+<template>
+    <span>
+        <span
+            v-for="(segment, index) in resolvedSegments"
+            :key="index"
+            :class="{ 'font-weight-bold': segment.predictive }"
+            >{{ segment.text }}</span
+        >
+    </span>
+</template>

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -12,6 +12,7 @@ interface Props {
     minChars?: number;
     noResultsText?: string;
     placeholder?: string;
+    promptText?: string;
     required?: boolean;
     state?: boolean | null;
     suggestions: EsAutocompleteSuggestion[];
@@ -26,6 +27,7 @@ const props = withDefaults(defineProps<Props>(), {
     minChars: 1,
     noResultsText: 'No results found',
     placeholder: '',
+    promptText: 'Type for suggestions',
     required: false,
     state: null,
 });
@@ -61,6 +63,17 @@ const orderedSuggestions = computed(() => {
 let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastSelectedText: string | null = null;
 
+// whether the app's most recent suggestions update was empty — this is what lets
+// the shells distinguish "search found nothing" (show noResultsText) from "no
+// search has answered yet" (show promptText)
+const noResults = ref(false);
+watch(
+    () => props.suggestions,
+    (list) => {
+        noResults.value = list.length === 0;
+    },
+);
+
 watch(model, (newValue) => {
     if (searchTimeout) {
         clearTimeout(searchTimeout);
@@ -75,6 +88,9 @@ watch(model, (newValue) => {
     lastSelectedText = null;
     const query = (newValue ?? '').trim();
     if (query.length < props.minChars) {
+        // a fresh (or cleared) query starts from the prompt state, not a stale
+        // "no results" from the previous query
+        noResults.value = false;
         return;
     }
     searchTimeout = setTimeout(() => {
@@ -115,8 +131,10 @@ function onSubmit(query: string) {
             :label="label"
             :label-sr-only="labelSrOnly"
             :min-chars="minChars"
+            :no-results="noResults"
             :no-results-text="noResultsText"
             :placeholder="placeholder"
+            :prompt-text="promptText"
             :required="required"
             :state="state"
             :suggestions="orderedSuggestions"
@@ -140,8 +158,10 @@ function onSubmit(query: string) {
             :label="label"
             :label-sr-only="labelSrOnly"
             :min-chars="minChars"
+            :no-results="noResults"
             :no-results-text="noResultsText"
             :placeholder="placeholder"
+            :prompt-text="promptText"
             :required="required"
             :state="state"
             :suggestions="orderedSuggestions"

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -88,6 +88,9 @@ watch(model, (newValue) => {
         noResults.value = false;
         return;
     }
+    // the edited query's search is now pending: show promptText, not the previous
+    // query's "no results", until the app answers via the suggestions prop
+    noResults.value = false;
     searchTimeout = setTimeout(() => {
         emit('complete', query);
     }, props.delay);

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -58,9 +58,9 @@ const effectiveSuggestions = computed(() => {
 let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastSelectedText: string | null = null;
 
-// whether the app's most recent suggestions update was empty — this is what lets
-// the shells distinguish "search found nothing" (show noResultsText) from "no
-// search has answered yet" (show promptText)
+// whether the app's most recent suggestions update was empty — this is what
+// distinguishes "search found nothing" (show noResultsText) from "no search has
+// answered yet" (show promptText)
 const noResults = ref(false);
 watch(
     () => props.suggestions,
@@ -68,6 +68,17 @@ watch(
         noResults.value = list.length === 0;
     },
 );
+
+// what an open panel shows when there are no suggestions to render: the
+// no-results message once a search has actually come back empty, otherwise
+// the prompt (nothing searched yet, or the query is below minChars)
+const queryLongEnough = computed(() => model.value.trim().length >= props.minChars);
+const panelMessage = computed(() => {
+    if (effectiveSuggestions.value.length) {
+        return '';
+    }
+    return noResults.value && queryLongEnough.value ? props.noResultsText : props.promptText;
+});
 
 watch(model, (newValue) => {
     if (searchTimeout) {
@@ -128,11 +139,8 @@ function onSubmit(query: string) {
             :disabled="disabled"
             :label="label"
             :label-sr-only="labelSrOnly"
-            :min-chars="minChars"
-            :no-results="noResults"
-            :no-results-text="noResultsText"
+            :panel-message="panelMessage"
             :placeholder="placeholder"
-            :prompt-text="promptText"
             :required="required"
             :state="state"
             :suggestions="effectiveSuggestions"
@@ -155,11 +163,8 @@ function onSubmit(query: string) {
             :disabled="disabled"
             :label="label"
             :label-sr-only="labelSrOnly"
-            :min-chars="minChars"
-            :no-results="noResults"
-            :no-results-text="noResultsText"
+            :panel-message="panelMessage"
             :placeholder="placeholder"
-            :prompt-text="promptText"
             :required="required"
             :state="state"
             :suggestions="effectiveSuggestions"

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -47,10 +47,13 @@ const helpId = computed(() => `${props.id}-help`);
 const showError = computed(() => props.state === false && (!!slots.errorMessage || props.required));
 const describedBy = computed(() => (showError.value ? `${helpId.value} ${errorId.value}` : helpId.value));
 
-// pass an empty list below minChars so no suggestions show for too-short queries
+// pass an empty list below minChars so no suggestions show for too-short queries;
+// the shared constant keeps the computed referentially stable across keystrokes,
+// so downstream watchers don't re-fire for an unchanged empty list
+const EMPTY_SUGGESTIONS: EsAutocompleteSuggestion[] = [];
 const effectiveSuggestions = computed(() => {
     if (model.value.trim().length < props.minChars) {
-        return [];
+        return EMPTY_SUGGESTIONS;
     }
     return props.suggestions;
 });
@@ -83,6 +86,8 @@ watch(
     (list) => {
         noResults.value = list.length === 0;
     },
+    // depth 1 so apps that mutate the array in place (push/splice) are seen too
+    { deep: 1 },
 );
 
 // what an open panel shows when there are no suggestions to render: the

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -3,6 +3,7 @@ import type { EsAutocompleteSuggestion } from '../types';
 
 interface Props {
     cancelText?: string;
+    clearText?: string;
     delay?: number;
     disabled?: boolean;
     id: string;
@@ -18,6 +19,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     cancelText: 'Cancel',
+    clearText: 'Clear',
     delay: 300,
     disabled: false,
     labelSrOnly: false,
@@ -107,6 +109,7 @@ function onSubmit(query: string) {
         <es-autocomplete-desktop
             :id="id"
             v-model="model"
+            :clear-text="clearText"
             :described-by="describedBy"
             :disabled="disabled"
             :label="label"
@@ -131,6 +134,7 @@ function onSubmit(query: string) {
             :id="id"
             v-model="model"
             :cancel-text="cancelText"
+            :clear-text="clearText"
             :described-by="describedBy"
             :disabled="disabled"
             :label="label"

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -47,17 +47,12 @@ const helpId = computed(() => `${props.id}-help`);
 const showError = computed(() => props.state === false && (!!slots.errorMessage || props.required));
 const describedBy = computed(() => (showError.value ? `${helpId.value} ${errorId.value}` : helpId.value));
 
-// unscoped suggestions render first, then category-scoped ones (stable within each
-// group, separated visually by the shells); an empty list closes the panel, which
-// also covers queries shorter than minChars
-const orderedSuggestions = computed(() => {
+// pass an empty list below minChars so no suggestions show for too-short queries
+const effectiveSuggestions = computed(() => {
     if ((model.value ?? '').trim().length < props.minChars) {
         return [];
     }
-    return [
-        ...props.suggestions.filter((suggestion) => !suggestion.scope),
-        ...props.suggestions.filter((suggestion) => suggestion.scope),
-    ];
+    return props.suggestions;
 });
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -137,7 +132,7 @@ function onSubmit(query: string) {
             :prompt-text="promptText"
             :required="required"
             :state="state"
-            :suggestions="orderedSuggestions"
+            :suggestions="effectiveSuggestions"
             @select="onSelect"
             @submit="onSubmit">
             <template
@@ -164,7 +159,7 @@ function onSubmit(query: string) {
             :prompt-text="promptText"
             :required="required"
             :state="state"
-            :suggestions="orderedSuggestions"
+            :suggestions="effectiveSuggestions"
             @select="onSelect"
             @submit="onSubmit">
             <template

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -47,94 +47,19 @@ const helpId = computed(() => `${props.id}-help`);
 const showError = computed(() => props.state === false && (!!slots.errorMessage || props.required));
 const describedBy = computed(() => (showError.value ? `${helpId.value} ${errorId.value}` : helpId.value));
 
-// pass an empty list below minChars so no suggestions show for too-short queries;
-// the shared constant keeps the computed referentially stable across keystrokes,
-// so downstream watchers don't re-fire for an unchanged empty list
-const EMPTY_SUGGESTIONS: EsAutocompleteSuggestion[] = [];
-const effectiveSuggestions = computed(() => {
-    if (model.value.trim().length < props.minChars) {
-        return EMPTY_SUGGESTIONS;
-    }
-    return props.suggestions;
+// the debounced 'complete' contract, minChars gating, and prompt/no-results
+// messaging live in useAutocompleteSearch so the contract is unit-testable
+const { effectiveSuggestions, onSelect, onSubmit, panelMessage } = useAutocompleteSearch({
+    delay: () => props.delay,
+    emitComplete: (query) => emit('complete', query),
+    emitSelect: (suggestion) => emit('select', suggestion),
+    emitSubmit: (query) => emit('submit', query),
+    minChars: () => props.minChars,
+    model,
+    noResultsText: () => props.noResultsText,
+    promptText: () => props.promptText,
+    suggestions: () => props.suggestions,
 });
-
-// one cancellable handle for the debounced 'complete': every terminal path
-// (selection, submit, short query, unmount) cancels through the same place so
-// a late-arriving response can never reopen the panel
-let searchTimeout: ReturnType<typeof setTimeout> | null = null;
-function cancelPendingComplete() {
-    if (searchTimeout) {
-        clearTimeout(searchTimeout);
-        searchTimeout = null;
-    }
-}
-function scheduleComplete(query: string) {
-    cancelPendingComplete();
-    searchTimeout = setTimeout(() => {
-        emit('complete', query);
-    }, props.delay);
-}
-
-let lastSelectedText: string | null = null;
-
-// whether the app's most recent suggestions update was empty — this is what
-// distinguishes "search found nothing" (show noResultsText) from "no search has
-// answered yet" (show promptText)
-const noResults = ref(false);
-watch(
-    () => props.suggestions,
-    (list) => {
-        noResults.value = list.length === 0;
-    },
-    // depth 1 so apps that mutate the array in place (push/splice) are seen too
-    { deep: 1 },
-);
-
-// what an open panel shows when there are no suggestions to render: the
-// no-results message once a search has actually come back empty, otherwise
-// the prompt (nothing searched yet, or the query is below minChars)
-const queryLongEnough = computed(() => model.value.trim().length >= props.minChars);
-const panelMessage = computed(() => {
-    if (effectiveSuggestions.value.length) {
-        return '';
-    }
-    return noResults.value && queryLongEnough.value ? props.noResultsText : props.promptText;
-});
-
-watch(model, (newValue) => {
-    cancelPendingComplete();
-    // selecting a suggestion copies its text into the input; that change is
-    // terminal and must not trigger another fetch
-    if (lastSelectedText !== null && newValue === lastSelectedText) {
-        lastSelectedText = null;
-        return;
-    }
-    lastSelectedText = null;
-    const query = newValue.trim();
-    if (query.length < props.minChars) {
-        // a fresh (or cleared) query starts from the prompt state, not a stale
-        // "no results" from the previous query
-        noResults.value = false;
-        return;
-    }
-    // the edited query's search is now pending: show promptText, not the previous
-    // query's "no results", until the app answers via the suggestions prop
-    noResults.value = false;
-    scheduleComplete(query);
-});
-
-onUnmounted(cancelPendingComplete);
-
-function onSelect(suggestion: EsAutocompleteSuggestion) {
-    lastSelectedText = suggestion.text;
-    emit('select', suggestion);
-}
-
-function onSubmit(query: string) {
-    // submitting is terminal for this query
-    cancelPendingComplete();
-    emit('submit', query);
-}
 </script>
 
 <template>

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import type { EsAutocompleteSuggestion } from '../types';
+
+interface Props {
+    cancelText?: string;
+    delay?: number;
+    disabled?: boolean;
+    id: string;
+    label: string;
+    labelSrOnly?: boolean;
+    minChars?: number;
+    noResultsText?: string;
+    placeholder?: string;
+    required?: boolean;
+    state?: boolean | null;
+    suggestions: EsAutocompleteSuggestion[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    cancelText: 'Cancel',
+    delay: 300,
+    disabled: false,
+    labelSrOnly: false,
+    minChars: 1,
+    noResultsText: 'No results found',
+    placeholder: '',
+    required: false,
+    state: null,
+});
+
+const emit = defineEmits<{
+    complete: [query: string];
+    select: [suggestion: EsAutocompleteSuggestion];
+    submit: [query: string];
+}>();
+
+const model = defineModel<string>({ default: '' });
+
+const slots = useSlots();
+
+const errorId = computed(() => `${props.id}-error`);
+const helpId = computed(() => `${props.id}-help`);
+const showError = computed(() => props.state === false && (!!slots.errorMessage || props.required));
+const describedBy = computed(() => (showError.value ? `${helpId.value} ${errorId.value}` : helpId.value));
+
+// unscoped suggestions render first, then category-scoped ones (stable within each
+// group, separated visually by the shells); an empty list closes the panel, which
+// also covers queries shorter than minChars
+const orderedSuggestions = computed(() => {
+    if ((model.value ?? '').trim().length < props.minChars) {
+        return [];
+    }
+    return [
+        ...props.suggestions.filter((suggestion) => !suggestion.scope),
+        ...props.suggestions.filter((suggestion) => suggestion.scope),
+    ];
+});
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+let lastSelectedText: string | null = null;
+
+watch(model, (newValue) => {
+    if (searchTimeout) {
+        clearTimeout(searchTimeout);
+        searchTimeout = null;
+    }
+    // selecting a suggestion copies its text into the input; that change is
+    // terminal and must not trigger another fetch
+    if (lastSelectedText !== null && newValue === lastSelectedText) {
+        lastSelectedText = null;
+        return;
+    }
+    lastSelectedText = null;
+    const query = (newValue ?? '').trim();
+    if (query.length < props.minChars) {
+        return;
+    }
+    searchTimeout = setTimeout(() => {
+        emit('complete', query);
+    }, props.delay);
+});
+
+onUnmounted(() => {
+    if (searchTimeout) {
+        clearTimeout(searchTimeout);
+    }
+});
+
+function onSelect(suggestion: EsAutocompleteSuggestion) {
+    lastSelectedText = suggestion.text;
+    emit('select', suggestion);
+}
+
+function onSubmit(query: string) {
+    // submitting is terminal for this query: cancel any pending 'complete' so
+    // late-arriving suggestions don't reopen the panel
+    if (searchTimeout) {
+        clearTimeout(searchTimeout);
+        searchTimeout = null;
+    }
+    emit('submit', query);
+}
+</script>
+
+<template>
+    <div class="es-autocomplete">
+        <es-autocomplete-desktop
+            :id="id"
+            v-model="model"
+            :described-by="describedBy"
+            :disabled="disabled"
+            :label="label"
+            :label-sr-only="labelSrOnly"
+            :min-chars="minChars"
+            :no-results-text="noResultsText"
+            :placeholder="placeholder"
+            :required="required"
+            :state="state"
+            :suggestions="orderedSuggestions"
+            @select="onSelect"
+            @submit="onSubmit">
+            <template
+                v-if="$slots.item"
+                #item="slotProps">
+                <slot
+                    name="item"
+                    v-bind="slotProps" />
+            </template>
+        </es-autocomplete-desktop>
+        <es-autocomplete-mobile
+            :id="id"
+            v-model="model"
+            :cancel-text="cancelText"
+            :described-by="describedBy"
+            :disabled="disabled"
+            :label="label"
+            :label-sr-only="labelSrOnly"
+            :min-chars="minChars"
+            :no-results-text="noResultsText"
+            :placeholder="placeholder"
+            :required="required"
+            :state="state"
+            :suggestions="orderedSuggestions"
+            @select="onSelect"
+            @submit="onSubmit">
+            <template
+                v-if="$slots.item"
+                #item="slotProps">
+                <slot
+                    name="item"
+                    v-bind="slotProps" />
+            </template>
+        </es-autocomplete-mobile>
+        <small
+            v-if="showError"
+            :id="errorId"
+            aria-live="polite"
+            class="text-danger"
+            role="status">
+            <slot
+                v-if="$slots.errorMessage"
+                name="errorMessage" />
+            <template v-else> This field is required. </template>
+        </small>
+        <small
+            v-else-if="$slots.message"
+            class="text-muted">
+            <slot name="message" />
+        </small>
+        <div
+            :id="helpId"
+            class="sr-only">
+            Type your search and select from dropdown suggestions.
+        </div>
+    </div>
+</template>

--- a/es-ds-components/app/components/es-autocomplete.vue
+++ b/es-ds-components/app/components/es-autocomplete.vue
@@ -49,13 +49,29 @@ const describedBy = computed(() => (showError.value ? `${helpId.value} ${errorId
 
 // pass an empty list below minChars so no suggestions show for too-short queries
 const effectiveSuggestions = computed(() => {
-    if ((model.value ?? '').trim().length < props.minChars) {
+    if (model.value.trim().length < props.minChars) {
         return [];
     }
     return props.suggestions;
 });
 
+// one cancellable handle for the debounced 'complete': every terminal path
+// (selection, submit, short query, unmount) cancels through the same place so
+// a late-arriving response can never reopen the panel
 let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+function cancelPendingComplete() {
+    if (searchTimeout) {
+        clearTimeout(searchTimeout);
+        searchTimeout = null;
+    }
+}
+function scheduleComplete(query: string) {
+    cancelPendingComplete();
+    searchTimeout = setTimeout(() => {
+        emit('complete', query);
+    }, props.delay);
+}
+
 let lastSelectedText: string | null = null;
 
 // whether the app's most recent suggestions update was empty — this is what
@@ -81,10 +97,7 @@ const panelMessage = computed(() => {
 });
 
 watch(model, (newValue) => {
-    if (searchTimeout) {
-        clearTimeout(searchTimeout);
-        searchTimeout = null;
-    }
+    cancelPendingComplete();
     // selecting a suggestion copies its text into the input; that change is
     // terminal and must not trigger another fetch
     if (lastSelectedText !== null && newValue === lastSelectedText) {
@@ -92,7 +105,7 @@ watch(model, (newValue) => {
         return;
     }
     lastSelectedText = null;
-    const query = (newValue ?? '').trim();
+    const query = newValue.trim();
     if (query.length < props.minChars) {
         // a fresh (or cleared) query starts from the prompt state, not a stale
         // "no results" from the previous query
@@ -102,16 +115,10 @@ watch(model, (newValue) => {
     // the edited query's search is now pending: show promptText, not the previous
     // query's "no results", until the app answers via the suggestions prop
     noResults.value = false;
-    searchTimeout = setTimeout(() => {
-        emit('complete', query);
-    }, props.delay);
+    scheduleComplete(query);
 });
 
-onUnmounted(() => {
-    if (searchTimeout) {
-        clearTimeout(searchTimeout);
-    }
-});
+onUnmounted(cancelPendingComplete);
 
 function onSelect(suggestion: EsAutocompleteSuggestion) {
     lastSelectedText = suggestion.text;
@@ -119,12 +126,8 @@ function onSelect(suggestion: EsAutocompleteSuggestion) {
 }
 
 function onSubmit(query: string) {
-    // submitting is terminal for this query: cancel any pending 'complete' so
-    // late-arriving suggestions don't reopen the panel
-    if (searchTimeout) {
-        clearTimeout(searchTimeout);
-        searchTimeout = null;
-    }
+    // submitting is terminal for this query
+    cancelPendingComplete();
     emit('submit', query);
 }
 </script>

--- a/es-ds-components/app/composables/autocomplete-content-el.test.ts
+++ b/es-ds-components/app/composables/autocomplete-content-el.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { nextTick, ref } from 'vue';
+import { useAutocompleteContentEl } from './autocomplete-content-el';
+
+// $el swaps between a placeholder comment node and the real element as the panel
+// mounts/unmounts, and it is NOT reactive — this composable exists because a
+// computed over it silently caches the wrong node (which caused both a
+// ResizeObserver crash and a permanently invisible panel during development)
+
+function makeInstance(el: Node) {
+    return ref({ $el: el }) as unknown as Ref<ComponentPublicInstance | null>;
+}
+
+/** the composable resolves after `active` changes and the DOM settles (one tick) */
+async function settle() {
+    await nextTick();
+    await nextTick();
+}
+
+describe('useAutocompleteContentEl', () => {
+    it('is null until activated', () => {
+        const contentEl = useAutocompleteContentEl(makeInstance(document.createElement('div')), ref(false));
+        expect(contentEl.value).toBeNull();
+    });
+
+    it('resolves the element once active, and clears on deactivate', async () => {
+        const element = document.createElement('div');
+        const active = ref(false);
+        const contentEl = useAutocompleteContentEl(makeInstance(element), active);
+
+        active.value = true;
+        await settle();
+        expect(contentEl.value).toBe(element);
+
+        active.value = false;
+        await settle();
+        expect(contentEl.value).toBeNull();
+    });
+
+    it('never resolves a placeholder comment node as the element', async () => {
+        const active = ref(false);
+        const contentEl = useAutocompleteContentEl(makeInstance(document.createComment('placeholder')), active);
+
+        active.value = true;
+        await settle();
+        expect(contentEl.value).toBeNull();
+    });
+
+    it('re-resolves a swapped $el on the next activation', async () => {
+        const instance = makeInstance(document.createComment('placeholder'));
+        const active = ref(false);
+        const contentEl = useAutocompleteContentEl(instance, active);
+
+        active.value = true;
+        await settle();
+        expect(contentEl.value).toBeNull();
+
+        // the panel unmounts, then remounts with a real element in $el
+        active.value = false;
+        await settle();
+        const element = document.createElement('div');
+        (instance.value as unknown as { $el: Node }).$el = element;
+        active.value = true;
+        await settle();
+        expect(contentEl.value).toBe(element);
+    });
+});

--- a/es-ds-components/app/composables/autocomplete-content-el.ts
+++ b/es-ds-components/app/composables/autocomplete-content-el.ts
@@ -1,0 +1,20 @@
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { nextTick, ref, watch } from 'vue';
+
+/**
+ * Resolve the AutocompleteContent panel element from its component ref.
+ *
+ * $el is not reactive — and is a placeholder comment node while the panel is
+ * unmounted — so a computed over it silently caches the wrong node. Instead the
+ * element is re-resolved whenever `active` (the open state that mounts the panel)
+ * changes and the DOM has settled. Both autocomplete shells share this.
+ */
+export function useAutocompleteContentEl(contentRef: Ref<ComponentPublicInstance | null>, active: Ref<boolean>) {
+    const contentEl = ref<HTMLElement | null>(null);
+    watch(active, async (isActive) => {
+        await nextTick();
+        const el = contentRef.value?.$el as Node | undefined;
+        contentEl.value = isActive && el && el.nodeType === Node.ELEMENT_NODE ? (el as HTMLElement) : null;
+    });
+    return contentEl;
+}

--- a/es-ds-components/app/composables/autocomplete-search.test.ts
+++ b/es-ds-components/app/composables/autocomplete-search.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, nextTick, ref } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+import { useAutocompleteSearch } from './autocomplete-search';
+
+const DELAY = 300;
+
+const apps: App[] = [];
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    apps.forEach((app) => app.unmount());
+    apps.length = 0;
+    vi.useRealTimers();
+});
+
+/** run a composable inside a real component so lifecycle hooks work */
+function withSetup<T>(composable: () => T): { app: App; result: T } {
+    let result!: T;
+    const app = createApp({
+        setup() {
+            result = composable();
+            return () => null;
+        },
+    });
+    app.mount(document.createElement('div'));
+    apps.push(app);
+    return { app, result };
+}
+
+function makeSearch(overrides: { minChars?: number } = {}) {
+    const model = ref('');
+    const suggestions = ref<EsAutocompleteSuggestion[]>([]);
+    const emitComplete = vi.fn();
+    const emitSelect = vi.fn();
+    const emitSubmit = vi.fn();
+    const { app, result: search } = withSetup(() =>
+        useAutocompleteSearch({
+            delay: () => DELAY,
+            emitComplete,
+            emitSelect,
+            emitSubmit,
+            minChars: () => overrides.minChars ?? 1,
+            model,
+            noResultsText: () => 'No results found',
+            promptText: () => 'Type for suggestions',
+            suggestions: () => suggestions.value,
+        }),
+    );
+    /** type a value and let the model watcher run */
+    async function type(value: string) {
+        model.value = value;
+        await nextTick();
+    }
+    return { app, emitComplete, emitSelect, emitSubmit, model, search, suggestions, type };
+}
+
+describe('useAutocompleteSearch complete debouncing', () => {
+    it('emits complete once per typing pause, with the trimmed query', async () => {
+        const { emitComplete, type } = makeSearch();
+        await type('s');
+        vi.advanceTimersByTime(DELAY - 50);
+        await type('so');
+        await type(' solar ');
+        vi.advanceTimersByTime(DELAY);
+        expect(emitComplete).toHaveBeenCalledTimes(1);
+        expect(emitComplete).toHaveBeenCalledWith('solar');
+    });
+
+    it('does not emit below minChars', async () => {
+        const { emitComplete, type } = makeSearch({ minChars: 3 });
+        await type('so');
+        vi.advanceTimersByTime(DELAY * 2);
+        expect(emitComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fetch when selection copies the suggestion text into the input', async () => {
+        const { emitComplete, search, type } = makeSearch();
+        // selection is terminal: Reka sets the model to the chosen text afterward
+        search.onSelect({ id: 'a', text: 'solar batteries' });
+        await type('solar batteries');
+        vi.advanceTimersByTime(DELAY * 2);
+        expect(emitComplete).not.toHaveBeenCalled();
+
+        // ...but the suppression is one-shot: typing again fetches normally
+        await type('solar batteries plus');
+        vi.advanceTimersByTime(DELAY);
+        expect(emitComplete).toHaveBeenCalledWith('solar batteries plus');
+    });
+
+    it('submit cancels a pending complete so a late response cannot arrive after', async () => {
+        const { emitComplete, emitSubmit, search, type } = makeSearch();
+        await type('solar');
+        search.onSubmit('solar');
+        vi.advanceTimersByTime(DELAY * 2);
+        expect(emitSubmit).toHaveBeenCalledWith('solar');
+        expect(emitComplete).not.toHaveBeenCalled();
+    });
+
+    it('unmount cancels a pending complete', async () => {
+        const { app, emitComplete, type } = makeSearch();
+        await type('solar');
+        app.unmount();
+        vi.advanceTimersByTime(DELAY * 2);
+        expect(emitComplete).not.toHaveBeenCalled();
+    });
+});
+
+describe('useAutocompleteSearch panel message and suggestion gating', () => {
+    it('walks prompt → results → no-results → prompt-while-pending correctly', async () => {
+        const { search, suggestions, type } = makeSearch();
+        // nothing searched yet
+        expect(search.panelMessage.value).toBe('Type for suggestions');
+
+        // results arrive: no message
+        await type('solar');
+        suggestions.value = [{ id: 'a', text: 'solar batteries' }];
+        await nextTick();
+        expect(search.panelMessage.value).toBe('');
+
+        // a search came back empty: no-results
+        await type('solarx');
+        suggestions.value = [];
+        await nextTick();
+        expect(search.panelMessage.value).toBe('No results found');
+
+        // the query changed again, so a new search is pending: prompt, not the
+        // previous query's stale no-results
+        await type('solarxy');
+        expect(search.panelMessage.value).toBe('Type for suggestions');
+    });
+
+    it('gates suggestions below minChars with a referentially stable empty list', async () => {
+        const { search, suggestions, type } = makeSearch({ minChars: 3 });
+        suggestions.value = [{ id: 'a', text: 'solar batteries' }];
+        await type('so');
+        const first = search.effectiveSuggestions.value;
+        expect(first).toHaveLength(0);
+        await type('s');
+        // same reference: downstream watchers must not re-fire per keystroke
+        expect(search.effectiveSuggestions.value).toBe(first);
+
+        await type('sol');
+        expect(search.effectiveSuggestions.value).toHaveLength(1);
+    });
+});

--- a/es-ds-components/app/composables/autocomplete-search.ts
+++ b/es-ds-components/app/composables/autocomplete-search.ts
@@ -1,0 +1,119 @@
+import type { Ref } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+
+interface AutocompleteSearchOptions {
+    delay: () => number;
+    emitComplete: (query: string) => void;
+    emitSelect: (suggestion: EsAutocompleteSuggestion) => void;
+    emitSubmit: (query: string) => void;
+    minChars: () => number;
+    model: Ref<string>;
+    noResultsText: () => string;
+    promptText: () => string;
+    suggestions: () => EsAutocompleteSuggestion[];
+}
+
+// the shared constant keeps effectiveSuggestions referentially stable across
+// keystrokes below minChars, so downstream watchers don't re-fire for an
+// unchanged empty list
+const EMPTY_SUGGESTIONS: EsAutocompleteSuggestion[] = [];
+
+/**
+ * The search state behind es-autocomplete.vue: the debounced 'complete' contract
+ * (one emission per typing pause, suppressed after selection, cancelled by every
+ * terminal path so a late-arriving response can never reopen the panel), the
+ * minChars gate, and the prompt/no-results empty-state messaging. Extracted from
+ * the component so this contract is unit-testable without a component mount.
+ */
+export function useAutocompleteSearch(options: AutocompleteSearchOptions) {
+    const { model } = options;
+
+    // pass an empty list below minChars so no suggestions show for too-short queries
+    const effectiveSuggestions = computed(() => {
+        if (model.value.trim().length < options.minChars()) {
+            return EMPTY_SUGGESTIONS;
+        }
+        return options.suggestions();
+    });
+
+    // one cancellable handle for the debounced 'complete': every terminal path
+    // (selection, submit, short query, unmount) cancels through the same place
+    let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+    function cancelPendingComplete() {
+        if (searchTimeout) {
+            clearTimeout(searchTimeout);
+            searchTimeout = null;
+        }
+    }
+    function scheduleComplete(query: string) {
+        cancelPendingComplete();
+        searchTimeout = setTimeout(() => {
+            options.emitComplete(query);
+        }, options.delay());
+    }
+
+    let lastSelectedText: string | null = null;
+
+    // whether the app's most recent suggestions update was empty — this is what
+    // distinguishes "search found nothing" (show noResultsText) from "no search
+    // has answered yet" (show promptText)
+    const noResults = ref(false);
+    watch(
+        options.suggestions,
+        (list) => {
+            noResults.value = list.length === 0;
+        },
+        // depth 1 so apps that mutate the array in place (push/splice) are seen too
+        { deep: 1 },
+    );
+
+    // what an open panel shows when there are no suggestions to render: the
+    // no-results message once a search has actually come back empty, otherwise
+    // the prompt (nothing searched yet, or the query is below minChars)
+    const queryLongEnough = computed(() => model.value.trim().length >= options.minChars());
+    const panelMessage = computed(() => {
+        if (effectiveSuggestions.value.length) {
+            return '';
+        }
+        return noResults.value && queryLongEnough.value ? options.noResultsText() : options.promptText();
+    });
+
+    watch(model, (newValue) => {
+        cancelPendingComplete();
+        // selecting a suggestion copies its text into the input; that change is
+        // terminal and must not trigger another fetch
+        if (lastSelectedText !== null && newValue === lastSelectedText) {
+            lastSelectedText = null;
+            return;
+        }
+        lastSelectedText = null;
+        const query = newValue.trim();
+        if (query.length < options.minChars()) {
+            // a fresh (or cleared) query starts from the prompt state, not a stale
+            // "no results" from the previous query
+            noResults.value = false;
+            return;
+        }
+        // the edited query's search is now pending: show promptText, not the
+        // previous query's "no results", until the app answers via the
+        // suggestions prop
+        noResults.value = false;
+        scheduleComplete(query);
+    });
+
+    onUnmounted(cancelPendingComplete);
+
+    function onSelect(suggestion: EsAutocompleteSuggestion) {
+        lastSelectedText = suggestion.text;
+        options.emitSelect(suggestion);
+    }
+
+    function onSubmit(query: string) {
+        // submitting is terminal for this query
+        cancelPendingComplete();
+        options.emitSubmit(query);
+    }
+
+    return { effectiveSuggestions, onSelect, onSubmit, panelMessage };
+}

--- a/es-ds-components/app/composables/autocomplete-shell.test.ts
+++ b/es-ds-components/app/composables/autocomplete-shell.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { nextTick, ref } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+import { useAutocompleteShell } from './autocomplete-shell';
+
+function makeShell() {
+    const inputEl = document.createElement('input');
+    document.body.append(inputEl);
+    const contentEl = ref<HTMLElement | null>(document.createElement('div'));
+    const model = ref('solar');
+    const suggestions = ref<EsAutocompleteSuggestion[]>([{ id: 'a', text: 'solar batteries' }]);
+    const close = vi.fn();
+    const emitSelect = vi.fn();
+    const emitSubmit = vi.fn();
+    const shell = useAutocompleteShell({
+        close,
+        contentEl,
+        emitSelect,
+        emitSubmit,
+        inputRef: ref({ $el: inputEl }) as unknown as Ref<ComponentPublicInstance | null>,
+        model,
+        suggestions: () => suggestions.value,
+    });
+    return { close, contentEl, emitSelect, emitSubmit, inputEl, model, shell, suggestions };
+}
+
+/** a keydown Enter as the shells' capture handler receives it */
+function enterEvent(target: EventTarget, init: { isComposing?: boolean } = {}) {
+    const event = {
+        isComposing: init.isComposing ?? false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target,
+    };
+    return event as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+}
+
+function highlightAnItem(contentEl: Ref<HTMLElement | null>) {
+    const item = document.createElement('div');
+    item.setAttribute('data-highlighted', '');
+    contentEl.value!.append(item);
+    return item;
+}
+
+describe('useAutocompleteShell onEnterKey', () => {
+    it('submits the typed query and closes when nothing is highlighted', () => {
+        const { close, emitSubmit, inputEl, shell } = makeShell();
+        const event = enterEvent(inputEl);
+        shell.onEnterKey(event);
+        expect(emitSubmit).toHaveBeenCalledWith('solar');
+        expect(close).toHaveBeenCalled();
+        // keeps a surrounding <form> from natively submitting, and keeps Reka
+        // from acting on the same keystroke
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('submits even when an item is highlighted, if the user did not create the highlight', () => {
+        // Reka auto-highlights the first item when results arrive — Enter on an
+        // auto-highlight must submit, not select
+        const { contentEl, emitSubmit, inputEl, shell } = makeShell();
+        highlightAnItem(contentEl);
+        shell.onEnterKey(enterEvent(inputEl));
+        expect(emitSubmit).toHaveBeenCalledWith('solar');
+    });
+
+    it('lets the event through to Reka (selection) for a user-created highlight', () => {
+        const { close, contentEl, emitSubmit, inputEl, shell } = makeShell();
+        highlightAnItem(contentEl);
+        shell.markUserHighlight();
+        const event = enterEvent(inputEl);
+        shell.onEnterKey(event);
+        expect(emitSubmit).not.toHaveBeenCalled();
+        expect(close).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
+
+    it('a user highlight no longer counts once the suggestion list changes', async () => {
+        const { contentEl, emitSubmit, inputEl, shell, suggestions } = makeShell();
+        highlightAnItem(contentEl);
+        shell.markUserHighlight();
+        suggestions.value = [{ id: 'b', text: 'solar financing' }];
+        await nextTick();
+        shell.onEnterKey(enterEvent(inputEl));
+        expect(emitSubmit).toHaveBeenCalledWith('solar');
+    });
+
+    it('ignores the Enter that commits an IME composition', () => {
+        const { close, emitSubmit, inputEl, shell } = makeShell();
+        shell.onEnterKey(enterEvent(inputEl, { isComposing: true }));
+        expect(emitSubmit).not.toHaveBeenCalled();
+        expect(close).not.toHaveBeenCalled();
+    });
+
+    it('ignores Enter that did not originate from the input (e.g. the clear button)', () => {
+        const { close, emitSubmit, shell } = makeShell();
+        const clearButton = document.createElement('button');
+        const event = enterEvent(clearButton);
+        shell.onEnterKey(event);
+        expect(emitSubmit).not.toHaveBeenCalled();
+        expect(close).not.toHaveBeenCalled();
+        // the button's own click-on-Enter must still fire
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+});
+
+describe('useAutocompleteShell selection and clearing', () => {
+    it('onSelect closes the shell and emits the full suggestion', () => {
+        const { close, emitSelect, shell } = makeShell();
+        const suggestion = { id: 'a', text: 'solar batteries', value: { anything: true } };
+        shell.onSelect(suggestion);
+        expect(close).toHaveBeenCalled();
+        expect(emitSelect).toHaveBeenCalledWith(suggestion);
+    });
+
+    it('onClear empties the model and refocuses the input', () => {
+        const { inputEl, model, shell } = makeShell();
+        shell.onClear();
+        expect(model.value).toBe('');
+        expect(document.activeElement).toBe(inputEl);
+    });
+});

--- a/es-ds-components/app/composables/autocomplete-shell.ts
+++ b/es-ds-components/app/composables/autocomplete-shell.ts
@@ -1,0 +1,90 @@
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { ref, watch } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+
+interface AutocompleteShellOptions {
+    /** close this shell's panel/takeover */
+    close: () => void;
+    contentEl: Ref<HTMLElement | null>;
+    emitSelect: (suggestion: EsAutocompleteSuggestion) => void;
+    emitSubmit: (query: string) => void;
+    inputRef: Ref<ComponentPublicInstance | null>;
+    model: Ref<string | undefined>;
+    suggestions: () => EsAutocompleteSuggestion[];
+}
+
+/**
+ * Interaction logic shared by the desktop popover and mobile takeover shells:
+ * Enter-key semantics, selection, clearing, and tracking whether the current
+ * highlight was created by the user.
+ */
+export function useAutocompleteShell(options: AutocompleteShellOptions) {
+    // Reka auto-highlights the first item whenever results arrive from an empty
+    // list, which is NOT a user choice — Enter must submit the typed query then,
+    // not select. Only a highlight the user created (arrow keys or pointer
+    // movement over the list) makes Enter select. Reset whenever the list content
+    // changes or the shell reopens (shells call resetUserHighlight for the latter).
+    const userHighlighted = ref(false);
+    watch(
+        () => {
+            return options
+                .suggestions()
+                .map((suggestion) => suggestion.id)
+                .join('\n');
+        },
+        () => {
+            userHighlighted.value = false;
+        },
+    );
+
+    function markUserHighlight() {
+        userHighlighted.value = true;
+    }
+
+    function resetUserHighlight() {
+        userHighlighted.value = false;
+    }
+
+    function focusInput() {
+        (options.inputRef.value?.$el as HTMLElement | undefined)?.focus();
+    }
+
+    // runs in the capture phase on the anchor, ahead of Reka's input-level handler
+    function onEnterKey(event: KeyboardEvent) {
+        // only Enter from the input itself submits — Enter on the clear button
+        // (also inside the anchor) is a click and must reach the button
+        if (event.target !== options.inputRef.value?.$el) {
+            return;
+        }
+        // the Enter that commits an IME composition (Japanese/Chinese/Korean
+        // input) is not a submit
+        if (event.isComposing) {
+            return;
+        }
+        // highlight checked via the DOM rather than Reka's exposed
+        // highlightedElement, which can hold a stale (detached) element after
+        // the list re-renders
+        if (userHighlighted.value && options.contentEl.value?.querySelector('[data-highlighted]')) {
+            // let the event through to Reka, which selects the highlighted item
+            return;
+        }
+        // keep Reka from selecting an auto-highlighted item the user never chose,
+        // and keep a surrounding <form> from natively submitting
+        event.preventDefault();
+        event.stopPropagation();
+        options.close();
+        options.emitSubmit(options.model.value ?? '');
+    }
+
+    function onSelect(suggestion: EsAutocompleteSuggestion) {
+        options.close();
+        options.emitSelect(suggestion);
+    }
+
+    function onClear() {
+        options.model.value = '';
+        focusInput();
+    }
+
+    return { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight };
+}

--- a/es-ds-components/app/composables/autocomplete-shell.ts
+++ b/es-ds-components/app/composables/autocomplete-shell.ts
@@ -9,7 +9,7 @@ interface AutocompleteShellOptions {
     emitSelect: (suggestion: EsAutocompleteSuggestion) => void;
     emitSubmit: (query: string) => void;
     inputRef: Ref<ComponentPublicInstance | null>;
-    model: Ref<string | undefined>;
+    model: Ref<string>;
     suggestions: () => EsAutocompleteSuggestion[];
 }
 
@@ -73,7 +73,7 @@ export function useAutocompleteShell(options: AutocompleteShellOptions) {
         event.preventDefault();
         event.stopPropagation();
         options.close();
-        options.emitSubmit(options.model.value ?? '');
+        options.emitSubmit(options.model.value);
     }
 
     function onSelect(suggestion: EsAutocompleteSuggestion) {

--- a/es-ds-components/app/composables/autocomplete-shell.ts
+++ b/es-ds-components/app/composables/autocomplete-shell.ts
@@ -86,5 +86,5 @@ export function useAutocompleteShell(options: AutocompleteShellOptions) {
         focusInput();
     }
 
-    return { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight };
+    return { markUserHighlight, onClear, onEnterKey, onSelect, resetUserHighlight, userHighlighted };
 }

--- a/es-ds-components/app/composables/fit-to-viewport.test.ts
+++ b/es-ds-components/app/composables/fit-to-viewport.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, nextTick, ref } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+import { useFitToViewport } from './fit-to-viewport';
+
+// NOTE: happy-dom has no real layout, so element geometry (offsetTop,
+// offsetHeight, clientHeight) is mocked per element. These tests cover the
+// counting/limit LOGIC — which items fit, what counts as an item, the min-1
+// floor, and which height constraint wins. Whether real browser layout produces
+// that geometry is covered by the planned Playwright specs (plan §8a).
+
+const apps: App[] = [];
+afterEach(() => {
+    apps.forEach((app) => app.unmount());
+    apps.length = 0;
+    document.body.innerHTML = '';
+});
+
+/** run a composable inside a real component so lifecycle hooks work */
+function withSetup<T>(composable: () => T): T {
+    let result!: T;
+    const app = createApp({
+        setup() {
+            result = composable();
+            return () => null;
+        },
+    });
+    app.mount(document.createElement('div'));
+    apps.push(app);
+    return result;
+}
+
+function suggestionList(count: number): EsAutocompleteSuggestion[] {
+    return Array.from({ length: count }, (_, index) => ({ id: `s${index}`, text: `suggestion ${index}` }));
+}
+
+interface FakeChild {
+    height: number;
+    isItem?: boolean;
+    top: number;
+}
+
+function makeContainer(children: FakeChild[], size: { clientHeight?: number; maxHeight?: number }) {
+    const container = document.createElement('div');
+    // happy-dom only resolves computed styles (the max-height limit) for
+    // elements attached to the document
+    document.body.append(container);
+    if (size.maxHeight !== undefined) {
+        container.style.maxHeight = `${size.maxHeight}px`;
+    }
+    Object.defineProperty(container, 'clientHeight', {
+        configurable: true,
+        get: () => size.clientHeight ?? 0,
+    });
+    for (const child of children) {
+        const el = document.createElement('div');
+        if (child.isItem ?? true) {
+            el.dataset.esAutocompleteItem = '';
+        }
+        Object.defineProperty(el, 'offsetTop', { configurable: true, value: child.top });
+        Object.defineProperty(el, 'offsetHeight', { configurable: true, value: child.height });
+        container.append(el);
+    }
+    return container;
+}
+
+/** 30px rows stacked from the top */
+function rows(count: number): FakeChild[] {
+    return Array.from({ length: count }, (_, index) => ({ height: 30, top: index * 30 }));
+}
+
+describe('useFitToViewport', () => {
+    it('trims to only the items that fully fit the height limit', async () => {
+        const contentEl = ref<HTMLElement | null>(makeContainer(rows(7), { maxHeight: 100 }));
+        const suggestions = ref(suggestionList(7));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        // rows at 0, 30, 60 fit within 100; the row ending at 120 does not
+        expect(fit.visibleSuggestions.value).toHaveLength(3);
+        expect(fit.measured.value).toBe(true);
+    });
+
+    it('never trims below one item, even when nothing fully fits', async () => {
+        const contentEl = ref<HTMLElement | null>(makeContainer([{ height: 200, top: 0 }], { maxHeight: 100 }));
+        const suggestions = ref(suggestionList(5));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        expect(fit.visibleSuggestions.value).toHaveLength(1);
+    });
+
+    it('non-item children consume space but are not counted, and stop the walk when they overflow', async () => {
+        const children: FakeChild[] = [
+            { height: 30, top: 0 },
+            { height: 10, isItem: false, top: 30 }, // e.g. the no-results/message div
+            { height: 30, top: 40 },
+            { height: 40, top: 70 }, // ends at 110 — does not fit
+        ];
+        const contentEl = ref<HTMLElement | null>(makeContainer(children, { maxHeight: 100 }));
+        const suggestions = ref(suggestionList(3));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        expect(fit.visibleSuggestions.value).toHaveLength(2);
+    });
+
+    it('prefers the resolved max-height over the content-sized clientHeight', async () => {
+        // clientHeight is content-limited (40) but max-height allows 100: the trim
+        // must measure against what COULD fit, or a grown viewport never refills
+        const contentEl = ref<HTMLElement | null>(makeContainer(rows(5), { clientHeight: 40, maxHeight: 100 }));
+        const suggestions = ref(suggestionList(5));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        expect(fit.visibleSuggestions.value).toHaveLength(3);
+    });
+
+    it('falls back to clientHeight when there is no max-height (the mobile takeover list)', async () => {
+        const contentEl = ref<HTMLElement | null>(makeContainer(rows(5), { clientHeight: 70 }));
+        const suggestions = ref(suggestionList(5));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        expect(fit.visibleSuggestions.value).toHaveLength(2);
+    });
+
+    it('re-measures when the suggestions change', async () => {
+        const container = makeContainer(rows(7), { maxHeight: 100 });
+        const contentEl = ref<HTMLElement | null>(container);
+        const suggestions = ref(suggestionList(7));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        await fit.remeasure();
+        expect(fit.visibleSuggestions.value).toHaveLength(3);
+
+        container.style.maxHeight = '70px';
+        suggestions.value = suggestionList(7);
+        await nextTick(); // the watcher fires
+        await nextTick(); // remeasure's internal tick
+        expect(fit.visibleSuggestions.value).toHaveLength(2);
+    });
+
+    it('is unmeasured (list hidden) until a container exists', async () => {
+        const contentEl = ref<HTMLElement | null>(null);
+        const suggestions = ref(suggestionList(3));
+        const fit = withSetup(() => useFitToViewport(contentEl, suggestions, 10));
+        expect(fit.measured.value).toBe(false);
+
+        contentEl.value = makeContainer(rows(3), { maxHeight: 100 });
+        await nextTick(); // the watcher fires
+        await nextTick(); // remeasure's internal tick
+        expect(fit.measured.value).toBe(true);
+        expect(fit.visibleSuggestions.value).toHaveLength(3);
+    });
+});

--- a/es-ds-components/app/composables/fit-to-viewport.ts
+++ b/es-ds-components/app/composables/fit-to-viewport.ts
@@ -1,0 +1,99 @@
+import type { Ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import type { EsAutocompleteSuggestion } from '../types';
+
+/**
+ * Measure-then-trim: render up to `cap` suggestions, then trim the list to only the
+ * items that fully fit within the container, so the list never scrolls and never
+ * clips an item mid-row. Items may wrap to multiple lines, so heights are measured,
+ * not assumed.
+ *
+ * The container must be `position: relative` with `overflow: hidden` — item fit is
+ * computed from `offsetTop`, which must be relative to the container.
+ */
+export function useFitToViewport(
+    contentEl: Ref<HTMLElement | null>,
+    suggestions: Ref<EsAutocompleteSuggestion[]>,
+    cap: number,
+) {
+    const visibleCount = ref(cap);
+    const measured = ref(false);
+
+    let resizeObserver: ResizeObserver | null = null;
+    // trimming itself changes the container height, which re-fires the ResizeObserver;
+    // these guards keep that feedback from becoming an endless measure loop
+    let settledHeight = -1;
+    let measuring = false;
+    let pending = false;
+
+    async function runMeasure() {
+        visibleCount.value = cap;
+        await nextTick();
+        const el = contentEl.value;
+        if (!el) {
+            measured.value = false;
+            return;
+        }
+        const limit = el.clientHeight;
+        let fits = 0;
+        for (const child of Array.from(el.children) as HTMLElement[]) {
+            // stop at the first child (item or separator) that does not fully fit
+            if (child.offsetTop + child.offsetHeight > limit) {
+                break;
+            }
+            if ('esAutocompleteItem' in child.dataset) {
+                fits += 1;
+            }
+        }
+        visibleCount.value = Math.max(fits, 1);
+        await nextTick();
+        settledHeight = contentEl.value?.clientHeight ?? -1;
+        measured.value = true;
+    }
+
+    async function remeasure() {
+        if (measuring) {
+            pending = true;
+            return;
+        }
+        measuring = true;
+        do {
+            pending = false;
+            await runMeasure();
+        } while (pending);
+        measuring = false;
+    }
+
+    watch(contentEl, (el) => {
+        resizeObserver?.disconnect();
+        resizeObserver = null;
+        if (el) {
+            if (typeof ResizeObserver !== 'undefined') {
+                resizeObserver = new ResizeObserver(() => {
+                    if (!measuring && contentEl.value && contentEl.value.clientHeight !== settledHeight) {
+                        remeasure();
+                    }
+                });
+                resizeObserver.observe(el);
+            }
+            remeasure();
+        } else {
+            measured.value = false;
+        }
+    });
+
+    watch(suggestions, () => {
+        if (contentEl.value) {
+            remeasure();
+        }
+    });
+
+    onBeforeUnmount(() => {
+        resizeObserver?.disconnect();
+        resizeObserver = null;
+    });
+
+    const visibleSuggestions = computed(() => suggestions.value.slice(0, visibleCount.value));
+
+    return { measured, remeasure, visibleSuggestions };
+}

--- a/es-ds-components/app/composables/fit-to-viewport.ts
+++ b/es-ds-components/app/composables/fit-to-viewport.ts
@@ -62,11 +62,16 @@ export function useFitToViewport(
         }
     });
 
-    watch(suggestions, () => {
-        if (contentEl.value) {
-            remeasure();
-        }
-    });
+    watch(
+        suggestions,
+        () => {
+            if (contentEl.value) {
+                remeasure();
+            }
+        },
+        // depth 1 so apps that mutate the array in place (push/splice) are seen too
+        { deep: 1 },
+    );
 
     // available height tracks the viewport; re-measure when it changes, deferred a
     // frame so the popper's own resize handling updates the max-height constraint

--- a/es-ds-components/app/composables/fit-to-viewport.ts
+++ b/es-ds-components/app/composables/fit-to-viewport.ts
@@ -9,7 +9,14 @@ import type { EsAutocompleteSuggestion } from '../types';
  * not assumed.
  *
  * The container must be `position: relative` with `overflow: hidden` — item fit is
- * computed from `offsetTop`, which must be relative to the container.
+ * computed from `offsetTop`, which must be relative to the container. The height
+ * limit is read from the container's resolved max-height (the desktop popover) or
+ * its explicit height (the mobile takeover list); both are stable while items
+ * render, so measuring is idempotent and needs no re-entrancy guards.
+ *
+ * Re-measures on suggestion changes and window resizes; callers whose container
+ * height changes by other means (e.g. the mobile visualViewport keyboard handling)
+ * call the returned `remeasure` themselves.
  */
 export function useFitToViewport(
     contentEl: Ref<HTMLElement | null>,
@@ -19,25 +26,23 @@ export function useFitToViewport(
     const visibleCount = ref(cap);
     const measured = ref(false);
 
-    let resizeObserver: ResizeObserver | null = null;
-    // trimming itself changes the container height, which re-fires the ResizeObserver;
-    // these guards keep that feedback from becoming an endless measure loop
-    let settledHeight = -1;
-    let measuring = false;
-    let pending = false;
+    function heightLimit(element: HTMLElement): number {
+        const maxHeight = Number.parseFloat(getComputedStyle(element).maxHeight);
+        return Number.isFinite(maxHeight) ? maxHeight : element.clientHeight;
+    }
 
-    async function runMeasure() {
+    async function remeasure() {
         visibleCount.value = cap;
         await nextTick();
-        const el = contentEl.value;
-        if (!el) {
+        const element = contentEl.value;
+        if (!element) {
             measured.value = false;
             return;
         }
-        const limit = el.clientHeight;
+        const limit = heightLimit(element);
         let fits = 0;
-        for (const child of Array.from(el.children) as HTMLElement[]) {
-            // stop at the first child (item or separator) that does not fully fit
+        for (const child of Array.from(element.children) as HTMLElement[]) {
+            // stop at the first child that does not fully fit
             if (child.offsetTop + child.offsetHeight > limit) {
                 break;
             }
@@ -46,36 +51,11 @@ export function useFitToViewport(
             }
         }
         visibleCount.value = Math.max(fits, 1);
-        await nextTick();
-        settledHeight = contentEl.value?.clientHeight ?? -1;
         measured.value = true;
     }
 
-    async function remeasure() {
-        if (measuring) {
-            pending = true;
-            return;
-        }
-        measuring = true;
-        do {
-            pending = false;
-            await runMeasure();
-        } while (pending);
-        measuring = false;
-    }
-
-    watch(contentEl, (el) => {
-        resizeObserver?.disconnect();
-        resizeObserver = null;
-        if (el) {
-            if (typeof ResizeObserver !== 'undefined') {
-                resizeObserver = new ResizeObserver(() => {
-                    if (!measuring && contentEl.value && contentEl.value.clientHeight !== settledHeight) {
-                        remeasure();
-                    }
-                });
-                resizeObserver.observe(el);
-            }
+    watch(contentEl, (element) => {
+        if (element) {
             remeasure();
         } else {
             measured.value = false;
@@ -88,10 +68,9 @@ export function useFitToViewport(
         }
     });
 
-    // the ResizeObserver watches the container, whose height the trim itself
-    // controls — so when the available height GROWS, a trimmed container never
-    // resizes and the observer stays silent. Window resizes re-measure directly
-    // so the list can grow back after the viewport gets taller.
+    // available height tracks the viewport; re-measure when it changes, deferred a
+    // frame so the popper's own resize handling updates the max-height constraint
+    // first (also coalesces resize-event bursts to one measure per frame)
     let resizeFrame: number | null = null;
     function onWindowResize() {
         if (!contentEl.value) {
@@ -100,9 +79,6 @@ export function useFitToViewport(
         if (resizeFrame !== null) {
             cancelAnimationFrame(resizeFrame);
         }
-        // wait a frame so the popper's own resize handling has updated the
-        // available-height constraint before we measure against it (also
-        // coalesces resize-event bursts to one measure per frame)
         resizeFrame = requestAnimationFrame(() => {
             resizeFrame = null;
             remeasure();
@@ -115,8 +91,9 @@ export function useFitToViewport(
 
     onBeforeUnmount(() => {
         window.removeEventListener('resize', onWindowResize);
-        resizeObserver?.disconnect();
-        resizeObserver = null;
+        if (resizeFrame !== null) {
+            cancelAnimationFrame(resizeFrame);
+        }
     });
 
     const visibleSuggestions = computed(() => suggestions.value.slice(0, visibleCount.value));

--- a/es-ds-components/app/composables/fit-to-viewport.ts
+++ b/es-ds-components/app/composables/fit-to-viewport.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue';
-import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { EsAutocompleteSuggestion } from '../types';
 
 /**
@@ -88,7 +88,33 @@ export function useFitToViewport(
         }
     });
 
+    // the ResizeObserver watches the container, whose height the trim itself
+    // controls — so when the available height GROWS, a trimmed container never
+    // resizes and the observer stays silent. Window resizes re-measure directly
+    // so the list can grow back after the viewport gets taller.
+    let resizeFrame: number | null = null;
+    function onWindowResize() {
+        if (!contentEl.value) {
+            return;
+        }
+        if (resizeFrame !== null) {
+            cancelAnimationFrame(resizeFrame);
+        }
+        // wait a frame so the popper's own resize handling has updated the
+        // available-height constraint before we measure against it (also
+        // coalesces resize-event bursts to one measure per frame)
+        resizeFrame = requestAnimationFrame(() => {
+            resizeFrame = null;
+            remeasure();
+        });
+    }
+
+    onMounted(() => {
+        window.addEventListener('resize', onWindowResize);
+    });
+
     onBeforeUnmount(() => {
+        window.removeEventListener('resize', onWindowResize);
         resizeObserver?.disconnect();
         resizeObserver = null;
     });

--- a/es-ds-components/app/types/es-autocomplete.ts
+++ b/es-ds-components/app/types/es-autocomplete.ts
@@ -1,0 +1,11 @@
+export interface EsAutocompleteSuggestion {
+    id: string;
+    /** full suggested query, e.g. "backpack rain cover" */
+    text: string;
+    /** present only for category-scoped suggestions, e.g. { label: 'in Outdoor Gear' } */
+    scope?: {
+        label: string;
+    };
+    /** opaque app payload, returned untouched on select */
+    value?: unknown;
+}

--- a/es-ds-components/app/types/es-autocomplete.ts
+++ b/es-ds-components/app/types/es-autocomplete.ts
@@ -8,10 +8,6 @@ export interface EsAutocompleteSuggestion {
     id: string;
     /** full suggested query, e.g. "backpack rain cover" */
     text: string;
-    /** present only for category-scoped suggestions, e.g. { label: 'in Outdoor Gear' } */
-    scope?: {
-        label: string;
-    };
     /** opaque app payload, returned untouched on select */
     value?: unknown;
 }

--- a/es-ds-components/app/types/es-autocomplete.ts
+++ b/es-ds-components/app/types/es-autocomplete.ts
@@ -1,3 +1,9 @@
+export interface EsAutocompleteTextSegment {
+    /** true when this is text the suggestion would add beyond the typed query — render it bold */
+    predictive: boolean;
+    text: string;
+}
+
 export interface EsAutocompleteSuggestion {
     id: string;
     /** full suggested query, e.g. "backpack rain cover" */

--- a/es-ds-components/app/types/index.ts
+++ b/es-ds-components/app/types/index.ts
@@ -1,1 +1,2 @@
+export type * from './es-autocomplete';
 export type * from './es-carousel';

--- a/es-ds-components/app/utils/autocomplete.test.ts
+++ b/es-ds-components/app/utils/autocomplete.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { EsAutocompleteTextSegment } from '../types';
+import { splitAutocompleteText, splitAutocompleteTextLines } from './autocomplete';
+
+// matched (typed) portions render regular; predictive portions render bold
+const regular = (text: string): EsAutocompleteTextSegment => ({ predictive: false, text });
+const bold = (text: string): EsAutocompleteTextSegment => ({ predictive: true, text });
+
+/** segments must always reconstruct the input exactly — no lost or duplicated characters */
+function expectReconstructs(text: string, segments: EsAutocompleteTextSegment[]) {
+    expect(segments.map((segment) => segment.text).join('')).toBe(text);
+}
+
+describe('splitAutocompleteText', () => {
+    it('bolds the predictive remainder of a prefix match', () => {
+        expect(splitAutocompleteText('solar batteries', 'solar')).toEqual([regular('solar'), bold(' batteries')]);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(splitAutocompleteText('Solar Batteries', 'SOLAR')).toEqual([regular('Solar'), bold(' Batteries')]);
+    });
+
+    it('matches tokens in any order, at every word start', () => {
+        expect(splitAutocompleteText('123 Main St, Boston, MA', 'boston main')).toEqual([
+            bold('123 '),
+            regular('Main'),
+            bold(' St, '),
+            regular('Boston'),
+            bold(', MA'),
+        ]);
+    });
+
+    it('prefers word starts: "st" matches "St" but not the middle of "Boston"', () => {
+        expect(splitAutocompleteText('Boston St', 'st')).toEqual([bold('Boston '), regular('St')]);
+    });
+
+    it('falls back to mid-word matching when a token never matches at a word start', () => {
+        expect(splitAutocompleteText('123 Main St', '3')).toEqual([bold('12'), regular('3'), bold(' Main St')]);
+    });
+
+    it('renders everything regular when nothing matches, and for a blank query', () => {
+        expect(splitAutocompleteText('solar panels', 'xyz')).toEqual([regular('solar panels')]);
+        expect(splitAutocompleteText('solar panels', '  ')).toEqual([regular('solar panels')]);
+    });
+
+    it('merges overlapping token matches', () => {
+        expect(splitAutocompleteText('solar panels', 'solar sol')).toEqual([regular('solar'), bold(' panels')]);
+    });
+
+    it('never mis-slices when lowercasing changes string length (e.g. İ)', () => {
+        const text = 'İzmir solar';
+        const segments = splitAutocompleteText(text, 'solar');
+        expectReconstructs(text, segments);
+        expect(segments).toContainEqual(regular('solar'));
+    });
+
+    it('always reconstructs the input text exactly', () => {
+        const cases: Array<[string, string]> = [
+            ['solar batteries', 'solar'],
+            ['123 Main St', 'main 123 st'],
+            ['heat pump water heater', 'heat'],
+            ['no match here', 'zzz'],
+            ['', 'anything'],
+        ];
+        for (const [text, query] of cases) {
+            expectReconstructs(text, splitAutocompleteText(text, query));
+        }
+    });
+});
+
+describe('splitAutocompleteTextLines', () => {
+    const addressLines = ['1200 Beacon St', 'Brookline, MA 02446'];
+
+    it('highlights tokens on the lines they match', () => {
+        expect(splitAutocompleteTextLines(['123 Main St', 'Boston, MA 02108'], 'boston main')).toEqual([
+            [bold('123 '), regular('Main'), bold(' St')],
+            [regular('Boston'), bold(', MA 02108')],
+        ]);
+    });
+
+    it('bolds a whole line without its own match when another line matched (bolding mode)', () => {
+        expect(splitAutocompleteTextLines(addressLines, 'beacon')).toEqual([
+            [bold('1200 '), regular('Beacon'), bold(' St')],
+            [bold('Brookline, MA 02446')],
+        ]);
+    });
+
+    it('renders every line regular when no line matches', () => {
+        expect(splitAutocompleteTextLines(addressLines, 'zzz')).toEqual([
+            [regular('1200 Beacon St')],
+            [regular('Brookline, MA 02446')],
+        ]);
+    });
+
+    it('decides the word-start fallback across all lines together', () => {
+        // "st" has a word-start match on line 1, so it must NOT fall back to
+        // mid-word matching inside "Brookline" on line 2
+        expect(splitAutocompleteTextLines(addressLines, 'beacon st')).toEqual([
+            [bold('1200 '), regular('Beacon'), bold(' '), regular('St')],
+            [bold('Brookline, MA 02446')],
+        ]);
+    });
+});

--- a/es-ds-components/app/utils/autocomplete.ts
+++ b/es-ds-components/app/utils/autocomplete.ts
@@ -1,0 +1,97 @@
+import type { EsAutocompleteTextSegment } from '../types';
+
+/**
+ * Split a line of text into segments for predictive bolding, the same way the
+ * default EsAutocomplete item renderer does. Matching is token-based, as in most
+ * typeahead libraries: the query is split on whitespace and every token is matched
+ * case-insensitively at word starts (all occurrences), so query terms may appear in
+ * any order — "boston main" highlights both "Main" in "123 Main St" and "Boston" in
+ * "Boston, MA 02108".
+ *
+ * Matched portions are non-predictive (render them regular — the user typed them);
+ * everything else is predictive (render it bold — what selecting would add):
+ *
+ *     <span
+ *         v-for="(segment, index) in splitAutocompleteText(line, query)"
+ *         :key="index"
+ *         :class="{ 'font-weight-bold': segment.predictive }">
+ *         {{ segment.text }}</span>
+ *
+ * When no token matches (or the query is blank), the whole text is returned as one
+ * non-predictive segment, so unmatched text renders regular rather than fully bold.
+ * This is presentation only — it never decides what matches, the app's suggestion
+ * source already did — so a backend match it cannot see (typo tolerance, synonyms)
+ * simply doesn't highlight. Apps whose search API returns its own match offsets
+ * (e.g. Google Places matched substrings) should build segments from those offsets
+ * in a custom `item` slot renderer instead.
+ */
+export function splitAutocompleteText(text: string, query: string): EsAutocompleteTextSegment[] {
+    return splitAutocompleteTextLines([text], query)[0]!;
+}
+
+/**
+ * Multi-line variant of splitAutocompleteText for suggestions rendered as several
+ * lines (or fields) that form one suggestion. Whether to bold is decided across all
+ * lines together: when no line matches any query token, every line renders regular;
+ * when any line matches, lines without a token match of their own are entirely
+ * predictive (bold) — they are part of what selecting adds, matching how the
+ * suggestion would render as a single joined string.
+ */
+export function splitAutocompleteTextLines(lines: string[], query: string): EsAutocompleteTextSegment[][] {
+    const tokens = [...new Set(query.trim().toLowerCase().split(/\s+/).filter(Boolean))];
+    const rangesPerLine = lines.map((line) => findTokenRanges(line, tokens));
+    const anyLineMatches = rangesPerLine.some((ranges) => ranges.length > 0);
+    return lines.map((line, lineIndex) => {
+        const ranges = rangesPerLine[lineIndex]!;
+        if (!ranges.length) {
+            return [{ predictive: anyLineMatches, text: line }];
+        }
+        return segmentsFromRanges(line, ranges);
+    });
+}
+
+/** merged [start, end) ranges of all word-start token matches within the text */
+function findTokenRanges(text: string, tokens: string[]): Array<[number, number]> {
+    const textLower = text.toLowerCase();
+    const isWordChar = (character: string | undefined) => !!character && /[\p{L}\p{N}]/u.test(character);
+
+    const ranges: Array<[number, number]> = [];
+    for (const token of tokens) {
+        let index = textLower.indexOf(token);
+        while (index !== -1) {
+            // word starts only: "st" matches the "St" in "Beacon St", not "Boston"
+            if (!isWordChar(textLower[index - 1])) {
+                ranges.push([index, index + token.length]);
+            }
+            index = textLower.indexOf(token, index + 1);
+        }
+    }
+
+    ranges.sort((a, b) => a[0] - b[0]);
+    const merged: Array<[number, number]> = [];
+    for (const range of ranges) {
+        const last = merged[merged.length - 1];
+        if (last && range[0] <= last[1]) {
+            last[1] = Math.max(last[1], range[1]);
+        } else {
+            merged.push([...range]);
+        }
+    }
+    return merged;
+}
+
+function segmentsFromRanges(text: string, ranges: Array<[number, number]>): EsAutocompleteTextSegment[] {
+    const segments: EsAutocompleteTextSegment[] = [];
+    let position = 0;
+    for (const [start, end] of ranges) {
+        if (start > position) {
+            segments.push({ predictive: true, text: text.slice(position, start) });
+        }
+        segments.push({ predictive: false, text: text.slice(start, end) });
+        position = end;
+    }
+    if (position < text.length) {
+        segments.push({ predictive: true, text: text.slice(position) });
+    }
+    return segments;
+}

--- a/es-ds-components/app/utils/autocomplete.ts
+++ b/es-ds-components/app/utils/autocomplete.ts
@@ -66,7 +66,12 @@ export function splitAutocompleteTextLines(lines: string[], query: string): EsAu
 
 /** [start, end) ranges where the token occurs within the text */
 function findTokenRanges(text: string, token: string, wordStartsOnly: boolean): Array<[number, number]> {
-    const textLower = text.toLowerCase();
+    // lowercasing can change string length for rare characters (e.g. İ, which
+    // lowercases to two code units), which would misalign match offsets against
+    // the original text — fall back to case-sensitive matching rather than
+    // mis-slice the segments
+    const lowered = text.toLowerCase();
+    const textLower = lowered.length === text.length ? lowered : text;
     const isWordChar = (character: string | undefined) => !!character && /[\p{L}\p{N}]/u.test(character);
 
     const ranges: Array<[number, number]> = [];

--- a/es-ds-components/app/utils/autocomplete.ts
+++ b/es-ds-components/app/utils/autocomplete.ts
@@ -4,9 +4,10 @@ import type { EsAutocompleteTextSegment } from '../types';
  * Split a line of text into segments for predictive bolding, the same way the
  * default EsAutocomplete item renderer does. Matching is token-based, as in most
  * typeahead libraries: the query is split on whitespace and every token is matched
- * case-insensitively at word starts (all occurrences), so query terms may appear in
- * any order — "boston main" highlights both "Main" in "123 Main St" and "Boston" in
- * "Boston, MA 02108".
+ * case-insensitively (all occurrences), so query terms may appear in any order —
+ * "boston main" highlights both "Main" in "123 Main St" and "Boston" in
+ * "Boston, MA 02108". Word-start matches are preferred; a token that never matches
+ * at a word start falls back to matching anywhere ("3" highlights within "123").
  *
  * Matched portions are non-predictive (render them regular — the user typed them);
  * everything else is predictive (render it bold — what selecting would add):
@@ -39,10 +40,23 @@ export function splitAutocompleteText(text: string, query: string): EsAutocomple
  */
 export function splitAutocompleteTextLines(lines: string[], query: string): EsAutocompleteTextSegment[][] {
     const tokens = [...new Set(query.trim().toLowerCase().split(/\s+/).filter(Boolean))];
-    const rangesPerLine = lines.map((line) => findTokenRanges(line, tokens));
-    const anyLineMatches = rangesPerLine.some((ranges) => ranges.length > 0);
+
+    // per token: prefer word-start matches ("st" matches the "St" in "Beacon St",
+    // not "Boston"); only when a token never matches at any word start, fall back
+    // to matching it anywhere (so "3" still highlights within "123")
+    const rangesPerLine: Array<Array<[number, number]>> = lines.map(() => []);
+    for (const token of tokens) {
+        const wordStartRanges = lines.map((line) => findTokenRanges(line, token, true));
+        const chosenRanges = wordStartRanges.some((ranges) => ranges.length > 0)
+            ? wordStartRanges
+            : lines.map((line) => findTokenRanges(line, token, false));
+        chosenRanges.forEach((ranges, lineIndex) => rangesPerLine[lineIndex]!.push(...ranges));
+    }
+
+    const mergedPerLine = rangesPerLine.map(mergeRanges);
+    const anyLineMatches = mergedPerLine.some((ranges) => ranges.length > 0);
     return lines.map((line, lineIndex) => {
-        const ranges = rangesPerLine[lineIndex]!;
+        const ranges = mergedPerLine[lineIndex]!;
         if (!ranges.length) {
             return [{ predictive: anyLineMatches, text: line }];
         }
@@ -50,23 +64,23 @@ export function splitAutocompleteTextLines(lines: string[], query: string): EsAu
     });
 }
 
-/** merged [start, end) ranges of all word-start token matches within the text */
-function findTokenRanges(text: string, tokens: string[]): Array<[number, number]> {
+/** [start, end) ranges where the token occurs within the text */
+function findTokenRanges(text: string, token: string, wordStartsOnly: boolean): Array<[number, number]> {
     const textLower = text.toLowerCase();
     const isWordChar = (character: string | undefined) => !!character && /[\p{L}\p{N}]/u.test(character);
 
     const ranges: Array<[number, number]> = [];
-    for (const token of tokens) {
-        let index = textLower.indexOf(token);
-        while (index !== -1) {
-            // word starts only: "st" matches the "St" in "Beacon St", not "Boston"
-            if (!isWordChar(textLower[index - 1])) {
-                ranges.push([index, index + token.length]);
-            }
-            index = textLower.indexOf(token, index + 1);
+    let index = textLower.indexOf(token);
+    while (index !== -1) {
+        if (!wordStartsOnly || !isWordChar(textLower[index - 1])) {
+            ranges.push([index, index + token.length]);
         }
+        index = textLower.indexOf(token, index + 1);
     }
+    return ranges;
+}
 
+function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
     ranges.sort((a, b) => a[0] - b[0]);
     const merged: Array<[number, number]> = [];
     for (const range of ranges) {

--- a/es-ds-components/package-lock.json
+++ b/es-ds-components/package-lock.json
@@ -18,6 +18,7 @@
                 "@vueuse/core": "^13.9.0",
                 "eslint": "^10.2.1",
                 "eslint-config-prettier": "^10.0.1",
+                "happy-dom": "^20.10.6",
                 "html-truncate": "^1.2.2",
                 "maska": "^3.2.0",
                 "mitt": "^3.0.1",
@@ -29,6 +30,7 @@
                 "reka-ui": "^2.8.0",
                 "sass": "^1.77.8",
                 "typescript": "^6.0.3",
+                "vitest": "^4.1.10",
                 "vue": "^3.5.28",
                 "vue-tsc": "^3.0.8"
             }
@@ -4384,6 +4386,13 @@
             "dev": true,
             "license": "CC0-1.0"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@stylistic/eslint-plugin": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -4454,6 +4463,24 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -4482,6 +4509,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/node": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+            "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
+        },
         "node_modules/@types/resolve": {
             "version": "1.20.2",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4495,6 +4532,23 @@
             "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.59.4",
@@ -5159,6 +5213,129 @@
             "peerDependencies": {
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "vue": "^3.0.0"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@volar/language-core": {
@@ -5896,6 +6073,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ast-kit": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -6268,6 +6455,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/buffer-image-size": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+            "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/builtin-modules": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
@@ -6383,6 +6583,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/change-case": {
             "version": "5.4.4",
@@ -7995,6 +8205,16 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/exsolve": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -8521,6 +8741,25 @@
                 "radix3": "^1.1.2",
                 "ufo": "^1.6.3",
                 "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/happy-dom": {
+            "version": "20.10.6",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+            "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "buffer-image-size": "^0.6.4",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.21.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/hasown": {
@@ -12432,6 +12671,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12596,6 +12842,13 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/standard-as-callback": {
             "version": "2.1.0",
@@ -12975,6 +13228,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyclip": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -13010,6 +13270,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -13198,6 +13468,13 @@
             "engines": {
                 "node": ">=18.12.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unenv": {
             "version": "2.0.0-rc.24",
@@ -13969,6 +14246,96 @@
                 "@types/estree": "^1.0.0"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -14188,6 +14555,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -14213,6 +14590,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/es-ds-components/package.json
+++ b/es-ds-components/package.json
@@ -19,7 +19,7 @@
     },
     "main": "./nuxt.config.ts",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "vitest run",
         "lint:eslint": "eslint .",
         "lint:prettier": "prettier --check .",
         "lint": "npm run lint:eslint && npm run lint:prettier",
@@ -38,6 +38,7 @@
         "@vueuse/core": "^13.9.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.0.1",
+        "happy-dom": "^20.10.6",
         "html-truncate": "^1.2.2",
         "maska": "^3.2.0",
         "mitt": "^3.0.1",
@@ -49,6 +50,7 @@
         "reka-ui": "^2.8.0",
         "sass": "^1.77.8",
         "typescript": "^6.0.3",
+        "vitest": "^4.1.10",
         "vue": "^3.5.28",
         "vue-tsc": "^3.0.8"
     }

--- a/es-ds-docs/app/components/ds-molecules-list.vue
+++ b/es-ds-docs/app/components/ds-molecules-list.vue
@@ -4,6 +4,9 @@
             <ds-link to="/molecules/accordion"> Accordion </ds-link>
         </li>
         <li>
+            <ds-link to="/molecules/autocomplete"> Autocomplete </ds-link>
+        </li>
+        <li>
             <ds-link to="/molecules/badge"> Badge </ds-link>
         </li>
         <li>

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -325,8 +325,9 @@ const autocompleteSlots = [
         'suggestion, query',
         `
         Custom renderer for each suggestion. When not provided, the suggestion text is rendered with the
-        predictive portion bolded, plus the scope label if present. Use the splitAutocompleteText utility
-        to apply the same predictive bolding to your own text (see the custom item rendering example).
+        predictive portion bolded, plus the scope label if present. Use the EsAutocompleteSuggestionText
+        component to apply the same predictive bolding to your own text (see the custom item rendering
+        example).
         `,
     ],
     [
@@ -457,16 +458,17 @@ const autocompleteSlots = [
             <h2>Custom item rendering</h2>
             <p>
                 Use the <code>item</code> slot to control how each suggestion renders, e.g. a two-line address
-                suggestion. To reproduce the predictive-portion bolding of the default renderer, call the
-                <code>splitAutocompleteText(text, query)</code> utility (auto-imported from
-                <code>es-ds-components</code>) on a line of text — or
-                <code>splitAutocompleteTextLines(lines, query)</code> when several lines form one suggestion, so a line
-                without its own match still renders bold when another line matched. Matching is token by token at word
-                starts, in any order; both utilities return segments with a <code>predictive</code> flag telling you
-                which portions to bold. Try typing <code>main</code>, <code>boston main</code> (out of order), or
-                <code>beacon</code> (second line bolds as part of the suggestion). If your search API returns its own
-                match offsets (e.g. Google Places matched substrings), build the segments from those offsets here
-                instead.
+                suggestion. To reproduce the predictive-portion bolding of the default renderer, render a line of text
+                with <code>&lt;es-autocomplete-suggestion-text :text="line" :query="query" /&gt;</code> — put your own
+                classes (font size, etc.) directly on it. Matching is token by token, in any order, preferring word
+                starts and falling back to in-word matches when a term only occurs mid-word (try <code>3</code>). When
+                several lines form one suggestion, compute all lines at once with the
+                <code>splitAutocompleteTextLines(lines, query)</code> utility (auto-imported from
+                <code>es-ds-components</code>) and pass each line's result via the <code>segments</code> prop, so a
+                line without its own match still renders bold when another line matched — that's what this example
+                does. Try typing <code>main</code>, <code>boston main</code> (out of order), or <code>beacon</code>
+                (second line bolds as part of the suggestion). If your search API returns its own match offsets (e.g.
+                Google Places matched substrings), build the segments from those offsets and pass them the same way.
             </p>
             <div class="row">
                 <div class="col-md-6">
@@ -479,18 +481,12 @@ const autocompleteSlots = [
                         @complete="onAddressComplete"
                         @select="onAddressSelect">
                         <template #item="{ suggestion, query }">
-                            <span
+                            <es-autocomplete-suggestion-text
                                 v-for="(lineSegments, lineIndex) in splitAddressLines(suggestion, query)"
                                 :key="lineIndex"
                                 class="d-block"
-                                :class="{ 'font-size-50': lineIndex === 1 }">
-                                <span
-                                    v-for="(segment, index) in lineSegments"
-                                    :key="index"
-                                    :class="{ 'font-weight-bold': segment.predictive }"
-                                    >{{ segment.text }}</span
-                                >
-                            </span>
+                                :class="{ 'font-size-50': lineIndex === 1 }"
+                                :segments="lineSegments" />
                         </template>
                     </es-autocomplete>
                     <p class="text-muted">Selected: {{ selectedAddress || 'None' }}</p>

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -128,6 +128,14 @@ const autocompleteProps = [
         `,
     ],
     [
+        'clearText',
+        'String',
+        'Clear',
+        `
+        Accessible label for the X button that clears the input. The button appears whenever the input has text.
+        `,
+    ],
+    [
         'delay',
         'Number',
         '300',

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -150,6 +150,7 @@ const onErrorComplete = (query: string) => {
 const disabledQuery = ref('');
 
 const autocompleteProps = [
+    ['v-model', 'String', 'n/a', 'Required. The v-model directive binds the query text to a data property.'],
     [
         'cancelText',
         'String',

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -108,6 +108,48 @@ const onAddressSelect = (suggestion: DocSuggestion) => {
     selectedAddress.value = suggestion.text;
 };
 
+// Requiring a selection example (e.g. address validation)
+const requiredQuery = ref('');
+const requiredSuggestions = ref<DocSuggestion[]>([]);
+const requiredSelection = ref<DocSuggestion | null>(null);
+const requiredState = ref<boolean | null>(null);
+const requiredResult = ref('');
+const onRequiredComplete = (query: string) => {
+    requiredSuggestions.value = ADDRESSES.filter((address) =>
+        `${address.street} ${address.cityStateZip}`.toLowerCase().includes(query.toLowerCase()),
+    ).map((address) => ({
+        id: address.street,
+        text: `${address.street}, ${address.cityStateZip}`,
+        value: address,
+    }));
+};
+const onRequiredSelect = (suggestion: DocSuggestion) => {
+    requiredSelection.value = suggestion;
+    requiredState.value = null;
+    requiredResult.value = '';
+};
+// typing after selecting invalidates the selection: the text no longer matches
+// what was chosen from the list
+watch(requiredQuery, (query) => {
+    if (requiredSelection.value && query !== requiredSelection.value.text) {
+        requiredSelection.value = null;
+    }
+    if (requiredState.value === false) {
+        requiredState.value = null;
+    }
+});
+// called by the submit button AND by the component's own 'submit' event
+// (pressing Enter on free text), so both paths validate the same way
+const onRequiredSubmit = () => {
+    if (requiredSelection.value) {
+        requiredState.value = null;
+        requiredResult.value = `validated address: ${requiredSelection.value.text}`;
+    } else {
+        requiredState.value = false;
+        requiredResult.value = '';
+    }
+};
+
 // Error state example
 const errorQuery = ref('');
 const errorSuggestions = ref<DocSuggestion[]>([]);
@@ -335,6 +377,11 @@ const autocompleteSlots = [
                 </li>
                 <li><code>value</code> (any, optional): app payload, returned untouched on select</li>
             </ul>
+            <p>
+                Submitting free text (Enter with no suggestion highlighted) is allowed by default, which suits search
+                use cases. For use cases that require choosing a suggestion (e.g. address validation), validate at the
+                app level — see the "Requiring a selection" example below.
+            </p>
         </div>
 
         <div class="mb-500">
@@ -424,6 +471,45 @@ const autocompleteSlots = [
                         </template>
                     </es-autocomplete>
                     <p class="text-muted">Selected: {{ selectedAddress || 'None' }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Requiring a selection</h2>
+            <p>
+                For address validation and similar use cases, the user must pick a suggestion rather than submit free
+                text. The component stays presentational: the app tracks the last <code>select</code>-ed suggestion,
+                invalidates it when the text is edited afterward (compare the input text to the selection's
+                <code>text</code>), and treats the <code>submit</code> event as a validation trigger instead of a
+                search. Try typing <code>main</code>, then pressing Enter or the button without picking a suggestion.
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-required-selection"
+                        v-model="requiredQuery"
+                        label="Street address"
+                        placeholder="Enter your address"
+                        required
+                        :state="requiredState"
+                        :suggestions="requiredSuggestions"
+                        @complete="onRequiredComplete"
+                        @select="onRequiredSelect"
+                        @submit="onRequiredSubmit">
+                        <template #errorMessage> Please select an address from the suggestions. </template>
+                    </es-autocomplete>
+                    <es-button
+                        class="mt-100"
+                        @click="onRequiredSubmit">
+                        Validate address
+                    </es-button>
+                    <p class="text-muted mt-100">
+                        {{
+                            requiredResult ||
+                            (requiredSelection ? `selected: ${requiredSelection.text}` : 'No valid selection yet')
+                        }}
+                    </p>
                 </div>
             </div>
         </div>

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -1,0 +1,470 @@
+<script setup lang="ts">
+const { $prism } = useNuxtApp();
+const compCode = ref('');
+const docCode = ref('');
+onMounted(async () => {
+    if ($prism) {
+        const compSource = await import('@energysage/es-ds-components/app/components/es-autocomplete.vue?raw');
+
+        const docSource = await import('./autocomplete.vue?raw');
+        compCode.value = $prism.normalizeCode(compSource.default);
+        docCode.value = $prism.normalizeCode(docSource.default);
+        $prism.highlight();
+    }
+});
+
+interface DocSuggestion {
+    id: string;
+    text: string;
+    scope?: {
+        label: string;
+    };
+    value?: unknown;
+}
+
+const SEARCH_TERMS = [
+    'heat pump cost',
+    'heat pump installation',
+    'heat pump rebates',
+    'heat pump water heater',
+    'heat pumps',
+    'solar batteries',
+    'solar financing',
+    'solar installers near me',
+    'solar panel cost',
+    'solar panel installation',
+    'solar panels',
+    'solar rebates and incentives',
+];
+
+const filterTerms = (query: string) =>
+    SEARCH_TERMS.filter((term) => term.toLowerCase().startsWith(query.toLowerCase())).map((term) => ({
+        id: term,
+        text: term,
+    }));
+
+// Basic example
+const basicQuery = ref('');
+const basicSuggestions = ref<DocSuggestion[]>([]);
+const basicResult = ref('');
+const onBasicComplete = (query: string) => {
+    basicSuggestions.value = filterTerms(query);
+};
+const onBasicSelect = (suggestion: DocSuggestion) => {
+    basicResult.value = `selected "${suggestion.text}"`;
+};
+const onBasicSubmit = (query: string) => {
+    basicResult.value = `submitted "${query}"`;
+};
+
+// Scoped suggestions example
+const scopedQuery = ref('');
+const scopedSuggestions = ref<DocSuggestion[]>([]);
+const onScopedComplete = (query: string) => {
+    const matches = filterTerms(query);
+    scopedSuggestions.value = [
+        ...matches,
+        ...matches.slice(0, 2).map((match) => ({
+            id: `${match.id}-articles`,
+            text: match.text,
+            scope: { label: 'in Articles' },
+        })),
+    ];
+};
+
+// Hidden label example
+const hiddenLabelQuery = ref('');
+const hiddenLabelSuggestions = ref<DocSuggestion[]>([]);
+const onHiddenLabelComplete = (query: string) => {
+    hiddenLabelSuggestions.value = filterTerms(query);
+};
+
+// Custom item slot example
+interface AddressValue {
+    street: string;
+    cityStateZip: string;
+}
+const ADDRESSES: AddressValue[] = [
+    { street: '123 Main St', cityStateZip: 'Boston, MA 02108' },
+    { street: '125 Main St', cityStateZip: 'Boston, MA 02108' },
+    { street: '12 Maple Ave', cityStateZip: 'Cambridge, MA 02138' },
+    { street: '1200 Beacon St', cityStateZip: 'Brookline, MA 02446' },
+    { street: '15 Harbor Dr', cityStateZip: 'Salem, MA 01970' },
+];
+const asAddress = (value: unknown) => value as AddressValue;
+const addressQuery = ref('');
+const addressSuggestions = ref<DocSuggestion[]>([]);
+const selectedAddress = ref('');
+const onAddressComplete = (query: string) => {
+    addressSuggestions.value = ADDRESSES.filter((address) =>
+        `${address.street} ${address.cityStateZip}`.toLowerCase().includes(query.toLowerCase()),
+    ).map((address) => ({
+        id: address.street,
+        text: `${address.street}, ${address.cityStateZip}`,
+        value: address,
+    }));
+};
+const onAddressSelect = (suggestion: DocSuggestion) => {
+    selectedAddress.value = suggestion.text;
+};
+
+// Error state example
+const errorQuery = ref('');
+const errorSuggestions = ref<DocSuggestion[]>([]);
+const onErrorComplete = (query: string) => {
+    errorSuggestions.value = filterTerms(query);
+};
+
+// Disabled example
+const disabledQuery = ref('');
+
+const autocompleteProps = [
+    [
+        'cancelText',
+        'String',
+        'Cancel',
+        `
+        Text for the button that closes the full-screen takeover on mobile.
+        `,
+    ],
+    [
+        'delay',
+        'Number',
+        '300',
+        `
+        Milliseconds to debounce typing before the 'complete' event is emitted.
+        `,
+    ],
+    [
+        'disabled',
+        'Boolean',
+        'false',
+        `
+        When disabled, the input has a gray background and cannot be interacted with.
+        `,
+    ],
+    [
+        'id',
+        'String',
+        'n/a',
+        `
+        Required. Used for the input id and to associate the label, help text, and error message for accessibility.
+        `,
+    ],
+    [
+        'label',
+        'String',
+        'n/a',
+        `
+        Required. Label text for the input. Also used as the accessible title of the mobile takeover.
+        `,
+    ],
+    [
+        'labelSrOnly',
+        'Boolean',
+        'false',
+        `
+        Visually hides the label so the autocomplete can stand on its own, described only by its placeholder.
+        The label is still announced to screen readers.
+        `,
+    ],
+    [
+        'minChars',
+        'Number',
+        '1',
+        `
+        Minimum number of characters (after trimming) before the 'complete' event is emitted and suggestions
+        are shown.
+        `,
+    ],
+    [
+        'noResultsText',
+        'String',
+        'No results found',
+        `
+        Message shown inside the suggestions panel when a search returns no suggestions. Only shown after
+        suggestions have appeared at least once, so it never flashes while the first search is in flight.
+        `,
+    ],
+    [
+        'placeholder',
+        'String',
+        'n/a',
+        `
+        Text to display inside the input when it is empty.
+        `,
+    ],
+    [
+        'required',
+        'Boolean',
+        'false',
+        `
+        When true, a red asterisk is displayed next to the label and a default error message is available.
+        `,
+    ],
+    [
+        'state',
+        'Boolean | null',
+        'null',
+        `
+        Specifies the validity of the input. Can be true (success), false (error), or null (default).
+        `,
+    ],
+    [
+        'suggestions',
+        'Array',
+        'n/a',
+        `
+        Required. Array of suggestion objects to display. See the suggestion shape section above.
+        `,
+    ],
+];
+
+const autocompleteEvents = [
+    [
+        'complete',
+        'query: string',
+        `
+        Emitted (debounced) when the user has typed at least minChars characters. Fetch or filter your
+        suggestions in response and update the 'suggestions' prop.
+        `,
+    ],
+    [
+        'select',
+        'suggestion',
+        `
+        Emitted when a suggestion is chosen, by click/tap or by pressing Enter on a highlighted suggestion.
+        The full suggestion object is passed, including its 'value' payload if provided.
+        `,
+    ],
+    [
+        'submit',
+        'query: string',
+        `
+        Emitted when the user presses Enter with no suggestion highlighted, e.g. to submit a free-form search.
+        `,
+    ],
+    [
+        'update:modelValue',
+        'value: string',
+        `
+        Emitted whenever the input text changes (v-model).
+        `,
+    ],
+];
+
+const autocompleteSlots = [
+    [
+        'item',
+        'suggestion, query',
+        `
+        Custom renderer for each suggestion. When not provided, the suggestion text is rendered with the
+        predictive portion bolded, plus the scope label if present.
+        `,
+    ],
+    [
+        'errorMessage',
+        'n/a',
+        `
+        Error message shown below the input when 'state' is false.
+        `,
+    ],
+    [
+        'message',
+        'n/a',
+        `
+        Muted helper message shown below the input when there is no error.
+        `,
+    ],
+];
+</script>
+
+<template>
+    <div>
+        <h1>Autocomplete</h1>
+        <p class="mb-500">
+            Extended from
+            <nuxt-link
+                to="https://reka-ui.com/docs/components/autocomplete"
+                target="_blank">
+                Reka UI Autocomplete
+            </nuxt-link>
+        </p>
+
+        <div class="mb-500">
+            <h2>Overview</h2>
+            <p>
+                <code>EsAutocomplete</code> is a presentational search-suggestions input: your app owns fetching and
+                filtering. Listen for the <code>complete</code> event, then update the <code>suggestions</code> prop
+                with at most 10 items. The component further trims the list so it always fits on screen without
+                scrolling, and it renders the <em>predictive</em> portion of each suggestion in bold.
+            </p>
+            <p>
+                On viewports below the <code>md</code> breakpoint, tapping the input opens a full-screen takeover with
+                its own input and cancel button. Resize your browser to try it.
+            </p>
+            <p>Each suggestion is an object with the following shape:</p>
+            <ul>
+                <li><code>id</code> (string, required): unique key</li>
+                <li><code>text</code> (string, required): the full suggested query</li>
+                <li>
+                    <code>scope</code> (object, optional): <code>{ label }</code> for category-scoped suggestions,
+                    rendered in muted italics and separated from unscoped suggestions
+                </li>
+                <li><code>value</code> (any, optional): app payload, returned untouched on select</li>
+            </ul>
+        </div>
+
+        <div class="mb-500">
+            <h2>Basic example</h2>
+            <p>
+                Try typing <code>solar</code> or <code>heat</code>. Keep typing past a match (e.g.
+                <code>solarium</code>) to see the no-results state — the panel stays open instead of flickering closed.
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-basic"
+                        v-model="basicQuery"
+                        label="Search"
+                        placeholder="Search for a topic"
+                        :suggestions="basicSuggestions"
+                        @complete="onBasicComplete"
+                        @select="onBasicSelect"
+                        @submit="onBasicSubmit" />
+                    <p class="text-muted">{{ basicResult || 'Nothing selected or submitted yet' }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Scoped suggestions</h2>
+            <p>
+                Suggestions with a <code>scope</code> are styled differently and separated from unscoped suggestions,
+                so users understand they search within a category.
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-scoped"
+                        v-model="scopedQuery"
+                        label="Search"
+                        placeholder="Search for a topic"
+                        :suggestions="scopedSuggestions"
+                        @complete="onScopedComplete" />
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Hidden label</h2>
+            <p>
+                Use <code>labelSrOnly</code> when the autocomplete should stand on its own, described only by its
+                placeholder. The label is still announced to screen readers.
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-hidden-label"
+                        v-model="hiddenLabelQuery"
+                        label="Search"
+                        label-sr-only
+                        placeholder="Search for a topic"
+                        :suggestions="hiddenLabelSuggestions"
+                        @complete="onHiddenLabelComplete" />
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Custom item rendering</h2>
+            <p>
+                Use the <code>item</code> slot to control how each suggestion renders, e.g. a two-line address
+                suggestion. Try typing <code>1</code> or <code>main</code>.
+            </p>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-address"
+                        v-model="addressQuery"
+                        label="Street address"
+                        placeholder="Enter your address"
+                        :suggestions="addressSuggestions"
+                        @complete="onAddressComplete"
+                        @select="onAddressSelect">
+                        <template #item="{ suggestion }">
+                            <span class="d-block font-weight-semibold">
+                                {{ asAddress(suggestion.value).street }}
+                            </span>
+                            <span class="d-block font-size-50">
+                                {{ asAddress(suggestion.value).cityStateZip }}
+                            </span>
+                        </template>
+                    </es-autocomplete>
+                    <p class="text-muted">Selected: {{ selectedAddress || 'None' }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Required and error state</h2>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-error"
+                        v-model="errorQuery"
+                        label="Search"
+                        placeholder="Search for a topic"
+                        required
+                        :state="errorQuery ? null : false"
+                        :suggestions="errorSuggestions"
+                        @complete="onErrorComplete">
+                        <template #errorMessage> Please enter a search term. </template>
+                    </es-autocomplete>
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>Disabled</h2>
+            <div class="row">
+                <div class="col-md-6">
+                    <es-autocomplete
+                        id="autocomplete-disabled"
+                        v-model="disabledQuery"
+                        disabled
+                        label="Search"
+                        placeholder="This autocomplete is disabled"
+                        :suggestions="[]" />
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-500">
+            <h2>EsAutocomplete props</h2>
+            <ds-prop-table :rows="autocompleteProps" />
+        </div>
+
+        <div class="mb-500">
+            <h2>EsAutocomplete events</h2>
+            <ds-prop-table
+                :columns="['Name', 'Payload', 'Description']"
+                :rows="autocompleteEvents"
+                :widths="{ md: ['3', '3', '6'] }" />
+        </div>
+
+        <div class="mb-500">
+            <h2>EsAutocomplete slots</h2>
+            <ds-prop-table
+                :columns="['Name', 'Slot props', 'Description']"
+                :rows="autocompleteSlots"
+                :widths="{ md: ['3', '3', '6'] }" />
+        </div>
+
+        <ds-doc-source
+            :comp-code="compCode"
+            comp-source="es-ds-components/components/es-autocomplete.vue"
+            :doc-code="docCode"
+            doc-source="es-ds-docs/pages/molecules/autocomplete.vue" />
+    </div>
+</template>

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -16,9 +16,6 @@ onMounted(async () => {
 interface DocSuggestion {
     id: string;
     text: string;
-    scope?: {
-        label: string;
-    };
     value?: unknown;
 }
 
@@ -55,21 +52,6 @@ const onBasicSelect = (suggestion: DocSuggestion) => {
 };
 const onBasicSubmit = (query: string) => {
     basicResult.value = `submitted "${query}"`;
-};
-
-// Scoped suggestions example
-const scopedQuery = ref('');
-const scopedSuggestions = ref<DocSuggestion[]>([]);
-const onScopedComplete = (query: string) => {
-    const matches = filterTerms(query);
-    scopedSuggestions.value = [
-        ...matches,
-        ...matches.slice(0, 2).map((match) => ({
-            id: `${match.id}-articles`,
-            text: match.text,
-            scope: { label: 'in Articles' },
-        })),
-    ];
 };
 
 // Hidden label example
@@ -325,9 +307,8 @@ const autocompleteSlots = [
         'suggestion, query',
         `
         Custom renderer for each suggestion. When not provided, the suggestion text is rendered with the
-        predictive portion bolded, plus the scope label if present. Use the EsAutocompleteSuggestionText
-        component to apply the same predictive bolding to your own text (see the custom item rendering
-        example).
+        predictive portion bolded. Use the EsAutocompleteSuggestionText component to apply the same
+        predictive bolding to your own text (see the custom item rendering example).
         `,
     ],
     [
@@ -380,10 +361,6 @@ const autocompleteSlots = [
             <ul>
                 <li><code>id</code> (string, required): unique key</li>
                 <li><code>text</code> (string, required): the full suggested query</li>
-                <li>
-                    <code>scope</code> (object, optional): <code>{ label }</code> for category-scoped suggestions,
-                    rendered in muted italics and separated from unscoped suggestions
-                </li>
                 <li><code>value</code> (any, optional): app payload, returned untouched on select</li>
             </ul>
             <p>
@@ -411,25 +388,6 @@ const autocompleteSlots = [
                         @select="onBasicSelect"
                         @submit="onBasicSubmit" />
                     <p class="text-muted">{{ basicResult || 'Nothing selected or submitted yet' }}</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="mb-500">
-            <h2>Scoped suggestions</h2>
-            <p>
-                Suggestions with a <code>scope</code> are styled differently and separated from unscoped suggestions,
-                so users understand they search within a category.
-            </p>
-            <div class="row">
-                <div class="col-md-6">
-                    <es-autocomplete
-                        id="autocomplete-scoped"
-                        v-model="scopedQuery"
-                        label="Search"
-                        placeholder="Search for a topic"
-                        :suggestions="scopedSuggestions"
-                        @complete="onScopedComplete" />
                 </div>
             </div>
         </div>

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -190,8 +190,8 @@ const autocompleteProps = [
         'String',
         'No results found',
         `
-        Message shown inside the suggestions panel when a search returns no suggestions. Only shown after
-        suggestions have appeared at least once, so it never flashes while the first search is in flight.
+        Message shown inside the suggestions panel once a search has come back with no suggestions. Never
+        shown while a search is still in flight (promptText shows instead).
         `,
     ],
     [
@@ -200,6 +200,15 @@ const autocompleteProps = [
         'n/a',
         `
         Text to display inside the input when it is empty.
+        `,
+    ],
+    [
+        'promptText',
+        'String',
+        'Type for suggestions',
+        `
+        Message shown inside the suggestions panel when there is nothing else to show: before typing begins,
+        below minChars, or while the first search is in flight.
         `,
     ],
     [
@@ -306,6 +315,11 @@ const autocompleteSlots = [
                 filtering. Listen for the <code>complete</code> event, then update the <code>suggestions</code> prop
                 with at most 10 items. The component further trims the list so it always fits on screen without
                 scrolling, and it renders the <em>predictive</em> portion of each suggestion in bold.
+            </p>
+            <p>
+                On desktop, the suggestions panel and page-dim overlay open when the input gains focus and close when
+                it loses focus, staying up for the entire interaction. Before there is anything to show, the panel
+                displays <code>promptText</code>; a search that comes back empty displays <code>noResultsText</code>.
             </p>
             <p>
                 On viewports below the <code>md</code> breakpoint, tapping the input opens a full-screen takeover with

--- a/es-ds-docs/app/pages/molecules/autocomplete.vue
+++ b/es-ds-docs/app/pages/molecules/autocomplete.vue
@@ -92,17 +92,30 @@ const ADDRESSES: AddressValue[] = [
     { street: '15 Harbor Dr', cityStateZip: 'Salem, MA 01970' },
 ];
 const asAddress = (value: unknown) => value as AddressValue;
-const addressQuery = ref('');
-const addressSuggestions = ref<DocSuggestion[]>([]);
-const selectedAddress = ref('');
-const onAddressComplete = (query: string) => {
-    addressSuggestions.value = ADDRESSES.filter((address) =>
-        `${address.street} ${address.cityStateZip}`.toLowerCase().includes(query.toLowerCase()),
-    ).map((address) => ({
+// the two lines form one suggestion, so bolding is decided across both: a line
+// without its own token match still renders bold when the other line matched
+const splitAddressLines = (suggestion: DocSuggestion, query: string) => {
+    const address = asAddress(suggestion.value);
+    return splitAutocompleteTextLines([address.street, address.cityStateZip], query);
+};
+// token-based filtering (every query term must appear somewhere in the address),
+// so terms can be typed in any order, e.g. "boston main"
+const filterAddresses = (query: string) => {
+    const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+    return ADDRESSES.filter((address) => {
+        const joined = `${address.street} ${address.cityStateZip}`.toLowerCase();
+        return tokens.every((token) => joined.includes(token));
+    }).map((address) => ({
         id: address.street,
         text: `${address.street}, ${address.cityStateZip}`,
         value: address,
     }));
+};
+const addressQuery = ref('');
+const addressSuggestions = ref<DocSuggestion[]>([]);
+const selectedAddress = ref('');
+const onAddressComplete = (query: string) => {
+    addressSuggestions.value = filterAddresses(query);
 };
 const onAddressSelect = (suggestion: DocSuggestion) => {
     selectedAddress.value = suggestion.text;
@@ -115,13 +128,7 @@ const requiredSelection = ref<DocSuggestion | null>(null);
 const requiredState = ref<boolean | null>(null);
 const requiredResult = ref('');
 const onRequiredComplete = (query: string) => {
-    requiredSuggestions.value = ADDRESSES.filter((address) =>
-        `${address.street} ${address.cityStateZip}`.toLowerCase().includes(query.toLowerCase()),
-    ).map((address) => ({
-        id: address.street,
-        text: `${address.street}, ${address.cityStateZip}`,
-        value: address,
-    }));
+    requiredSuggestions.value = filterAddresses(query);
 };
 const onRequiredSelect = (suggestion: DocSuggestion) => {
     requiredSelection.value = suggestion;
@@ -318,7 +325,8 @@ const autocompleteSlots = [
         'suggestion, query',
         `
         Custom renderer for each suggestion. When not provided, the suggestion text is rendered with the
-        predictive portion bolded, plus the scope label if present.
+        predictive portion bolded, plus the scope label if present. Use the splitAutocompleteText utility
+        to apply the same predictive bolding to your own text (see the custom item rendering example).
         `,
     ],
     [
@@ -449,7 +457,16 @@ const autocompleteSlots = [
             <h2>Custom item rendering</h2>
             <p>
                 Use the <code>item</code> slot to control how each suggestion renders, e.g. a two-line address
-                suggestion. Try typing <code>1</code> or <code>main</code>.
+                suggestion. To reproduce the predictive-portion bolding of the default renderer, call the
+                <code>splitAutocompleteText(text, query)</code> utility (auto-imported from
+                <code>es-ds-components</code>) on a line of text — or
+                <code>splitAutocompleteTextLines(lines, query)</code> when several lines form one suggestion, so a line
+                without its own match still renders bold when another line matched. Matching is token by token at word
+                starts, in any order; both utilities return segments with a <code>predictive</code> flag telling you
+                which portions to bold. Try typing <code>main</code>, <code>boston main</code> (out of order), or
+                <code>beacon</code> (second line bolds as part of the suggestion). If your search API returns its own
+                match offsets (e.g. Google Places matched substrings), build the segments from those offsets here
+                instead.
             </p>
             <div class="row">
                 <div class="col-md-6">
@@ -461,12 +478,18 @@ const autocompleteSlots = [
                         :suggestions="addressSuggestions"
                         @complete="onAddressComplete"
                         @select="onAddressSelect">
-                        <template #item="{ suggestion }">
-                            <span class="d-block font-weight-semibold">
-                                {{ asAddress(suggestion.value).street }}
-                            </span>
-                            <span class="d-block font-size-50">
-                                {{ asAddress(suggestion.value).cityStateZip }}
+                        <template #item="{ suggestion, query }">
+                            <span
+                                v-for="(lineSegments, lineIndex) in splitAddressLines(suggestion, query)"
+                                :key="lineIndex"
+                                class="d-block"
+                                :class="{ 'font-size-50': lineIndex === 1 }">
+                                <span
+                                    v-for="(segment, index) in lineSegments"
+                                    :key="index"
+                                    :class="{ 'font-weight-bold': segment.predictive }"
+                                    >{{ segment.text }}</span
+                                >
                             </span>
                         </template>
                     </es-autocomplete>


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-683

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Added EsAutocomplete built on Reka UI's Autocomplete and Dialog primitive components
- Note: functionality and UX are built, but it needs:
      - a thorough, line-by-line code review
      - probably a complete rewrite of the docs page to be more concise and with clearer, more consistent examples
      - accessibility testing
      - mobile device and browser testing
      - a POC integration with the downstream functionality to ensure it can work with that
      - removal of the `docs/plans` markdown file once complete

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [ ] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [ ] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
