### PR TITLE
fix: make EsCarousel autoplay stop upon interaction

### DIFF
--- a/es-ds-components/app/components/es-carousel.vue
+++ b/es-ds-components/app/components/es-carousel.vue
@@ -156,11 +156,14 @@ const emblaOptions = computed<EmblaOptionsType>(() => {
     auto-advancing content is motion in its own right, so the preference should stop it entirely
     rather than merely removing the slide animation. (Manual paging stays instant via `duration`.)
 
-    It is a plugin, added at creation time. stopOnInteraction is false so it matches the previous
-    behavior of running until the user presses Esc.
+    It is a plugin, added at creation time. `stopOnInteraction` is on so that dragging the slides
+    stops autoplay and leaves it stopped — with it off, the plugin restarts the timer on pointer-up.
+    The plugin's own stop doesn't record anything on our side though, so we listen for the same
+    events (see onMounted) and route them through `stopAutoplay`, which remembers the stop and keeps
+    it from being undone by a reinitialization.
 */
 const autoplayEnabled = props.autoPlay && !prefersReducedMotion.value;
-const autoplayPlugins = autoplayEnabled ? [Autoplay({ delay: props.autoPlayInterval, stopOnInteraction: false })] : [];
+const autoplayPlugins = autoplayEnabled ? [Autoplay({ delay: props.autoPlayInterval, stopOnInteraction: true })] : [];
 
 // `emblaOptions` is passed as a ref, not unwrapped: the composable then watches it and reinitializes
 // the carousel itself when the options change, skipping the work when the new options are equivalent.
@@ -202,13 +205,29 @@ const onReInit = () => {
     }
 };
 
-const scrollPrev = () => emblaApi.value?.scrollPrev();
-const scrollNext = () => emblaApi.value?.scrollNext();
-const scrollTo = (index: number) => emblaApi.value?.scrollTo(index);
-
 const stopAutoplay = () => {
     autoplayStopped.value = true;
     emblaApi.value?.plugins()?.autoplay?.stop();
+};
+
+/*
+    Paging the carousel yourself stops autoplay for good. Once someone has taken control, having the
+    carousel keep moving under them fights whatever they were trying to look at.
+
+    These three cover the arrows and the dots. Dragging and swiping are handled separately, by the
+    `pointerDown` listener in onMounted, since those never come through here.
+*/
+const scrollPrev = () => {
+    stopAutoplay();
+    emblaApi.value?.scrollPrev();
+};
+const scrollNext = () => {
+    stopAutoplay();
+    emblaApi.value?.scrollNext();
+};
+const scrollTo = (index: number) => {
+    stopAutoplay();
+    emblaApi.value?.scrollTo(index);
 };
 
 // stop carousel when user presses Escape key, in lieu of a pause button
@@ -298,6 +317,16 @@ onMounted(() => {
         onReInit();
         api.on('select', onSelect);
         api.on('reInit', onReInit);
+        /*
+            The autoplay plugin stops itself on these two, but doesn't tell us, so a later
+            reinitialization would start it up again. Running our own handler on the same events
+            records the stop and keeps it stopped. Dragging and swiping arrive as `pointerDown`;
+            `slideFocusStart` is a slide receiving focus.
+        */
+        if (autoplayEnabled) {
+            api.on('pointerDown', stopAutoplay);
+            api.on('slideFocusStart', stopAutoplay);
+        }
     }
 
     if (autoplayEnabled) {
@@ -310,6 +339,8 @@ onBeforeUnmount(() => {
     if (api) {
         api.off('select', onSelect);
         api.off('reInit', onReInit);
+        api.off('pointerDown', stopAutoplay);
+        api.off('slideFocusStart', stopAutoplay);
     }
     document.removeEventListener('keyup', onEscapeKeyup);
 });

--- a/es-ds-docs/app/pages/organisms/carousel.vue
+++ b/es-ds-docs/app/pages/organisms/carousel.vue
@@ -54,7 +54,7 @@ const propTableRows = [
         'autoPlay',
         'Boolean',
         'false',
-        'If true, the carousel will automatically go to the next page after a set interval, determined by autoPlayInterval. The autoplay functionality can be stopped by pressing the Esc key, and does not run at all for readers who have asked their device to reduce motion.',
+        'If true, the carousel will automatically go to the next page after a set interval, determined by autoPlayInterval. Autoplay stops as soon as the reader pages the carousel themselves, whether by arrow, dot, drag, or swipe, and can also be stopped by pressing the Esc key. It does not run at all for readers who have asked their device to reduce motion.',
     ],
     [
         'autoPlayInterval',
@@ -313,7 +313,8 @@ const eventTableRows = [['update', 'value (Number)', 'Emitted when the visible p
             <h2>Autoplay with circular behavior</h2>
             <p>This example shows autoplay behavior with circular mode enabled, to show a slideshow of images.</p>
             <p class="mb-200">
-                Pressing the Esc key stops the autoplay. This matters for accessibility, because
+                Autoplay stops as soon as the reader pages the carousel themselves, whether by arrow, dot, drag, or
+                swipe, and it stays stopped. Pressing the Esc key stops it too. This matters for accessibility, because
                 <a
                     href="https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html"
                     target="_blank">


### PR DESCRIPTION
<!--
    NOTE: THIS IS A PUBLIC REPO, PLEASE USE COMPANY CHANNELS FOR ENERGYSAGE SPECIFIC QUESTIONS
-->

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number as #123 -->
- https://energysage.atlassian.net/browse/CEO-396

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
- Pressing the Esc key canceled the EsCarousel autoplay but user interaction (e.g. arrows, dots, swiping) did not, so it would fight the user's intention to view a particular slide
- This change makes it so any user pagination of an autoplay carousel stops the autoplay.

### 🥼 Testing
<!-- Describe actions you have taken to test feature, and ensure no regressions are introduced -->
- Tested locally on http://localhost:8500/organisms/carousel

#### 🧐 Feedback Requested / Focus Areas
<!-- Consider @mention-ing specific reviewers to give them guidance, and/or adding your own review comments after submitting the PR. -->
- Overall

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!-- Accessibility is required for new components unless specifically exempted. -->
<!-- The WAVE browser extension can be downloaded here: https://wave.webaim.org/extension/ -->
<!-- Navigating with keyboard means that any interactive elements like forms and buttons can be navigated -->
<!-- to using the Tab key and triggered with the Enter key. -->

- [x] I have verified accessibility of any new components by:
  - [ ] automated check with the WAVE browser extension
  - [ ] navigating by keyboard
  - [x] using with a screen reader (e.g. VoiceOver on Safari)
- [ ] I have updated any applicable documentation.
